### PR TITLE
Statically link libtimecode into libmidi++ instead of libardour

### DIFF
--- a/libs/ardour/wscript
+++ b/libs/ardour/wscript
@@ -341,7 +341,7 @@ def build(bld):
                         'OSX','BOOST','CURL','DL']
     obj.use          = ['libpbd','libmidipp','libevoral','libvamphost',
                         'libvampplugin','libtaglib','librubberband',
-                        'libaudiographer', 'ltc', 'timecode' ]
+                        'libaudiographer', 'ltc', 'timecode_includes' ]
     obj.vnum         = LIBARDOUR_LIB_VERSION
     obj.install_path = os.path.join(bld.env['LIBDIR'], 'ardour3')
     obj.defines      += [

--- a/libs/midi++2/mmc.cc
+++ b/libs/midi++2/mmc.cc
@@ -22,6 +22,7 @@
 #include <map>
 
 #include "timecode/time.h"
+#include "timecode/bbt_time.h"
 
 #include "pbd/error.h"
 
@@ -32,6 +33,13 @@
 using namespace std;
 using namespace MIDI;
 using namespace PBD;
+
+/**
+ * As libtimecode is linked statically to libmidi++ this
+ * is necessary to pull in all the symbols from libtimecode
+ * so they are exported for other users of libtimecode.
+ */
+double tmp = Timecode::BBT_Time::ticks_per_beat;
 
 static std::map<int,string> mmc_cmd_map;
 static void build_mmc_cmd_map ()

--- a/libs/midi++2/wscript
+++ b/libs/midi++2/wscript
@@ -76,7 +76,7 @@ def build(bld):
     obj.name         = 'libmidipp'
     obj.target       = 'midipp'
     obj.uselib       = 'GLIBMM SIGCPP XML JACK OSX'
-    obj.use          = 'libpbd libevoral timecode_includes'
+    obj.use          = 'libpbd libevoral timecode'
     obj.vnum         = LIBMIDIPP_LIB_VERSION
     obj.install_path = os.path.join(bld.env['LIBDIR'], 'ardour3')
 


### PR DESCRIPTION
This is necessary to get the libmidi++ test to work as libmidi++ has
unresolved symbols in libtimecode. This was not a problem when libtimecode
was statically linked into libardour if the executable depended on both
libtimecode and libardour as the symbols would get resolved.

This is not true for the midi++ test case as it doesn't depend on libardour

Also as libmidi++ only references symbols from one object file in the
libtimecode static archive only that object file gets included/exported
from libmidi++.

This is fixed by adding a dummy reference to a symbol in the other object
file in the libtimecode static archive.
