### PR TITLE
Various changes intended to improve GUI responsiveness wrt drawing  ops.

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -4704,13 +4704,13 @@ Editor::located ()
 void
 Editor::region_view_added (RegionView *)
 {
-	_summary->set_dirty ();
+	_summary->set_background_dirty ();
 }
 
 void
 Editor::region_view_removed ()
 {
-	_summary->set_dirty ();
+	_summary->set_background_dirty ();
 }
 
 RouteTimeAxisView*

--- a/gtk2_ardour/editor_summary.cc
+++ b/gtk2_ardour/editor_summary.cc
@@ -54,15 +54,24 @@ EditorSummary::EditorSummary (Editor* e)
 	  _view_rectangle_x (0, 0),
 	  _view_rectangle_y (0, 0),
 	  _zoom_dragging (false),
-	  _old_follow_playhead (false)
+	  _old_follow_playhead (false),
+	  _background_dirty (true)
 {
-	Region::RegionPropertyChanged.connect (region_property_connection, invalidator (*this), boost::bind (&CairoWidget::set_dirty, this), gui_context());
-	Route::RemoteControlIDChange.connect (route_ctrl_id_connection, invalidator (*this), boost::bind (&CairoWidget::set_dirty, this), gui_context());
-	_editor->playhead_cursor->PositionChanged.connect (position_connection, invalidator (*this), boost::bind (&EditorSummary::playhead_position_changed, this, _1), gui_context());
-
 	add_events (Gdk::POINTER_MOTION_MASK|Gdk::KEY_PRESS_MASK|Gdk::KEY_RELEASE_MASK|Gdk::ENTER_NOTIFY_MASK|Gdk::LEAVE_NOTIFY_MASK);
 	set_flags (get_flags() | Gtk::CAN_FOCUS);
 }
+
+/** Handle a size allocation.
+ *  @param alloc GTK allocation.
+ */
+void
+EditorSummary::on_size_allocate (Gtk::Allocation& alloc)
+{
+	Gtk::EventBox::on_size_allocate (alloc);
+	_background_dirty = true;
+	set_dirty ();
+}
+
 
 /** Connect to a session.
  *  @param s Session.
@@ -71,7 +80,6 @@ void
 EditorSummary::set_session (Session* s)
 {
 	SessionHandlePtr::set_session (s);
-
 	set_dirty ();
 
 	/* Note: the EditorSummary already finds out about new regions from Editor::region_view_added
@@ -80,26 +88,22 @@ EditorSummary::set_session (Session* s)
 	 */
 
 	if (_session) {
+		Region::RegionPropertyChanged.connect (region_property_connection, invalidator (*this), boost::bind (&EditorSummary::set_background_dirty, this), gui_context());
+		Route::RemoteControlIDChange.connect (route_ctrl_id_connection, invalidator (*this), boost::bind (&EditorSummary::set_background_dirty, this), gui_context());
+		_editor->playhead_cursor->PositionChanged.connect (position_connection, invalidator (*this), boost::bind (&EditorSummary::playhead_position_changed, this, _1), gui_context());
 		_session->StartTimeChanged.connect (_session_connections, invalidator (*this), boost::bind (&CairoWidget::set_dirty, this), gui_context());
 		_session->EndTimeChanged.connect (_session_connections, invalidator (*this), boost::bind (&CairoWidget::set_dirty, this), gui_context());
+
+		_background_dirty = true;
+		
 	}
 }
 
-/** Render the required regions to a cairo context.
- *  @param cr Context.
- */
 void
-EditorSummary::render (cairo_t* cr, cairo_rectangle_t*)
+EditorSummary::render_background_image ()
 {
-	/* background (really just the dividing lines between tracks */
-
-	cairo_set_source_rgb (cr, 0, 0, 0);
-	cairo_rectangle (cr, 0, 0, get_width(), get_height());
-	cairo_fill (cr);
-
-	if (_session == 0) {
-		return;
-	}
+	_image = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, get_width (), get_height ());
+	cairo_t* cr = cairo_create (_image);
 
 	/* compute start and end points for the summary */
 
@@ -160,6 +164,29 @@ EditorSummary::render (cairo_t* cr, cairo_rectangle_t*)
 
 		y += _track_height;
 	}
+	cairo_destroy (cr);
+}
+
+/** Render the required regions to a cairo context.
+ *  @param cr Context.
+ */
+void
+EditorSummary::render (cairo_t* cr, cairo_rectangle_t*)
+{
+
+	if (_session == 0) {
+		return;
+	}
+
+	if (!_image || _background_dirty) {
+		render_background_image ();
+		_background_dirty = false;
+	}
+	cairo_push_group (cr);
+	
+	cairo_rectangle (cr, 0, 0, get_width(), get_height());
+	cairo_set_source_surface (cr, _image, 0, 0);
+	cairo_paint (cr);
 
 	/* start and end markers */
 
@@ -169,7 +196,6 @@ EditorSummary::render (cairo_t* cr, cairo_rectangle_t*)
 	const double p = (_session->current_start_frame() - _start) * _x_scale;
 	cairo_move_to (cr, p, 0);
 	cairo_line_to (cr, p, get_height());
-	cairo_stroke (cr);
 
 	double const q = (_session->current_end_frame() - _start) * _x_scale;
 	cairo_move_to (cr, q, 0);
@@ -185,11 +211,9 @@ EditorSummary::render (cairo_t* cr, cairo_rectangle_t*)
 		get_editor (&_view_rectangle_x, &_view_rectangle_y);
 	}
 
-	cairo_move_to (cr, _view_rectangle_x.first, _view_rectangle_y.first);
-	cairo_line_to (cr, _view_rectangle_x.second, _view_rectangle_y.first);
-	cairo_line_to (cr, _view_rectangle_x.second, _view_rectangle_y.second);
-	cairo_line_to (cr, _view_rectangle_x.first, _view_rectangle_y.second);
-	cairo_line_to (cr, _view_rectangle_x.first, _view_rectangle_y.first);
+	int32_t width = _view_rectangle_x.second - _view_rectangle_x.first;
+	int32_t height = _view_rectangle_y.second - _view_rectangle_y.first;
+	cairo_rectangle (cr, _view_rectangle_x.first, _view_rectangle_y.first, width, height); 
 	cairo_set_source_rgba (cr, 1, 1, 1, 0.25);
 	cairo_fill_preserve (cr);
 	cairo_set_line_width (cr, 1);
@@ -206,6 +230,8 @@ EditorSummary::render (cairo_t* cr, cairo_rectangle_t*)
 	cairo_move_to (cr, ph, 0);
 	cairo_line_to (cr, ph, get_height());
 	cairo_stroke (cr);
+	cairo_pop_group_to_source (cr);
+	cairo_paint_with_alpha (cr, 1.0);
 	_last_playhead = ph;
 
 }
@@ -234,6 +260,13 @@ EditorSummary::render_region (RegionView* r, cairo_t* cr, double y) const
 	}
 
 	cairo_stroke (cr);
+}
+
+void
+EditorSummary::set_background_dirty ()
+{
+	_background_dirty = true;
+	set_dirty ();
 }
 
 /** Set the summary so that just the overlays (viewbox, playhead etc.) will be re-rendered */
@@ -981,10 +1014,11 @@ EditorSummary::routes_added (list<RouteTimeAxisView*> const & r)
 		(*i)->route()->gui_changed.connect (*this, invalidator (*this), boost::bind (&EditorSummary::route_gui_changed, this, _1), gui_context ());
 		boost::shared_ptr<Track> tr = boost::dynamic_pointer_cast<Track> ((*i)->route ());
 		if (tr) {
-			tr->PlaylistChanged.connect (*this, invalidator (*this), boost::bind (&CairoWidget::set_dirty, this), gui_context ());
+			tr->PlaylistChanged.connect (*this, invalidator (*this), boost::bind (&EditorSummary::set_background_dirty, this), gui_context ());
 		}
 	}
 
+	_background_dirty = true;
 	set_dirty ();
 }
 
@@ -992,6 +1026,8 @@ void
 EditorSummary::route_gui_changed (string c)
 {
 	if (c == "color") {
+	
+		_background_dirty = true;
 		set_dirty ();
 	}
 }

--- a/gtk2_ardour/editor_summary.h
+++ b/gtk2_ardour/editor_summary.h
@@ -39,9 +39,11 @@ public:
 
 	void set_session (ARDOUR::Session *);
 	void set_overlays_dirty ();
+	void set_background_dirty ();
 	void routes_added (std::list<RouteTimeAxisView*> const &);
 
 private:
+	void on_size_allocate (Gtk::Allocation& alloc);
 
 	enum Position {
 		LEFT,
@@ -120,6 +122,9 @@ private:
 	Position _zoom_position;
 
 	bool _old_follow_playhead;
+	cairo_surface_t* _image;
+	void render_background_image ();
+	bool _background_dirty;
 
 	PBD::ScopedConnectionList position_connection;
 	PBD::ScopedConnection route_ctrl_id_connection;

--- a/libs/canvas/canvas.cc
+++ b/libs/canvas/canvas.cc
@@ -165,7 +165,9 @@ Canvas::item_shown_or_hidden (Item* item)
 {
 	boost::optional<Rect> bbox = item->bounding_box ();
 	if (bbox) {
-		queue_draw_item_area (item, bbox.get ());
+		if (item->item_to_window (*bbox).intersection (visible_area ())) {
+			queue_draw_item_area (item, bbox.get ());
+		}
 	}
 }
 
@@ -178,7 +180,9 @@ Canvas::item_visual_property_changed (Item* item)
 {
 	boost::optional<Rect> bbox = item->bounding_box ();
 	if (bbox) {
-		queue_draw_item_area (item, bbox.get ());
+		if (item->item_to_window (*bbox).intersection (visible_area ())) {
+			queue_draw_item_area (item, bbox.get ());
+		}
 	}
 }
 
@@ -190,15 +194,24 @@ Canvas::item_visual_property_changed (Item* item)
 void
 Canvas::item_changed (Item* item, boost::optional<Rect> pre_change_bounding_box)
 {
+	
+	Rect window_bbox = visible_area ();
+
 	if (pre_change_bounding_box) {
-		/* request a redraw of the item's old bounding box */
-		queue_draw_item_area (item, pre_change_bounding_box.get ());
+
+		if (item->item_to_window (*pre_change_bounding_box).intersection (window_bbox)) {
+			/* request a redraw of the item's old bounding box */
+			queue_draw_item_area (item, pre_change_bounding_box.get ());
+		}
 	}
 
 	boost::optional<Rect> post_change_bounding_box = item->bounding_box ();
 	if (post_change_bounding_box) {
-		/* request a redraw of the item's new bounding box */
-		queue_draw_item_area (item, post_change_bounding_box.get ());
+		
+		if (item->item_to_window (*post_change_bounding_box).intersection (window_bbox)) {
+			/* request a redraw of the item's new bounding box */
+			queue_draw_item_area (item, post_change_bounding_box.get ());
+		}
 	}
 }
 

--- a/libs/canvas/item.cc
+++ b/libs/canvas/item.cc
@@ -543,10 +543,12 @@ Item::begin_change ()
 void
 Item::end_change ()
 {
-	_canvas->item_changed (this, _pre_change_bounding_box);
+	if (_visible) {
+		_canvas->item_changed (this, _pre_change_bounding_box);
 	
-	if (_parent) {
-		_parent->child_changed ();
+		if (_parent) {
+			_parent->child_changed ();
+		}
 	}
 }
 
@@ -558,7 +560,9 @@ Item::begin_visual_change ()
 void
 Item::end_visual_change ()
 {
-	_canvas->item_visual_property_changed (this);
+	if (_visible) {
+		_canvas->item_visual_property_changed (this);
+	}
 }
 
 void

--- a/libs/canvas/text.cc
+++ b/libs/canvas/text.cc
@@ -143,7 +143,7 @@ Text::render (Rect const & /*area*/, Cairo::RefPtr<Cairo::Context> context) cons
 		redraw (context);
 	}
 	
-	Rect self = item_to_window (Rect (0, 0, min (_clamped_width, _width), _height));
+	Rect self = item_to_window (Rect (0, 0, min (_clamped_width, (double)_image->get_width ()), _image->get_height ()));
 	
 	context->rectangle (self.x0, self.y0, self.width(), self.height());
 	context->set_source (_image, self.x0, self.y0);

--- a/libs/canvas/wave_view.cc
+++ b/libs/canvas/wave_view.cc
@@ -461,68 +461,68 @@ WaveView::draw_image (Cairo::RefPtr<Cairo::ImageSurface>& image, PeakData* _peak
 	context->translate (0.5, 0.0);
 
 	/* draw the lines */
+	/* we add dots to the top and bottom of each line (this is
+	 * modelled on pyramix, except that we add clipping indicators
+	 * (see below).
+	 */
 
 	if (_shape == WaveView::Rectified) {
 		for (int i = 0; i < n_peaks; ++i) {
 			context->move_to (i, tips[i].top); /* down 1 pixel */
+			if (!tips[i].clip_max && !tips[i].clip_min) {
+				/* normal upper terminal dot */
+				context->rel_line_to (0, 1.0);
+			}
+			context->move_to (i, tips[i].top);
 			context->line_to (i, tips[i].bot);
 		}
 	} else {
 		for (int i = 0; i < n_peaks; ++i) {
 			context->move_to (i, tips[i].top);
+			if (!tips[i].clip_max) {
+				/* normal upper terminal dot */
+				context->rel_line_to (0, 1.0);
+			}
+			context->move_to (i, tips[i].top);
 			context->line_to (i, tips[i].bot);
+			if (!tips[i].clip_min) {
+				/* normal lower terminal dot */
+				context->rel_line_to (0, -1.0);
+			}
 		}
 	}
 
 	context->stroke ();
 
-	/* now add dots to the top and bottom of each line (this is
-	 * modelled on pyramix, except that we add clipping indicators.
-	 *
-	 * the height of the clip-indicator should be at most 7 pixels,
+	 /* the height of the clip-indicator should be at most 7 pixels,
 	 * or 5% of the height of the waveview item.
 	 */
 
 	const double clip_height = min (7.0, ceil (_height * 0.05));
 
-	set_source_rgba (context, _outline_color);
+	set_source_rgba (context, _clip_color);
 		
 	for (int i = 0; i < n_peaks; ++i) {
-		context->move_to (i, tips[i].top);
-			
+		
 		bool show_top_clip =   _global_show_waveform_clipping && 
 			((_shape == WaveView::Rectified && (tips[i].clip_max || tips[i].clip_min)) ||
 			 tips[i].clip_max);
 			
 		if (show_top_clip) {
-			/* clip-indicating upper terminal line */
-			set_source_rgba (context, _clip_color);
+			context->move_to (i, tips[i].top);
 			context->rel_line_to (0, clip_height);
-			context->stroke ();
-			set_source_rgba (context, _outline_color);
-		} else {
-			/* normal upper terminal dot */
-			context->rel_line_to (0, 1.0);
-			context->stroke ();
 		}
 
-
 		if (_global_show_waveform_clipping && _shape != WaveView::Rectified) {
-			context->move_to (i, tips[i].bot);
 			if (tips[i].clip_min) {
-				/* clip-indicating lower terminal line */
-				set_source_rgba (context, _clip_color);
+				context->move_to (i, tips[i].bot);
 				context->rel_line_to (0, -clip_height);
-				context->stroke ();
-				set_source_rgba (context, _outline_color);
-			} else {
-				/* normal lower terminal dot */
-				context->rel_line_to (0, -1.0);
-				context->stroke ();
 			}
 		}
 	}
-
+			
+	context->stroke ();
+		
 	if (show_zero_line()) {
 		set_source_rgba (context, _zero_color);
 		context->set_line_width (1.0);


### PR DESCRIPTION
```
* don't redraw the summary incessantly while loading session.
* use a background ImageSurface for summary containing track lines and regions.
Composite with 'live' playhead, view rect etc. using cairo_push/pop_group
* reduce use of cairo_stroke () when drawing waveforms (should be a visual no-op)
* don't queue a draw for canvas items that are off window or !visible.
```
