### PR TITLE
actually load new state after creating a session.

### DIFF
--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -276,6 +276,10 @@ Session::Session (AudioEngine &eng,
 			throw failed_constructor ();
 		}
 
+		if (load_state (_current_snapshot_name)) {
+			throw failed_constructor ();
+		}
+
 	} else {
 
 		if (load_state (_current_snapshot_name)) {


### PR DESCRIPTION
it seems that creating a new session from a template copies the new session file correctly but then ignores the fact that it has to be loaded.
i think this is the correct fix.
