### PR TITLE
Add editor selection state to session history via a SelectionMemento

### DIFF
--- a/gtk2_ardour/ardour.menus.in
+++ b/gtk2_ardour/ardour.menus.in
@@ -151,6 +151,10 @@
     <menu name='Edit' action='Edit'>
       <menuitem action='undo'/>
       <menuitem action='redo'/>
+      <separator/>
+      <menuitem action='undo-last-selection-op'/>
+      <menuitem action='redo-last-selection-op'/>
+      <separator/>  
       <menuitem action='editor-cut'/>
       <menuitem action='editor-copy'/>
       <menuitem action='editor-paste'/>

--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -281,6 +281,8 @@ Editor::Editor ()
 	, _tools_tearoff (0)
 
 	, _toolbar_viewport (*manage (new Gtk::Adjustment (0, 0, 1e10)), *manage (new Gtk::Adjustment (0, 0, 1e10)))
+	, selection_op_cmd_depth (0)
+	, selection_op_history_it (0)
 
 	  /* nudge */
 
@@ -306,6 +308,7 @@ Editor::Editor ()
 	selection = new Selection (this);
 	cut_buffer = new Selection (this);
 	_selection_memento = new SelectionMemento ();
+	selection_op_history.clear();
 	before.clear();
 
 	clicked_regionview = 0;
@@ -3308,6 +3311,95 @@ Editor::map_transport_state ()
 /* UNDO/REDO */
 
 void
+Editor::begin_selection_op_history ()
+{
+	selection_op_cmd_depth = 0;
+	selection_op_history_it = 0;
+	selection_op_history.clear();
+	selection_undo_action->set_sensitive (false);
+	selection_redo_action->set_sensitive (false);
+	selection_op_history.push_front (&_selection_memento->get_state ());
+}
+
+void
+Editor::begin_reversible_selection_op (string name)
+{
+	if (_session) {
+		//cerr << name << endl;
+		/* begin/commit pairs can be nested */
+		selection_op_cmd_depth++;
+	}
+}
+
+void
+Editor::commit_reversible_selection_op ()
+{
+	if (_session) {
+		if (selection_op_cmd_depth == 1) {
+
+			if (selection_op_history_it > 0 && selection_op_history_it < selection_op_history.size()) {
+				list<XMLNode *>::iterator it = selection_op_history.begin();
+				advance (it, selection_op_history_it);
+				selection_op_history.erase (selection_op_history.begin(), it);
+			}
+			selection_op_history.push_front (&_selection_memento->get_state ());
+			selection_op_history_it = 0;
+		}
+
+		if (selection_op_cmd_depth > 0) {
+			selection_op_cmd_depth--;
+		}
+
+		selection_undo_action->set_sensitive (true);
+		selection_redo_action->set_sensitive (false);
+	}
+}
+
+void
+Editor::undo_reversible_selection_op ()
+{
+	if (_session) {
+		selection_op_history_it++;
+		uint32_t n = 0;
+		for (std::list<XMLNode *>::iterator i = selection_op_history.begin(); i != selection_op_history.end(); ++i) {
+			if (n == selection_op_history_it) {
+				_selection_memento->set_state (*(*i), Stateful::current_state_version);
+				selection_redo_action->set_sensitive (true);
+			}
+			++n;
+
+		}
+		/* is there an earlier entry? */
+		if ((selection_op_history_it + 1) >= selection_op_history.size()) {
+			selection_undo_action->set_sensitive (false);
+		}
+	}
+}
+
+void
+Editor::redo_reversible_selection_op ()
+{
+	if (_session) {
+		if (selection_op_history_it > 0) {
+			selection_op_history_it--;
+		}
+		uint32_t n = 0;
+		for (std::list<XMLNode *>::iterator i = selection_op_history.begin(); i != selection_op_history.end(); ++i) {
+			if (n == selection_op_history_it) {
+				_selection_memento->set_state (*(*i), Stateful::current_state_version);
+				selection_undo_action->set_sensitive (true);
+			}
+			++n;
+
+		}
+
+		if (selection_op_history_it == 0) {
+			selection_redo_action->set_sensitive (false);
+		}
+	}
+}
+
+void
 Editor::begin_reversible_command (string name)
 {
 	if (_session) {
@@ -3331,9 +3423,12 @@ Editor::commit_reversible_command ()
 	if (_session) {
 		if (before.size() == 1) {
 			_session->add_command (new MementoCommand<SelectionMemento>(*(_selection_memento), before.front(), &_selection_memento->get_state ()));
+			begin_selection_op_history ();
 		}
 
-		if (!before.empty()) {
+		if (before.empty()) {
+			cerr << "Please call begin_reversible_command() before commit_reversible_command()." << endl;
+		} else {
 			before.pop_back();
 		}
 
@@ -4917,6 +5012,9 @@ Editor::first_idle ()
 	_routes->redisplay ();
 
 	delete dialog;
+
+	begin_selection_op_history ();
+
 	_have_idled = true;
 }
 

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -430,6 +430,11 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 	              ARDOUR::RoundMode direction = ARDOUR::RoundNearest,
 	              bool              for_mark  = false);
 
+	void begin_selection_op_history ();
+	void begin_reversible_selection_op (std::string cmd_name);
+	void commit_reversible_selection_op ();
+	void undo_reversible_selection_op ();
+	void redo_reversible_selection_op ();
 	void begin_reversible_command (std::string cmd_name);
 	void begin_reversible_command (GQuark);
 	void commit_reversible_command ();
@@ -1879,6 +1884,10 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 
 	void write_selection ();
 
+	uint32_t selection_op_cmd_depth;
+	uint32_t selection_op_history_it;
+
+	std::list<XMLNode *> selection_op_history; /* used in *_reversible_selection_op */
 	std::list<XMLNode *> before; /* used in *_reversible_command */
 
 	void update_title ();
@@ -2004,6 +2013,8 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 
 	Glib::RefPtr<Gtk::Action>              undo_action;
 	Glib::RefPtr<Gtk::Action>              redo_action;
+	Glib::RefPtr<Gtk::Action>              selection_undo_action;
+	Glib::RefPtr<Gtk::Action>              selection_redo_action;
 
 	void history_changed ();
 

--- a/gtk2_ardour/editor_actions.cc
+++ b/gtk2_ardour/editor_actions.cc
@@ -319,6 +319,9 @@ Editor::register_actions ()
 	redo_action = reg_sens (editor_actions, "alternate-redo", _("Redo"), sigc::bind (sigc::mem_fun(*this, &Editor::redo), 1U));
 	redo_action = reg_sens (editor_actions, "alternate-alternate-redo", _("Redo"), sigc::bind (sigc::mem_fun(*this, &Editor::redo), 1U));
 
+	selection_undo_action = reg_sens (editor_actions, "undo-last-selection-op", _("Undo Last Selection Op"), sigc::mem_fun(*this, &Editor::undo_reversible_selection_op));
+	selection_redo_action = reg_sens (editor_actions, "redo-last-selection-op", _("Redo Last Selection Op"), sigc::mem_fun(*this, &Editor::redo_reversible_selection_op));
+
 	reg_sens (editor_actions, "export-audio", _("Export Audio"), sigc::mem_fun(*this, &Editor::export_audio));
 	reg_sens (editor_actions, "export-range", _("Export Range"), sigc::mem_fun(*this, &Editor::export_range));
 

--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -4379,6 +4379,7 @@ SelectionDrag::finished (GdkEvent* event, bool movement_occurred)
 {
 	Session* s = _editor->session();
 
+	_editor->begin_reversible_selection_op (_("Change Time Selection"));
 	if (movement_occurred) {
 		motion (event, false);
 		/* XXX this is not object-oriented programming at all. ick */
@@ -4435,6 +4436,7 @@ SelectionDrag::finished (GdkEvent* event, bool movement_occurred)
 
 	_editor->stop_canvas_autoscroll ();
 	_editor->clicked_selection = 0;
+	_editor->commit_reversible_selection_op ();
 }
 
 void
@@ -5192,11 +5194,11 @@ EditorRubberbandSelectDrag::select_things (int button_state, framepos_t x1, fram
 	
 	Selection::Operation op = ArdourKeyboard::selection_type (button_state);
 
-	_editor->begin_reversible_command (_("rubberband selection"));
+	_editor->begin_reversible_selection_op (_("rubberband selection"));
 
 	_editor->select_all_within (x1, x2 - 1, y1, y2, _editor->track_views, op, false);
 
-	_editor->commit_reversible_command ();
+	_editor->commit_reversible_selection_op ();
 }
 
 void

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -1456,7 +1456,11 @@ Editor::button_release_handler (ArdourCanvas::Item* item, GdkEvent* event, ItemT
 		}
 
                 /* do any (de)selection operations that should occur on button release */
+
+		begin_reversible_selection_op (_("Button Select"));
                 button_selection (item, event, item_type);
+		commit_reversible_selection_op ();
+
 		return true;
 		break;
 

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -121,6 +121,8 @@ Editor::undo (uint32_t n)
 	
 	if (_session) {
 		_session->undo (n);
+		redo_action->set_sensitive(true);
+		begin_selection_op_history ();
 	}
 }
 
@@ -133,6 +135,11 @@ Editor::redo (uint32_t n)
 	
 	if (_session) {
 		_session->redo (n);
+		cerr << "redo depth is : " << _session->redo_depth() << endl;
+		if (_session->redo_depth() == 0) {
+			redo_action->set_sensitive(false);
+		}
+		begin_selection_op_history ();
 	}
 }
 

--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -270,6 +270,8 @@ Editor::set_selected_track_as_side_effect (Selection::Operation op)
 void
 Editor::set_selected_track (TimeAxisView& view, Selection::Operation op, bool no_remove)
 {
+	begin_reversible_selection_op(_("Set Selected Track"));
+
 	switch (op) {
 	case Selection::Toggle:
 		if (selection->selected (&view)) {
@@ -295,6 +297,8 @@ Editor::set_selected_track (TimeAxisView& view, Selection::Operation op, bool no
 		extend_selection_to_track (view);
 		break;
 	}
+
+	commit_reversible_selection_op ();
 }
 
 void
@@ -892,7 +896,7 @@ Editor::set_selected_regionview_from_region_list (boost::shared_ptr<Region> regi
 		return;
 	}
 
-	begin_reversible_command (_("set selected regions"));
+	begin_reversible_selection_op (_("set selected regions"));
 
 	switch (op) {
 	case Selection::Toggle:
@@ -910,7 +914,7 @@ Editor::set_selected_regionview_from_region_list (boost::shared_ptr<Region> regi
 		break;
 	}
 
-	commit_reversible_command () ;
+	commit_reversible_selection_op () ;
 }
 
 bool
@@ -935,11 +939,11 @@ Editor::set_selected_regionview_from_map_event (GdkEventAny* /*ev*/, StreamView*
 		return true;
 	}
 
-	begin_reversible_command (_("set selected regions"));
+	begin_reversible_selection_op (_("set selected regions"));
 
 	selection->set (rv);
 
-	commit_reversible_command () ;
+	commit_reversible_selection_op () ;
 
 	return true;
 }
@@ -1348,6 +1352,8 @@ Editor::select_all_in_track (Selection::Operation op)
 		return;
 	}
 
+	begin_reversible_selection_op(_("Select All in Track"));
+
 	clicked_routeview->get_selectables (0, max_framepos, 0, DBL_MAX, touched);
 
 	switch (op) {
@@ -1364,6 +1370,8 @@ Editor::select_all_in_track (Selection::Operation op)
 		selection->add (touched);
 		break;
 	}
+
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1416,7 +1424,7 @@ Editor::select_all_objects (Selection::Operation op)
 	}
 
 
-	begin_reversible_command (_("select all"));
+	begin_reversible_selection_op (_("select all"));
 	switch (op) {
 	case Selection::Add:
 		selection->add (touched);
@@ -1431,7 +1439,7 @@ Editor::select_all_objects (Selection::Operation op)
 		/* meaningless, because we're selecting everything */
 		break;
 	}
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1443,8 +1451,10 @@ Editor::invert_selection_in_track ()
 		return;
 	}
 
+	begin_reversible_selection_op(_("Invert Selection in Track"));
 	clicked_routeview->get_inverted_selectables (*selection, touched);
 	selection->set (touched);
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1469,7 +1479,9 @@ Editor::invert_selection ()
 		(*iter)->get_inverted_selectables (*selection, touched);
 	}
 
+	begin_reversible_selection_op(_("Invert Selection"));
 	selection->set (touched);
+	commit_reversible_selection_op ();
 }
 
 /** @param start Start time in session frames.
@@ -1510,7 +1522,7 @@ Editor::select_all_within (framepos_t start, framepos_t end, double top, double 
 		}
 	}
 
-	begin_reversible_command (_("select all within"));
+	begin_reversible_selection_op (_("select all within"));
 	switch (op) {
 	case Selection::Add:
 		selection->add (found);
@@ -1526,7 +1538,7 @@ Editor::select_all_within (framepos_t start, framepos_t end, double top, double 
 		break;
 	}
 
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1568,9 +1580,9 @@ Editor::set_selection_from_loop()
 void
 Editor::set_selection_from_range (Location& loc)
 {
-	begin_reversible_command (_("set selection from range"));
+	begin_reversible_selection_op (_("set selection from range"));
 	selection->set (loc.start(), loc.end());
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 
 	if (!Profile->get_sae()) {
 		set_mouse_mode (Editing::MouseRange, false);
@@ -1608,9 +1620,9 @@ Editor::select_all_selectables_using_time_selection ()
 		(*iter)->get_selectables (start, end - 1, 0, DBL_MAX, touched);
 	}
 
-	begin_reversible_command (_("select all from range"));
+	begin_reversible_selection_op (_("select all from range"));
 	selection->set (touched);
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 }
 
 
@@ -1639,9 +1651,9 @@ Editor::select_all_selectables_using_punch()
 		}
 		(*iter)->get_selectables (location->start(), location->end() - 1, 0, DBL_MAX, touched);
 	}
-	begin_reversible_command (_("select all from punch"));
+	begin_reversible_selection_op (_("select all from punch"));
 	selection->set (touched);
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 
 }
 
@@ -1670,9 +1682,9 @@ Editor::select_all_selectables_using_loop()
 		}
 		(*iter)->get_selectables (location->start(), location->end() - 1, 0, DBL_MAX, touched);
 	}
-	begin_reversible_command (_("select all from loop"));
+	begin_reversible_selection_op (_("select all from loop"));
 	selection->set (touched);
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 
 }
 
@@ -1706,9 +1718,9 @@ Editor::select_all_selectables_using_cursor (EditorCursor *cursor, bool after)
 	}
 
 	if (after) {
-		begin_reversible_command (_("select all after cursor"));
+		begin_reversible_selection_op (_("select all after cursor"));
 	} else {
-		begin_reversible_command (_("select all before cursor"));
+		begin_reversible_selection_op (_("select all before cursor"));
 	}
 
 	TrackViewList* ts;
@@ -1726,7 +1738,7 @@ Editor::select_all_selectables_using_cursor (EditorCursor *cursor, bool after)
 		(*iter)->get_selectables (start, end, 0, DBL_MAX, touched);
 	}
 	selection->set (touched);
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1757,9 +1769,9 @@ Editor::select_all_selectables_using_edit (bool after)
 	}
 
 	if (after) {
-		begin_reversible_command (_("select all after edit"));
+		begin_reversible_selection_op (_("select all after edit"));
 	} else {
-		begin_reversible_command (_("select all before edit"));
+		begin_reversible_selection_op (_("select all before edit"));
 	}
 
 	TrackViewList* ts;
@@ -1777,7 +1789,7 @@ Editor::select_all_selectables_using_edit (bool after)
 		(*iter)->get_selectables (start, end, 0, DBL_MAX, touched);
 	}
 	selection->set (touched);
-	commit_reversible_command ();
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1814,7 +1826,9 @@ Editor::select_all_selectables_between (bool /*within*/)
 		(*iter)->get_selectables (start, end, 0, DBL_MAX, touched);
 	}
 
+	begin_reversible_selection_op(_("Select all Selectables Between"));
 	selection->set (touched);
+	commit_reversible_selection_op ();
 }
 
 void
@@ -1831,8 +1845,10 @@ Editor::select_range_between ()
 		return;
 	}
 
+	begin_reversible_selection_op(_("Select Range Between"));
 	set_mouse_mode (MouseRange);
 	selection->set (start, end);
+	commit_reversible_selection_op ();
 }
 
 bool
@@ -1939,13 +1955,18 @@ Editor::get_edit_op_range (framepos_t& start, framepos_t& end) const
 void
 Editor::deselect_all ()
 {
+	begin_reversible_selection_op(_("Clear Selection"));
 	selection->clear ();
+	commit_reversible_selection_op ();
 }
 
 long
 Editor::select_range (framepos_t s, framepos_t e)
 {
+	begin_reversible_selection_op(_("Select Range"));
 	selection->add (clicked_axisview);
 	selection->time.clear ();
-	return selection->set (s, e);
+	long ret = selection->set (s, e);
+	commit_reversible_selection_op ();
+	return ret;
 }

--- a/gtk2_ardour/selection.cc
+++ b/gtk2_ardour/selection.cc
@@ -1261,6 +1261,7 @@ Selection::set_state (XMLNode const & node, int)
 	}
 
 	clear_regions ();
+	clear_points ();
 	clear_time ();
 	clear_tracks ();
 	clear_markers ();


### PR DESCRIPTION
.Add editor selection state to session history via a SelectionMemento, which
combines selection related editor properties with the current editor selection.

The related editor properties are:
mouse mode,
zoom setting,
left frame of the canvas,
y origin of the canvas.

Selection state now includes region views (storing the underlying region id)
and time.

This patch also fixes a region mute undo bug.