### PR TITLE
Fix tests compilation after Control API changes

### DIFF
--- a/libs/ardour/test/control_surfaces_test.cc
+++ b/libs/ardour/test/control_surfaces_test.cc
@@ -35,7 +35,7 @@ ControlSurfacesTest::instantiateAndTeardownTest ()
 	
 	ControlProtocolManager& m = ControlProtocolManager::instance ();
 	for (list<ControlProtocolInfo*>::iterator i = m.control_protocol_info.begin(); i != m.control_protocol_info.end(); ++i) {
-		m.instantiate (**i);
-		m.teardown (**i);
+		m.activate (**i);
+		m.deactivate (**i);
 	}
 }


### PR DESCRIPTION
Hi

Tests compilation was failing after an update in the Control API that put instantiate/teardown as private functions, it seems the public functions are now activate/deactivate.
