### PR TITLE
Fix two glitches in Min:Sec ruler display

### DIFF
--- a/gtk2_ardour/editor_rulers.cc
+++ b/gtk2_ardour/editor_rulers.cc
@@ -2053,7 +2053,7 @@ Editor::metric_get_minsec (GtkCustomRulerMark **marks, gdouble lower, gdouble /*
 		for (n = 0; n < minsec_nmarks; pos += minsec_mark_interval, ++n) {
 			sample_to_clock_parts (pos, _session->frame_rate(), &hrs, &mins, &secs, &millisecs);
 			if (millisecs % minsec_mark_modulo == 0) {
-				if (secs == 0) {
+				if (millisecs == 0) {
 					(*marks)[n].style = GtkCustomRulerMarkMajor;
 				} else {
 					(*marks)[n].style = GtkCustomRulerMarkMinor;


### PR DESCRIPTION
The first was unexpected and inconsistent offsetting between timecode and H:M:S rulers due to rounding error, and the second was just the type of ticks used.  Both are visual glitches only, and grid/snap had correct values.
