### PR TITLE
Fix tests compilation

### DIFF
--- a/libs/ardour/wscript
+++ b/libs/ardour/wscript
@@ -550,11 +550,11 @@ def create_ardour_test_program(bld, includes, name, target, sources):
     testobj.use          = ['libpbd','libmidipp','libevoral','libvampplugin',
                             'libaudiographer','ardour','testcommon']
     if bld.is_defined('USE_EXTERNAL_LIBS'):
-        testcommon.uselib.extend(['RUBBERBAND', 'TAGLIB', 'LIBLTC', 'VAMPSDK',
-                                  'VAMPHOSTSDK'])
+        testobj.uselib.extend(['RUBBERBAND', 'TAGLIB', 'LIBLTC', 'VAMPSDK',
+                               'VAMPHOSTSDK'])
     else:
-        testcommon.use.extend(['libltc', 'librubberband', 'libtaglib',
-                               'libvamphost'])
+        testobj.use.extend(['libltc', 'librubberband', 'libtaglib',
+                            'libvamphost'])
 
     testobj.name         = name
     testobj.target       = target


### PR DESCRIPTION
Hi,
After the recently introduced USE_EXTERNAL_LIBS flag, tests were not compiling anymore, a variable is badly named. This pull request should fix this issue.
Regards.
Julien
