### PR TITLE
New routes are placed after highest selected route.

### DIFF
--- a/gtk2_ardour/ardour_ui.h
+++ b/gtk2_ardour/ardour_ui.h
@@ -582,6 +582,7 @@ class ARDOUR_UI : public Gtkmm2ext::UI, public ARDOUR::SessionHandlePtr
 
 	void snapshot_session (bool switch_to_it);
 	void rename_session ();
+	void setup_order_hint ();
 
 	Mixer_UI   *mixer;
 	int         create_mixer ();

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -241,6 +241,7 @@ class Session : public PBD::StatefulDestructible, public PBD::ScopedConnectionLi
 		bool operator() (boost::shared_ptr<Route>, boost::shared_ptr<Route> b);
 	};
 
+	void set_order_hint (uint32_t order_hint) {_order_hint = order_hint;};
         void notify_remote_id_change ();
         void sync_order_keys ();
 
@@ -1594,6 +1595,7 @@ class Session : public PBD::StatefulDestructible, public PBD::ScopedConnectionLi
 	GraphEdges _current_route_graph;
 
 	uint32_t next_control_id () const;
+	uint32_t _order_hint;
 	bool ignore_route_processor_changes;
 
 	MidiClockTicker* midi_clock;

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -257,6 +257,7 @@ Session::Session (AudioEngine &eng,
 	, _step_editors (0)
 	, _suspend_timecode_transmission (0)
 	,  _speakers (new Speakers)
+	, _order_hint (0)
 	, ignore_route_processor_changes (false)
 	, _midi_ports (0)
 	, _mmc (0)
@@ -2334,6 +2335,11 @@ Session::add_routes_inner (RouteList& new_routes, bool input_auto_connect, bool 
         ChanCount existing_inputs;
         ChanCount existing_outputs;
 	uint32_t order = next_control_id();
+
+	if (_order_hint != 0) {
+		order = _order_hint;
+		_order_hint = 0;
+	}
 
         count_existing_track_channels (existing_inputs, existing_outputs);
 


### PR DESCRIPTION
Adds a session order hint which shows the session the starting order key for new routes..
Could probably be done another way, but this has a pretty minimal impact on libardour.
Comments welcome.
