### PR TITLE
Plugin Automation All: Fix bug where Switches weren't being changed.

### DIFF
--- a/gtk2_ardour/generic_pluginui.cc
+++ b/gtk2_ardour/generic_pluginui.cc
@@ -300,6 +300,7 @@ GenericPluginUI::build ()
 			}
 
 			control_uis.push_back(cui);
+			input_controls_with_automation.push_back (cui);
 		}
 	}
 
@@ -735,6 +736,7 @@ GenericPluginUI::build_control_ui (const Evoral::Parameter&             param,
 		mcontrol->alist()->automation_state_changed.connect (control_connections, invalidator (*this), boost::bind (&GenericPluginUI::automation_state_changed, this, control_ui), gui_context());
 
 		input_controls.push_back (control_ui);
+		input_controls_with_automation.push_back (control_ui);
 
 	} else if (!is_input) {
 
@@ -843,7 +845,7 @@ GenericPluginUI::astate_clicked (ControlUI* cui)
 void 
 GenericPluginUI::set_all_automation (AutoState as)
 {
-	for (vector<ControlUI*>::iterator i = input_controls.begin(); i != input_controls.end(); ++i) {
+	for (vector<ControlUI*>::iterator i = input_controls_with_automation.begin(); i != input_controls_with_automation.end(); ++i) {
 		if ((*i)->controller || (*i)->button) {
 			set_automation_state (as, (*i));
 		}

--- a/gtk2_ardour/plugin_ui.h
+++ b/gtk2_ardour/plugin_ui.h
@@ -266,6 +266,7 @@ class GenericPluginUI : public PlugUIBase, public Gtk::VBox
 	};
 
 	std::vector<ControlUI*>   input_controls;
+	std::vector<ControlUI*>   input_controls_with_automation;
 	std::vector<ControlUI*>   output_controls;
 	sigc::connection screen_update_connection;
 	void output_update();


### PR DESCRIPTION
Plugin controls under the Switches area weren't being changed with the automation-all buttons.
