### PR TITLE
Render waveview components onto alpha masks to simplify drawing.

### DIFF
--- a/gtk2_ardour/missing_file_dialog.cc
+++ b/gtk2_ardour/missing_file_dialog.cc
@@ -32,7 +32,7 @@ using namespace ARDOUR;
 using namespace PBD;
 
 MissingFileDialog::MissingFileDialog (Session* s, const std::string& path, DataType type)
-        : ArdourDialog (_("Missing File!"), true, false)
+        : ArdourDialog (_("Missing File"), true, false)
         , filetype (type)
         , chooser (_("Select a folder to search"), FILE_CHOOSER_ACTION_SELECT_FOLDER)
         , use_chosen (_("Add chosen folder to search path, and try again"))
@@ -66,7 +66,7 @@ MissingFileDialog::MissingFileDialog (Session* s, const std::string& path, DataT
 		oss << *i << endl;
 	}
 
-        msg.set_justify (JUSTIFY_CENTER);
+        msg.set_justify (JUSTIFY_LEFT);
         msg.set_markup (string_compose (_("%1 cannot find the %2 file\n\n<i>%3</i>\n\nin any of these folders:\n\n\
 <tt>%4</tt>\n\n"), PROGRAM_NAME, typestr, Glib::Markup::escape_text(path), Glib::Markup::escape_text (oss.str())));
 

--- a/libs/canvas/canvas/wave_view.h
+++ b/libs/canvas/canvas/wave_view.h
@@ -53,24 +53,24 @@ public:
 		Normal,
 		Rectified
         };
-	
+
 	struct CacheEntry {
 		int channel;
 		Coord height;
 		float amplitude;
 		Color fill_color;
-		Color outline_color;
 		framepos_t start;
 		framepos_t end;
 		Cairo::RefPtr<Cairo::ImageSurface> image;
-	CacheEntry() : 
-		channel (0), height (0), amplitude(0), fill_color (0), 
-			outline_color (0), start (0), end (0), image (0) {} 
-	CacheEntry(int chan, Coord hght, float amp, Color fcol, Color ocol, 
-		   framepos_t strt, framepos_t ed, Cairo::RefPtr<Cairo::ImageSurface> img) :
-		channel (chan), height (hght), amplitude (amp), fill_color (fcol),
-			outline_color (ocol), start (strt), end (ed), image (img) {} 
+
+	CacheEntry(int chan, Coord hght, float amp, Color fcl, framepos_t strt, framepos_t ed, Cairo::RefPtr<Cairo::ImageSurface> img)  :
+		
+		channel (chan), height (hght), amplitude (amp), fill_color (fcl), 
+			start (strt), end (ed), image (img) {} 
 	};
+
+	/* final ImageSurface rendered with colours */
+	Cairo::RefPtr<Cairo::ImageSurface> _image;
 	
     /* Displays a single channel of waveform data for the given Region.
 


### PR DESCRIPTION
Render waveview components onto alpha masks to simplify drawing.
Reduce user panic by removing ! from missing file dialog title.
Use justify left in missing file dialog.
