### PR TITLE
Render parts of summary to an ImageSurface.

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -4704,13 +4704,13 @@ Editor::located ()
 void
 Editor::region_view_added (RegionView *)
 {
-	_summary->set_dirty ();
+	_summary->set_background_dirty ();
 }
 
 void
 Editor::region_view_removed ()
 {
-	_summary->set_dirty ();
+	_summary->set_background_dirty ();
 }
 
 RouteTimeAxisView*

--- a/gtk2_ardour/editor_summary.h
+++ b/gtk2_ardour/editor_summary.h
@@ -39,9 +39,11 @@ public:
 
 	void set_session (ARDOUR::Session *);
 	void set_overlays_dirty ();
+	void set_background_dirty ();
 	void routes_added (std::list<RouteTimeAxisView*> const &);
 
 private:
+	void on_size_allocate (Gtk::Allocation& alloc);
 
 	enum Position {
 		LEFT,
@@ -120,6 +122,9 @@ private:
 	Position _zoom_position;
 
 	bool _old_follow_playhead;
+	cairo_surface_t* _image;
+	void render_background_image ();
+	bool _background_dirty;
 
 	PBD::ScopedConnectionList position_connection;
 	PBD::ScopedConnection route_ctrl_id_connection;


### PR DESCRIPTION
Render tracks and regions to a background image in the editor summary.
Connect to editor's SelectionChanged signal to display corresponding region colour change.
