### PR TITLE
Unify editor / mixer ordering.

### DIFF
--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -422,7 +422,7 @@ struct EditorOrderTimeAxisViewSorter {
 	    RouteTimeAxisView* ra = dynamic_cast<RouteTimeAxisView*> (a);
 	    RouteTimeAxisView* rb = dynamic_cast<RouteTimeAxisView*> (b);
 	    assert (ra && rb);
-	    return ra->route()->order_key (EditorSort) < rb->route()->order_key (EditorSort);
+	    return ra->route()->order_key () < rb->route()->order_key ();
     }
 };
 

--- a/gtk2_ardour/editor_group_tabs.cc
+++ b/gtk2_ardour/editor_group_tabs.cc
@@ -176,12 +176,6 @@ EditorGroupTabs::default_properties () const
 	return plist;
 }
 
-RouteSortOrderKey
-EditorGroupTabs::order_key () const
-{
-	return EditorSort;
-}
-
 RouteList
 EditorGroupTabs::selected_routes () const
 {

--- a/gtk2_ardour/editor_group_tabs.h
+++ b/gtk2_ardour/editor_group_tabs.h
@@ -37,7 +37,6 @@ private:
 	}
 	void add_menu_items (Gtk::Menu *, ARDOUR::RouteGroup *);
 	PBD::PropertyList default_properties () const;
-        ARDOUR::RouteSortOrderKey order_key () const;
 	ARDOUR::RouteList selected_routes () const;
 	void sync_order_keys ();
 };

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -5528,7 +5528,7 @@ Editor::split_region ()
 
 struct EditorOrderRouteSorter {
     bool operator() (boost::shared_ptr<Route> a, boost::shared_ptr<Route> b) {
-	    return a->order_key (EditorSort) < b->order_key (EditorSort);
+	    return a->order_key () < b->order_key ();
     }
 };
 

--- a/gtk2_ardour/editor_routes.cc
+++ b/gtk2_ardour/editor_routes.cc
@@ -284,7 +284,7 @@ EditorRoutes::EditorRoutes (Editor* e)
 
         _display.set_enable_search (false);
 
-	Route::SyncOrderKeys.connect (*this, MISSING_INVALIDATOR, boost::bind (&EditorRoutes::sync_treeview_from_order_keys, this, _1), gui_context());
+	Route::SyncOrderKeys.connect (*this, MISSING_INVALIDATOR, boost::bind (&EditorRoutes::sync_treeview_from_order_keys, this), gui_context());
 }
 
 bool
@@ -812,7 +812,7 @@ EditorRoutes::show_track_in_display (TimeAxisView& tv)
 void
 EditorRoutes::reset_remote_control_ids ()
 {
-	if (Config->get_remote_model() != EditorOrdered || !_session || _session->deletion_in_progress()) {
+	if (Config->get_remote_model() == UserOrdered || !_session || _session->deletion_in_progress()) {
 		return;
 	}
 
@@ -841,7 +841,7 @@ EditorRoutes::reset_remote_control_ids ()
 			uint32_t new_rid = (visible ? rid : invisible_key--);
 
 			if (new_rid != route->remote_control_id()) {
-				route->set_remote_control_id_from_order_key (EditorSort, new_rid);	
+				route->set_remote_control_id_explicit (new_rid);	
 				rid_change = true;
 			}
 			
@@ -887,20 +887,20 @@ EditorRoutes::sync_order_keys_from_treeview ()
 		boost::shared_ptr<Route> route = (*ri)[_columns.route];
 		bool visible = (*ri)[_columns.visible];
 
-		uint32_t old_key = route->order_key (EditorSort);
+		uint32_t old_key = route->order_key ();
 
 		if (order != old_key) {
-			route->set_order_key (EditorSort, order);
+			route->set_order_key (order);
 
 			changed = true;
 		}
 
-		if ((Config->get_remote_model() == EditorOrdered) && !route->is_master() && !route->is_monitor()) {
+		if ((Config->get_remote_model() == MixerOrdered) && !route->is_master() && !route->is_monitor()) {
 
 			uint32_t new_rid = (visible ? rid : invisible_key--);
 
 			if (new_rid != route->remote_control_id()) {
-				route->set_remote_control_id_from_order_key (EditorSort, new_rid);	
+				route->set_remote_control_id_explicit (new_rid);	
 				rid_change = true;
 			}
 			
@@ -915,7 +915,7 @@ EditorRoutes::sync_order_keys_from_treeview ()
 	
 	if (changed) {
 		/* tell the world that we changed the editor sort keys */
-		_session->sync_order_keys (EditorSort);
+		_session->sync_order_keys ();
 	}
 
 	if (rid_change) {
@@ -925,37 +925,17 @@ EditorRoutes::sync_order_keys_from_treeview ()
 }
 
 void
-EditorRoutes::sync_treeview_from_order_keys (RouteSortOrderKey src)
+EditorRoutes::sync_treeview_from_order_keys ()
 {
-	/* Some route order key(s) for `src' has been changed, make sure that 
+	/* Some route order key(s) have been changed, make sure that 
 	   we update out tree/list model and GUI to reflect the change.
 	*/
 
-	if (!_session || _session->deletion_in_progress()) {
+	if (_ignore_reorder || !_session || _session->deletion_in_progress()) {
 		return;
 	}
 
-	DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("editor sync model from order keys, src = %1\n", enum_2_string (src)));
-
-	if (src == MixerSort) {
-
-		if (!Config->get_sync_all_route_ordering()) {
-			/* mixer sort keys changed - we don't care */
-			return;
-		}
-
-		DEBUG_TRACE (DEBUG::OrderKeys, "reset editor order key to match mixer\n");
-
-		/* mixer sort keys were changed, update the editor sort
-		 * keys since "sync mixer+editor order" is enabled.
-		 */
-
-		boost::shared_ptr<RouteList> r = _session->get_routes ();
-		
-		for (RouteList::iterator i = r->begin(); i != r->end(); ++i) {
-			(*i)->sync_order_keys (src);
-		}
-	}
+	DEBUG_TRACE (DEBUG::OrderKeys, "editor sync model from order keys.\n");
 
 	/* we could get here after either a change in the Mixer or Editor sort
 	 * order, but either way, the mixer order keys reflect the intended
@@ -975,7 +955,7 @@ EditorRoutes::sync_treeview_from_order_keys (RouteSortOrderKey src)
 
 	for (TreeModel::Children::iterator ri = rows.begin(); ri != rows.end(); ++ri, ++old_order) {
 		boost::shared_ptr<Route> route = (*ri)[_columns.route];
-		sorted_routes.push_back (RoutePlusOrderKey (route, old_order, route->order_key (EditorSort)));
+		sorted_routes.push_back (RoutePlusOrderKey (route, old_order, route->order_key ()));
 	}
 
 	SortByNewDisplayOrder cmp;
@@ -1341,7 +1321,7 @@ struct EditorOrderRouteSorter {
 		    /* everything else before master */
 		    return false;
 	    }
-	    return a->order_key (EditorSort) < b->order_key (EditorSort);
+	    return a->order_key () < b->order_key ();
     }
 };
 
@@ -1501,7 +1481,7 @@ EditorRoutes::move_selected_tracks (bool up)
 	}
 
 	for (leading = view_routes.begin(); leading != view_routes.end(); ++leading) {
-		uint32_t order = leading->second->order_key (EditorSort);
+		uint32_t order = leading->second->order_key ();
 		neworder.push_back (order);
 	}
 

--- a/gtk2_ardour/editor_routes.h
+++ b/gtk2_ardour/editor_routes.h
@@ -72,7 +72,7 @@ private:
 	void on_tv_solo_safe_toggled (std::string const &);
 	void build_menu ();
 	void show_menu ();
-        void sync_treeview_from_order_keys (ARDOUR::RouteSortOrderKey);
+        void sync_treeview_from_order_keys ();
 	void route_deleted (Gtk::TreeModel::Path const &);
 	void visible_changed (std::string const &);
 	void active_changed (std::string const &);

--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -779,7 +779,7 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 
 					RouteTimeAxisView* closest = 0;
 					int distance = INT_MAX;
-					int key = rtv->route()->order_key (EditorSort);
+					int key = rtv->route()->order_key ();
 
 					for (RegionSelection::iterator x = selection->regions.begin(); x != selection->regions.end(); ++x) {
 
@@ -794,7 +794,7 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 							if (result.second) {
 								/* newly added to already_in_selection */
 
-								int d = artv->route()->order_key (EditorSort);
+								int d = artv->route()->order_key ();
 
 								d -= key;
 
@@ -810,7 +810,7 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 
 						/* now add all tracks between that one and this one */
 
-						int okey = closest->route()->order_key (EditorSort);
+						int okey = closest->route()->order_key ();
 
 						if (okey > key) {
 							swap (okey, key);
@@ -820,7 +820,7 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 							RouteTimeAxisView* artv = dynamic_cast<RouteTimeAxisView*>(*x);
 							if (artv && artv != rtv) {
 
-								int k = artv->route()->order_key (EditorSort);
+								int k = artv->route()->order_key ();
 
 								if (k >= okey && k <= key) {
 

--- a/gtk2_ardour/group_tabs.cc
+++ b/gtk2_ardour/group_tabs.cc
@@ -447,23 +447,15 @@ GroupTabs::un_subgroup (RouteGroup* g)
 }
 
 struct CollectSorter {
-	CollectSorter (RouteSortOrderKey key) : _key (key) {}
-
 	bool operator () (boost::shared_ptr<Route> a, boost::shared_ptr<Route> b) {
-		return a->order_key (_key) < b->order_key (_key);
+		return a->order_key () < b->order_key ();
 	}
-
-        RouteSortOrderKey _key;
 };
 
 struct OrderSorter {
-	OrderSorter (RouteSortOrderKey key) : _key (key) {}
-	
 	bool operator() (boost::shared_ptr<Route> a, boost::shared_ptr<Route> b) {
-		return a->order_key (_key) < b->order_key (_key);
+		return a->order_key () < b->order_key ();
 	}
-
-	RouteSortOrderKey _key;
 };
 
 /** Collect all members of a RouteGroup so that they are together in the Editor or Mixer.
@@ -473,19 +465,19 @@ void
 GroupTabs::collect (RouteGroup* g)
 {
 	boost::shared_ptr<RouteList> group_routes = g->route_list ();
-	group_routes->sort (CollectSorter (order_key ()));
+	group_routes->sort (CollectSorter ());
 	int const N = group_routes->size ();
 
 	RouteList::iterator i = group_routes->begin ();
 	boost::shared_ptr<RouteList> routes = _session->get_routes ();
-	routes->sort (OrderSorter (order_key ()));
+	routes->sort (OrderSorter ());
 	RouteList::const_iterator j = routes->begin ();
 
 	int diff = 0;
 	int coll = -1;
 	while (i != group_routes->end() && j != routes->end()) {
 
-		int const k = (*j)->order_key (order_key ());
+		int const k = (*j)->order_key ();
 
 		if (*i == *j) {
 
@@ -496,14 +488,14 @@ GroupTabs::collect (RouteGroup* g)
 				--diff;
 			}
 
-			(*j)->set_order_key (order_key (), coll);
+			(*j)->set_order_key (coll);
 
 			++coll;
 			++i;
 
 		} else {
 
-			(*j)->set_order_key (order_key (), k + diff);
+			(*j)->set_order_key (k + diff);
 
 		}
 

--- a/gtk2_ardour/group_tabs.h
+++ b/gtk2_ardour/group_tabs.h
@@ -92,7 +92,6 @@ private:
 
 	virtual void add_menu_items (Gtk::Menu *, ARDOUR::RouteGroup *) {}
 	virtual PBD::PropertyList default_properties () const = 0;
-        virtual ARDOUR::RouteSortOrderKey order_key () const = 0;
 	virtual ARDOUR::RouteList selected_routes () const = 0;
 	virtual void sync_order_keys () = 0;
 

--- a/gtk2_ardour/meterbridge.cc
+++ b/gtk2_ardour/meterbridge.cc
@@ -92,7 +92,7 @@ struct SignalOrderRouteSorter {
 			/* everything comes before b */
 			return true;
 		}
-		return a->order_key (MixerSort) < b->order_key (MixerSort);
+		return a->order_key () < b->order_key ();
 	}
 };
 
@@ -138,7 +138,7 @@ Meterbridge::Meterbridge ()
 
 	signal_delete_event().connect (sigc::mem_fun (*this, &Meterbridge::hide_window));
 	signal_configure_event().connect (sigc::mem_fun (*ARDOUR_UI::instance(), &ARDOUR_UI::configure_handler));
-	Route::SyncOrderKeys.connect (*this, invalidator (*this), boost::bind (&Meterbridge::sync_order_keys, this, _1), gui_context());
+	Route::SyncOrderKeys.connect (*this, invalidator (*this), boost::bind (&Meterbridge::sync_order_keys, this), gui_context());
 	MeterStrip::CatchDeletion.connect (*this, invalidator (*this), boost::bind (&Meterbridge::remove_strip, this, _1), gui_context());
 	MeterStrip::MetricChanged.connect (*this, invalidator (*this), boost::bind(&Meterbridge::resync_order, this), gui_context());
 	MeterStrip::ConfigurationChanged.connect (*this, invalidator (*this), boost::bind(&Meterbridge::queue_resize, this), gui_context());
@@ -637,7 +637,7 @@ Meterbridge::remove_strip (MeterStrip* strip)
 }
 
 void
-Meterbridge::sync_order_keys (RouteSortOrderKey)
+Meterbridge::sync_order_keys ()
 {
 	Glib::Threads::Mutex::Lock lm (_resync_mutex);
 
@@ -776,7 +776,7 @@ Meterbridge::sync_order_keys (RouteSortOrderKey)
 void
 Meterbridge::resync_order()
 {
-	sync_order_keys(MixerSort);
+	sync_order_keys();
 }
 
 void

--- a/gtk2_ardour/meterbridge.h
+++ b/gtk2_ardour/meterbridge.h
@@ -80,7 +80,7 @@ class Meterbridge :
 	void remove_strip (MeterStrip *);
 
 	void session_going_away ();
-	void sync_order_keys (ARDOUR::RouteSortOrderKey src);
+	void sync_order_keys ();
 	void resync_order ();
 	mutable Glib::Threads::Mutex _resync_mutex;
 
@@ -107,7 +107,7 @@ class Meterbridge :
 				/* everything comes before b */
 				return true;
 			}
-			return a->order_key (ARDOUR::MixerSort) < b->order_key (ARDOUR::MixerSort);
+			return a->order_key () < b->order_key ();
 		}
 	};
 

--- a/gtk2_ardour/mixer_group_tabs.cc
+++ b/gtk2_ardour/mixer_group_tabs.cc
@@ -170,12 +170,6 @@ MixerGroupTabs::default_properties () const
 	return plist;
 }
 
-RouteSortOrderKey
-MixerGroupTabs::order_key () const
-{
-	return MixerSort;
-}
-
 RouteList
 MixerGroupTabs::selected_routes () const
 {

--- a/gtk2_ardour/mixer_group_tabs.h
+++ b/gtk2_ardour/mixer_group_tabs.h
@@ -36,7 +36,6 @@ private:
 	}
 
 	PBD::PropertyList default_properties () const;
-        ARDOUR::RouteSortOrderKey  order_key () const;
 	ARDOUR::RouteList selected_routes () const;
 	void sync_order_keys ();
 

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -96,7 +96,7 @@ Mixer_UI::Mixer_UI ()
 	/* allow this window to become the key focus window */
 	set_flags (CAN_FOCUS);
 
-	Route::SyncOrderKeys.connect (*this, invalidator (*this), boost::bind (&Mixer_UI::sync_treeview_from_order_keys, this, _1), gui_context());
+	Route::SyncOrderKeys.connect (*this, invalidator (*this), boost::bind (&Mixer_UI::sync_treeview_from_order_keys, this), gui_context());
 
 	scroller.set_can_default (true);
 	set_default (scroller);
@@ -408,7 +408,7 @@ Mixer_UI::remove_strip (MixerStrip* strip)
 void
 Mixer_UI::reset_remote_control_ids ()
 {
-	if (Config->get_remote_model() != MixerOrdered || !_session || _session->deletion_in_progress()) {
+	if (Config->get_remote_model() == UserOrdered || !_session || _session->deletion_in_progress()) {
 		return;
 	}
 
@@ -434,7 +434,7 @@ Mixer_UI::reset_remote_control_ids ()
 			uint32_t new_rid = (visible ? rid : invisible_key--);
 			
 			if (new_rid != route->remote_control_id()) {
-				route->set_remote_control_id_from_order_key (MixerSort, new_rid);	
+				route->set_remote_control_id_explicit (new_rid);	
 				rid_change = true;
 			}
 			
@@ -476,10 +476,10 @@ Mixer_UI::sync_order_keys_from_treeview ()
 		boost::shared_ptr<Route> route = (*ri)[track_columns.route];
 		bool visible = (*ri)[track_columns.visible];
 
-		uint32_t old_key = route->order_key (MixerSort);
+		uint32_t old_key = route->order_key ();
 
 		if (order != old_key) {
-			route->set_order_key (MixerSort, order);
+			route->set_order_key (order);
 			changed = true;
 		}
 
@@ -488,7 +488,7 @@ Mixer_UI::sync_order_keys_from_treeview ()
 			uint32_t new_rid = (visible ? rid : invisible_key--);
 
 			if (new_rid != route->remote_control_id()) {
-				route->set_remote_control_id_from_order_key (MixerSort, new_rid);	
+				route->set_remote_control_id_explicit (new_rid);	
 				rid_change = true;
 			}
 			
@@ -503,7 +503,7 @@ Mixer_UI::sync_order_keys_from_treeview ()
 
 	if (changed) {
 		/* tell everyone that we changed the mixer sort keys */
-		_session->sync_order_keys (MixerSort);
+		_session->sync_order_keys ();
 	}
 
 	if (rid_change) {
@@ -513,33 +513,13 @@ Mixer_UI::sync_order_keys_from_treeview ()
 }
 
 void
-Mixer_UI::sync_treeview_from_order_keys (RouteSortOrderKey src)
+Mixer_UI::sync_treeview_from_order_keys ()
 {
 	if (!_session || _session->deletion_in_progress()) {
 		return;
 	}
 
-	DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("mixer sync model from order keys, src = %1\n", enum_2_string (src)));
-
-	if (src == EditorSort) {
-
-		if (!Config->get_sync_all_route_ordering()) {
-			/* editor sort keys changed - we don't care */
-			return;
-		}
-
-		DEBUG_TRACE (DEBUG::OrderKeys, "reset mixer order key to match editor\n");
-
-		/* editor sort keys were changed, update the mixer sort
-		 * keys since "sync mixer+editor order" is enabled.
-		 */
-
-		boost::shared_ptr<RouteList> r = _session->get_routes ();
-		
-		for (RouteList::iterator i = r->begin(); i != r->end(); ++i) {
-			(*i)->sync_order_keys (src);
-		}
-	}
+	DEBUG_TRACE (DEBUG::OrderKeys, "mixer sync model from order keys.\n");
 
 	/* we could get here after either a change in the Mixer or Editor sort
 	 * order, but either way, the mixer order keys reflect the intended
@@ -559,7 +539,7 @@ Mixer_UI::sync_treeview_from_order_keys (RouteSortOrderKey src)
 
 	for (TreeModel::Children::iterator ri = rows.begin(); ri != rows.end(); ++ri, ++old_order) {
 		boost::shared_ptr<Route> route = (*ri)[track_columns.route];
-		sorted_routes.push_back (RoutePlusOrderKey (route, old_order, route->order_key (MixerSort)));
+		sorted_routes.push_back (RoutePlusOrderKey (route, old_order, route->order_key ()));
 	}
 
 	SortByNewDisplayOrder cmp;
@@ -1100,7 +1080,7 @@ struct SignalOrderRouteSorter {
 		    /* everything comes before b */
 		    return true;
 	    }
-	    return a->order_key (MixerSort) < b->order_key (MixerSort);
+	    return a->order_key () < b->order_key ();
 
     }
 };
@@ -1122,7 +1102,7 @@ Mixer_UI::initial_track_display ()
 		add_strips (copy);
 	}
 	
-	_session->sync_order_keys (MixerSort);
+	_session->sync_order_keys ();
 
 	redisplay_track_list ();
 }

--- a/gtk2_ardour/mixer_ui.h
+++ b/gtk2_ardour/mixer_ui.h
@@ -250,9 +250,9 @@ class Mixer_UI : public Gtk::Window, public PBD::ScopedConnectionList, public AR
 	Width _strip_width;
 
         void sync_order_keys_from_treeview ();
-        void sync_treeview_from_order_keys (ARDOUR::RouteSortOrderKey);
+        void sync_treeview_from_order_keys ();
         void reset_remote_control_ids ();
-        void reset_order_keys (ARDOUR::RouteSortOrderKey);
+        void reset_order_keys ();
 
         bool ignore_reorder;
 

--- a/gtk2_ardour/port_group.cc
+++ b/gtk2_ardour/port_group.cc
@@ -315,7 +315,7 @@ struct RouteIOs {
 class RouteIOsComparator {
 public:
 	bool operator() (RouteIOs const & a, RouteIOs const & b) {
-		return a.route->order_key (EditorSort) < b.route->order_key (EditorSort);
+		return a.route->order_key () < b.route->order_key ();
 	}
 };
 

--- a/gtk2_ardour/port_matrix.cc
+++ b/gtk2_ardour/port_matrix.cc
@@ -158,7 +158,7 @@ PortMatrix::init ()
 	_session->engine().PortRegisteredOrUnregistered.connect (_session_connections, invalidator (*this), boost::bind (&PortMatrix::setup_global_ports, this), gui_context());
 
 	/* watch for route order keys changing, which changes the order of things in our global ports list(s) */
-	Route::SyncOrderKeys.connect (_session_connections, invalidator (*this), boost::bind (&PortMatrix::setup_global_ports_proxy, this, _1), gui_context());
+	Route::SyncOrderKeys.connect (_session_connections, invalidator (*this), boost::bind (&PortMatrix::setup_global_ports_proxy, this), gui_context());
 
 	/* Part 3: other stuff */
 
@@ -619,15 +619,13 @@ PortMatrix::setup_global_ports ()
 }
 
 void
-PortMatrix::setup_global_ports_proxy (RouteSortOrderKey sk)
+PortMatrix::setup_global_ports_proxy ()
 {
-	if (sk == EditorSort) {
-		/* Avoid a deadlock by calling this in an idle handler: see IOSelector::io_changed_proxy
-		   for a discussion.
-		*/
+	/* Avoid a deadlock by calling this in an idle handler: see IOSelector::io_changed_proxy
+	   for a discussion.
+	*/
 		
-		Glib::signal_idle().connect_once (sigc::mem_fun (*this, &PortMatrix::setup_global_ports));
-	}
+	Glib::signal_idle().connect_once (sigc::mem_fun (*this, &PortMatrix::setup_global_ports));
 }
 
 void

--- a/gtk2_ardour/port_matrix.h
+++ b/gtk2_ardour/port_matrix.h
@@ -188,7 +188,7 @@ private:
 	void disassociate_all_on_channel (boost::weak_ptr<ARDOUR::Bundle>, uint32_t, int);
 	void disassociate_all_on_bundle (boost::weak_ptr<ARDOUR::Bundle>, int);
 	void setup_global_ports ();
-        void setup_global_ports_proxy (ARDOUR::RouteSortOrderKey);
+        void setup_global_ports_proxy ();
 	void toggle_show_only_bundles ();
 	bool on_scroll_event (GdkEventScroll *);
 	boost::shared_ptr<ARDOUR::IO> io_from_bundle (boost::shared_ptr<ARDOUR::Bundle>) const;

--- a/gtk2_ardour/rc_option_editor.cc
+++ b/gtk2_ardour/rc_option_editor.cc
@@ -1416,14 +1416,6 @@ RCOptionEditor::RCOptionEditor ()
 
 	add_option (_("Editor"),
 	     new BoolOption (
-		     "sync-all-route-ordering",
-		     _("Synchronise editor and mixer track order"),
-		     sigc::mem_fun (*_rc_config, &RCConfiguration::get_sync_all_route_ordering),
-		     sigc::mem_fun (*_rc_config, &RCConfiguration::set_sync_all_route_ordering)
-		     ));
-
-	add_option (_("Editor"),
-	     new BoolOption (
 		     "link-editor-and-mixer-selection",
 		     _("Synchronise editor and mixer selection"),
 		     sigc::mem_fun (*_rc_config, &RCConfiguration::get_link_editor_and_mixer_selection),
@@ -1830,7 +1822,6 @@ RCOptionEditor::RCOptionEditor ()
 
 	rm->add (UserOrdered, _("assigned by user"));
 	rm->add (MixerOrdered, _("follows order of mixer"));
-	rm->add (EditorOrdered, _("follows order of editor"));
 
 	add_option (_("Control Surfaces"), rm);
 

--- a/gtk2_ardour/route_ui.cc
+++ b/gtk2_ardour/route_ui.cc
@@ -1815,10 +1815,9 @@ RouteUI::open_remote_control_id_dialog ()
 						       _route->remote_control_id(),
 						       (_route->is_master() ? _("the master bus") : _("the monitor bus"))));
 		} else {
-			l->set_markup (string_compose (_("The remote control ID of %6 is: %3\n\n\n"
-							 "Remote Control IDs are currently determined by track/bus ordering in %1\n\n"
-							 "%4Use the User Interaction tab of the Preferences window if you want to change this%5"),
-						       (Config->get_remote_model() == MixerOrdered ? _("the mixer") : _("the editor")),
+			l->set_markup (string_compose (_("The remote control ID of %5 is: %2\n\n\n"
+							 "Remote Control IDs are currently determined by track/bus ordering in Ardour.\n\n"
+							 "%3Use the User Interaction tab of the Preferences window if you want to change this%4"),
 						       (is_track() ? _("track") : _("bus")),
 						       _route->remote_control_id(),
 						       "<span size=\"small\" style=\"italic\">",

--- a/libs/ardour/ardour/rc_configuration_vars.h
+++ b/libs/ardour/ardour/rc_configuration_vars.h
@@ -173,7 +173,6 @@ CONFIG_VARIABLE (bool, use_overlap_equivalency, "use-overlap-equivalency", false
 CONFIG_VARIABLE (bool, periodic_safety_backups, "periodic-safety-backups", true)
 CONFIG_VARIABLE (uint32_t, periodic_safety_backup_interval, "periodic-safety-backup-interval", 120)
 CONFIG_VARIABLE (float, automation_interval_msecs, "automation-interval-msecs", 30)
-CONFIG_VARIABLE (bool, sync_all_route_ordering, "sync-all-route-ordering", true)
 CONFIG_VARIABLE (bool, only_copy_imported_files, "only-copy-imported-files", false)
 CONFIG_VARIABLE (bool, keep_tearoffs, "keep-tearoffs", false)
 CONFIG_VARIABLE (bool, new_plugins_active, "new-plugins-active", true)

--- a/libs/ardour/ardour/route.h
+++ b/libs/ardour/ardour/route.h
@@ -101,10 +101,9 @@ class Route : public SessionObject, public Automatable, public RouteGroupMember,
 	bool set_name (const std::string& str);
 	static void set_name_in_state (XMLNode &, const std::string &);
 
-        uint32_t order_key (RouteSortOrderKey) const;
-        bool has_order_key (RouteSortOrderKey) const;
-	void set_order_key (RouteSortOrderKey, uint32_t);
-        void sync_order_keys (RouteSortOrderKey);
+        uint32_t order_key () const;
+        bool has_order_key () const;
+	void set_order_key (uint32_t);
 
 	bool is_auditioner() const { return _flags & Auditioner; }
 	bool is_master() const { return _flags & MasterOut; }
@@ -426,7 +425,7 @@ class Route : public SessionObject, public Automatable, public RouteGroupMember,
 
 	void     set_remote_control_id (uint32_t id, bool notify_class_listeners = true);
 	uint32_t remote_control_id () const;
-        void     set_remote_control_id_from_order_key (RouteSortOrderKey, uint32_t order_key);
+        void     set_remote_control_id_explicit (uint32_t order_key);
 
 	/* for things concerned about *this* route's RID */
 
@@ -435,7 +434,7 @@ class Route : public SessionObject, public Automatable, public RouteGroupMember,
 	/* for things concerned about *any* route's RID changes */
 
 	static PBD::Signal0<void> RemoteControlIDChange;
-	static PBD::Signal1<void,RouteSortOrderKey> SyncOrderKeys;
+	static PBD::Signal0<void> SyncOrderKeys;
 
 	bool has_external_redirects() const;
 
@@ -546,8 +545,8 @@ class Route : public SessionObject, public Automatable, public RouteGroupMember,
 	int set_state_2X (const XMLNode&, int);
 	void set_processor_state_2X (XMLNodeList const &, int);
 
-	typedef std::map<RouteSortOrderKey,uint32_t> OrderKeys;
- 	OrderKeys order_keys;
+ 	uint32_t _order_key;
+	bool _has_order_key;
         uint32_t _remote_control_id;
 
 	void input_change_handler (IOChange, void *src);

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -242,7 +242,7 @@ class Session : public PBD::StatefulDestructible, public PBD::ScopedConnectionLi
 	};
 
         void notify_remote_id_change ();
-        void sync_order_keys (RouteSortOrderKey);
+        void sync_order_keys ();
 
 	template<class T> void foreach_route (T *obj, void (T::*func)(Route&));
 	template<class T> void foreach_route (T *obj, void (T::*func)(boost::shared_ptr<Route>));

--- a/libs/ardour/ardour/types.h
+++ b/libs/ardour/ardour/types.h
@@ -353,11 +353,6 @@ namespace ARDOUR {
 		PostFader
 	};
 
-        enum RouteSortOrderKey { 
-		EditorSort,
-		MixerSort
-	};
-	    
 	enum MonitorModel {
 		HardwareMonitoring, ///< JACK does monitoring
 		SoftwareMonitoring, ///< Ardour does monitoring
@@ -419,8 +414,7 @@ namespace ARDOUR {
 
 	enum RemoteModel {
 		UserOrdered,
-		MixerOrdered,
-		EditorOrdered
+		MixerOrdered
 	};
 
 	enum CrossfadeModel {

--- a/libs/ardour/enums.cc
+++ b/libs/ardour/enums.cc
@@ -95,7 +95,6 @@ setup_enum_writer ()
 	AutoState _AutoState;
 	AutoStyle _AutoStyle;
 	AutoConnectOption _AutoConnectOption;
-	RouteSortOrderKey _RouteSortOrderKey;
 	Session::StateOfTheState _Session_StateOfTheState;
 	Route::Flag _Route_Flag;
 	Source::Flag _Source_Flag;
@@ -281,8 +280,13 @@ setup_enum_writer ()
 
 	REGISTER_ENUM (UserOrdered);
 	REGISTER_ENUM (MixerOrdered);
-	REGISTER_ENUM (EditorOrdered);
 	REGISTER (_RemoteModel);
+	/*
+	 * EditorOrdered has been deprecated
+	 * since the removal of independent 
+	 * editor / mixer ordering.
+	*/
+	enum_writer.add_to_hack_table ("EditorOrdered", "MixerOrdered");
 
 	REGISTER_ENUM (FullCrossfade);
 	REGISTER_ENUM (ShortCrossfade);
@@ -433,10 +437,6 @@ setup_enum_writer ()
 	REGISTER_CLASS_ENUM (Route, MasterOut);
 	REGISTER_CLASS_ENUM (Route, MonitorOut);
 	REGISTER_BITS (_Route_Flag);
-
-	REGISTER_ENUM (MixerSort);
-	REGISTER_ENUM (EditorSort);
-	REGISTER (_RouteSortOrderKey);
 
 	REGISTER_CLASS_ENUM (Source, Writable);
 	REGISTER_CLASS_ENUM (Source, CanRename);

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -69,7 +69,7 @@ using namespace std;
 using namespace ARDOUR;
 using namespace PBD;
 
-PBD::Signal1<void,RouteSortOrderKey> Route::SyncOrderKeys;
+PBD::Signal0<void> Route::SyncOrderKeys;
 PBD::Signal0<void> Route::RemoteControlIDChange;
 
 Route::Route (Session& sess, string name, Flag flg, DataType default_type)
@@ -96,6 +96,7 @@ Route::Route (Session& sess, string name, Flag flg, DataType default_type)
 	, _have_internal_generator (false)
 	, _solo_safe (false)
 	, _default_type (default_type)
+	, _has_order_key (false)
 	, _remote_control_id (0)
 	, _in_configure_processors (false)
 	, _initial_io_setup (false)
@@ -268,52 +269,19 @@ Route::remote_control_id() const
 }
 
 bool
-Route::has_order_key (RouteSortOrderKey key) const
+Route::has_order_key () const
 {
-	return (order_keys.find (key) != order_keys.end());
+	return _has_order_key;
 }
 
 uint32_t
-Route::order_key (RouteSortOrderKey key) const
+Route::order_key () const
 {
-	OrderKeys::const_iterator i = order_keys.find (key);
-
-	if (i == order_keys.end()) {
-		return 0;
-	}
-
-	return i->second;
+	return _order_key;
 }
 
 void
-Route::sync_order_keys (RouteSortOrderKey base)
-{
-	/* this is called after changes to 1 or more route order keys have been
-	 * made, and we want to sync up.
-	 */
-
-	OrderKeys::iterator i = order_keys.find (base);
-
-	if (i == order_keys.end()) {
-		return;
-	}
-
-	for (OrderKeys::iterator k = order_keys.begin(); k != order_keys.end(); ++k) {
-
-		if (k->first != base) {
-			DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("%1 set key for %2 to %3 from %4\n",
-								       name(),
-								       enum_2_string (k->first),
-								       i->second,
-								       enum_2_string (base)));
-								       
-			k->second = i->second;
-		}
-	}
-}
-
-void
-Route::set_remote_control_id_from_order_key (RouteSortOrderKey /*key*/, uint32_t rid)
+Route::set_remote_control_id_explicit (uint32_t rid)
 {
 	if (is_master() || is_monitor() || is_auditioner()) {
 		/* hard-coded remote IDs, or no remote ID */
@@ -337,18 +305,18 @@ Route::set_remote_control_id_from_order_key (RouteSortOrderKey /*key*/, uint32_t
 }
 
 void
-Route::set_order_key (RouteSortOrderKey key, uint32_t n)
+Route::set_order_key (uint32_t n)
 {
-	OrderKeys::iterator i = order_keys.find (key);
+	_has_order_key = true;
 
-	if (i != order_keys.end() && i->second == n) {
+	if (_order_key == n) {
 		return;
 	}
 
-	order_keys[key] = n;
+	_order_key = n;
 
-	DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("%1 order key %2 set to %3\n",
-						       name(), enum_2_string (key), order_key (key)));
+	DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("%1 order key set to %2\n",
+						       name(), order_key ()));
 
 	_session.set_dirty ();
 }
@@ -1909,24 +1877,8 @@ Route::state(bool full_state)
 		node->add_property("route-group", _route_group->name());
 	}
 
-	string order_string;
-	OrderKeys::iterator x = order_keys.begin();
-
-	while (x != order_keys.end()) {
-		order_string += enum_2_string ((*x).first);
-		order_string += '=';
-		snprintf (buf, sizeof(buf), "%" PRId32, (*x).second);
-		order_string += buf;
-
-		++x;
-
-		if (x == order_keys.end()) {
-			break;
-		}
-
-		order_string += ':';
-	}
-	node->add_property ("order-keys", order_string);
+	snprintf (buf, sizeof (buf), "%d", _order_key);
+	node->add_property ("order-key", buf);
 	node->add_property ("self-solo", (_self_solo ? "yes" : "no"));
 	snprintf (buf, sizeof (buf), "%d", _soloed_by_others_upstream);
 	node->add_property ("soloed-by-upstream", buf);
@@ -2127,7 +2079,11 @@ Route::set_state (const XMLNode& node, int version)
 		set_active (yn, this);
 	}
 
-	if ((prop = node.property (X_("order-keys"))) != 0) {
+	if ((prop = node.property (X_("order-key"))) != 0) { // New order key (no separate mixer/editor ordering)
+		set_order_key (atoi(prop->value()));
+	}
+
+	if ((prop = node.property (X_("order-keys"))) != 0) { // Deprecated order keys
 
 		int32_t n;
 
@@ -2145,17 +2101,11 @@ Route::set_state (const XMLNode& node, int version)
 					      << endmsg;
 				} else {
 					string keyname = remaining.substr (0, equal);
-					RouteSortOrderKey sk;
 
-					if (keyname == "signal") {
-						sk = MixerSort;
-					} else if (keyname == "editor") {
-						sk = EditorSort;
-					} else {
-						sk = (RouteSortOrderKey) string_2_enum (remaining.substr (0, equal), sk);
+					if ((keyname == "EditorSort") || (keyname == "editor")) {
+						cerr << "Setting " << name() << " order key to " << n << " using saved Editor order." << endl;
+						set_order_key (n);
 					}
-
-					set_order_key (sk, n);
 				}
 			}
 
@@ -2356,17 +2306,11 @@ Route::set_state_2X (const XMLNode& node, int version)
 						<< endmsg;
 				} else {
 					string keyname = remaining.substr (0, equal);
-					RouteSortOrderKey sk;
 
-					if (keyname == "signal") {
-						sk = MixerSort;
-					} else if (keyname == "editor") {
-						sk = EditorSort;
-					} else {
-						sk = (RouteSortOrderKey) string_2_enum (remaining.substr (0, equal), sk);
+					if (keyname == "EditorSort" || keyname == "editor") {
+						info << string_compose(_("Converting deprecated order key for %1 using Editor order %2"), name (), n) << endmsg;
+						set_order_key (n);
 					}
-
-					set_order_key (sk, n);
 				}
 			}
 

--- a/libs/ardour/route_graph.cc
+++ b/libs/ardour/route_graph.cc
@@ -170,7 +170,7 @@ struct RouteRecEnabledComparator
 		if (r1->record_enabled()) {
 			if (r2->record_enabled()) {
 				/* both rec-enabled, just use signal order */
-				return r1->order_key (MixerSort) < r2->order_key (MixerSort);
+				return r1->order_key () < r2->order_key ();
 			} else {
 				/* r1 rec-enabled, r2 not rec-enabled, run r2 early */
 				return false;
@@ -181,7 +181,7 @@ struct RouteRecEnabledComparator
 				return true;
 			} else {
 				/* neither rec-enabled, use signal order */
-				return r1->order_key (MixerSort) < r2->order_key (MixerSort);
+				return r1->order_key () < r2->order_key ();
 			}
 		}
 	}

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -1699,7 +1699,7 @@ Session::resort_routes_using (boost::shared_ptr<RouteList> r)
 		DEBUG_TRACE (DEBUG::Graph, "Routes resorted, order follows:\n");
 		for (RouteList::iterator i = r->begin(); i != r->end(); ++i) {
 			DEBUG_TRACE (DEBUG::Graph, string_compose ("\t%1 signal order %2\n",
-								   (*i)->name(), (*i)->order_key (MixerSort)));
+								   (*i)->name(), (*i)->order_key ()));
 		}
 #endif
 
@@ -2396,15 +2396,13 @@ Session::add_routes_inner (RouteList& new_routes, bool input_auto_connect, bool 
 		   ID in most situations.
 		*/
 
-		if (!r->has_order_key (EditorSort)) {
+		if (!r->has_order_key ()) {
 			if (r->is_auditioner()) {
 				/* use an arbitrarily high value */
-				r->set_order_key (EditorSort, UINT_MAX);
-				r->set_order_key (MixerSort, UINT_MAX);
+				r->set_order_key (UINT_MAX);
 			} else {
 				DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("while adding, set %1 to order key %2\n", r->name(), order));
-				r->set_order_key (EditorSort, order);
-				r->set_order_key (MixerSort, order);
+				r->set_order_key (order);
 				order++;
 			}
 		}
@@ -3715,7 +3713,7 @@ Session::RoutePublicOrderSorter::operator() (boost::shared_ptr<Route> a, boost::
 	if (b->is_monitor()) {
 		return false;
 	}
-	return a->order_key (MixerSort) < b->order_key (MixerSort);
+	return a->order_key () < b->order_key ();
 }
 
 bool
@@ -4952,8 +4950,7 @@ Session::notify_remote_id_change ()
 	}
 
 	switch (Config->get_remote_model()) {
-	case MixerSort:
-	case EditorSort:
+	case MixerOrdered:
 		Route::RemoteControlIDChange (); /* EMIT SIGNAL */
 		break;
 	default:
@@ -4962,7 +4959,7 @@ Session::notify_remote_id_change ()
 }
 
 void
-Session::sync_order_keys (RouteSortOrderKey sort_key_changed)
+Session::sync_order_keys ()
 {
 	if (deletion_in_progress()) {
 		return;
@@ -4974,9 +4971,9 @@ Session::sync_order_keys (RouteSortOrderKey sort_key_changed)
 	   opportunity to keep them in sync if they wish to.
 	*/
 
-	DEBUG_TRACE (DEBUG::OrderKeys, string_compose ("Sync Order Keys, based on %1\n", enum_2_string (sort_key_changed)));
+	DEBUG_TRACE (DEBUG::OrderKeys, "Sync Order Keys.\n");
 
-	Route::SyncOrderKeys (sort_key_changed); /* EMIT SIGNAL */
+	Route::SyncOrderKeys (); /* EMIT SIGNAL */
 
 	DEBUG_TRACE (DEBUG::OrderKeys, "\tsync done\n");
 }

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -3444,22 +3444,6 @@ Session::config_changed (std::string p, bool ours)
 		/* XXX DO SOMETHING HERE TO TELL THE GUI THAT WE NEED
 		   TO SET REMOTE ID'S
 		*/
-	} else if (p == "sync-all-route-ordering") {
-
-		/* sync to editor order unless mixer is used for remote IDs 
-		 */
-
-		switch (Config->get_remote_model()) {
-		case UserOrdered:
-			sync_order_keys (EditorSort);
-			break;
-		case EditorOrdered:
-			sync_order_keys (EditorSort);
-			break;
-		case MixerOrdered:
-			sync_order_keys (MixerSort);
-		}
-			
 	} else if (p == "initial-program-change") {
 
 		if (_mmc->output_port() && Config->get_initial_program_change() >= 0) {


### PR DESCRIPTION
Removes the ability to have separate mixer / editor display orders.
Replaces old "order-keys" .ardour property with "order-key".
Deprecates "EditorOrdered" remote model.
Tested reasonably thoroughly.

Comments welcome.
