### PR TITLE
Separate selection operations into their own temporary history

### DIFF
--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -156,7 +156,7 @@ void
 AutomationLine::update_visibility ()
 {
 	if (_visible & Line) {
-		/* Only show the line there are some points, otherwise we may show an out-of-date line
+		/* Only show the line when there are some points, otherwise we may show an out-of-date line
 		   when automation points have been removed (the line will still follow the shape of the
 		   old points).
 		*/

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -421,7 +421,8 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 
         void get_regions_corresponding_to (boost::shared_ptr<ARDOUR::Region> region, std::vector<RegionView*>& regions, bool src_comparison);
 
-	void get_regionviews_by_id (PBD::ID const & id, RegionSelection & regions) const;
+	void get_regionviews_by_id (PBD::ID const id, RegionSelection & regions) const;
+	void get_per_region_note_selection (std::list<std::pair<PBD::ID, std::set<boost::shared_ptr<Evoral::Note<Evoral::Beats> > > > >&) const;
 
 	void center_screen (framepos_t);
 
@@ -706,6 +707,7 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 	
 	void button_selection (ArdourCanvas::Item* item, GdkEvent* event, ItemType item_type);
 	bool button_release_can_deselect;
+	bool _mouse_changed_selection;
 
 	void catch_vanishing_regionview (RegionView *);
 

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -178,7 +178,9 @@ Editor::canvas_scroll_event (GdkEventScroll *event, bool from_canvas)
 bool
 Editor::track_canvas_button_press_event (GdkEventButton */*event*/)
 {
+	begin_reversible_selection_op (_("Clear Selection Click (track canvas)"));
 	selection->clear ();
+	commit_reversible_selection_op();
 	_track_canvas->grab_focus();
 	return false;
 }
@@ -1105,8 +1107,10 @@ Editor::canvas_drop_zone_event (GdkEvent* event)
 	switch (event->type) {
 	case GDK_BUTTON_RELEASE:
 		if (event->button.button == 1) {
+			begin_reversible_selection_op (_("Nowhere Click"));
 			selection->clear_objects ();
 			selection->clear_tracks ();
+			commit_reversible_selection_op ();
 		}
 		break;
 

--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -202,8 +202,9 @@ Editor::set_selected_track_as_side_effect (Selection::Operation op)
 				}
 			} else if (group && group->is_active()) {
 				for (TrackViewList::iterator i = track_views.begin(); i != track_views.end (); ++i) {
-					if ((*i)->route_group() == group)
+					if ((*i)->route_group() == group) {
 						selection->remove(*i);
+					}
 				}
 			} else {
 				selection->remove (clicked_axisview);
@@ -215,8 +216,9 @@ Editor::set_selected_track_as_side_effect (Selection::Operation op)
 				}
 			} else if (group && group->is_active()) {
 				for (TrackViewList::iterator i = track_views.begin(); i != track_views.end (); ++i) {
-					if ( (*i)->route_group() == group)
+					if ((*i)->route_group() == group) {
 						selection->add(*i);
+					}
 				}
 			} else {
 				selection->add (clicked_axisview);
@@ -234,8 +236,9 @@ Editor::set_selected_track_as_side_effect (Selection::Operation op)
 			}
 		} else if (group && group->is_active()) {
 			for (TrackViewList::iterator i  = track_views.begin(); i != track_views.end (); ++i) {
-				if ((*i)->route_group() == group)
+				if ((*i)->route_group() == group) {
 					selection->add(*i);
+				}
 			}
 		} else {
 			selection->add (clicked_axisview);
@@ -253,8 +256,9 @@ Editor::set_selected_track_as_side_effect (Selection::Operation op)
 			}
 		} else if (group && group->is_active()) {
 			for (TrackViewList::iterator i  = track_views.begin(); i != track_views.end (); ++i) {
-				if ((*i)->route_group() == group)
+				if ((*i)->route_group() == group) {
 					selection->add(*i);
+				}
 			}
 		} else {
 			selection->set (clicked_axisview);
@@ -1953,7 +1957,7 @@ Editor::get_edit_op_range (framepos_t& start, framepos_t& end) const
 void
 Editor::deselect_all ()
 {
-	begin_reversible_selection_op(_("Clear Selection"));
+	begin_reversible_selection_op(_("Deselect All"));
 	selection->clear ();
 	commit_reversible_selection_op ();
 }

--- a/gtk2_ardour/midi_region_view.h
+++ b/gtk2_ardour/midi_region_view.h
@@ -203,6 +203,7 @@ public:
 	void move_selection(double dx, double dy, double cumulative_dy);
 	void note_dropped (NoteBase* ev, ARDOUR::frameoffset_t, int8_t d_note);
 
+	void select_notes (std::list<boost::shared_ptr<NoteType> >);
 	void select_matching_notes (uint8_t notenum, uint16_t channel_mask, bool add, bool extend);
 	void toggle_matching_notes (uint8_t notenum, uint16_t channel_mask);
 
@@ -438,6 +439,9 @@ private:
 	 * when they appear after the command is applied. */
 	std::set< boost::shared_ptr<NoteType> > _marked_for_selection;
 
+	/** Notes that should be selected when the model is redisplayed. */
+	std::set< boost::shared_ptr<NoteType> > _pending_note_selection;
+
 	/** New notes (created in the current command) which should have visible velocity
 	 * when they appear after the command is applied. */
 	std::set< boost::shared_ptr<NoteType> > _marked_for_velocity;
@@ -448,6 +452,7 @@ private:
 	PBD::ScopedConnection content_connection;
 
 	NoteBase* find_canvas_note (boost::shared_ptr<NoteType>);
+	NoteBase* find_canvas_note (NoteType);
 	Events::iterator _optimization_iterator;
 
 	void update_note (NoteBase*, bool update_ghost_regions = true);
@@ -498,6 +503,8 @@ private:
 	double _last_event_y;
 	bool   _grabbed_keyboard;
 	bool   _entered;
+
+	bool _mouse_changed_selection;
 
 	framepos_t snap_frame_to_grid_underneath (framepos_t p, framecnt_t &) const;
 	

--- a/gtk2_ardour/midi_time_axis.h
+++ b/gtk2_ardour/midi_time_axis.h
@@ -30,6 +30,8 @@
 #include <gtkmm2ext/selector.h>
 #include <list>
 
+#include "evoral/Note.hpp"
+
 #include "ardour/types.h"
 #include "ardour/region.h"
 
@@ -65,7 +67,7 @@ class MidiChannelSelectorWindow;
 
 class MidiTimeAxisView : public RouteTimeAxisView
 {
-	public:
+public:
 	MidiTimeAxisView (PublicEditor&, ARDOUR::Session*, ArdourCanvas::Canvas& canvas);
 	virtual ~MidiTimeAxisView ();
 
@@ -100,11 +102,13 @@ class MidiTimeAxisView : public RouteTimeAxisView
 
 	uint8_t get_channel_for_add () const;
 
-	protected:
+	void get_per_region_note_selection (std::list<std::pair<PBD::ID, std::set<boost::shared_ptr<Evoral::Note<Evoral::Beats> > > > >&);
+
+protected:
 	void start_step_editing ();
 	void stop_step_editing ();
 
-	private:
+private:
 	sigc::signal<void, std::string, std::string>  _midi_patch_settings_changed;
 
 	void model_changed(const std::string& model);
@@ -165,6 +169,7 @@ class MidiTimeAxisView : public RouteTimeAxisView
 	void add_note_selection_region_view (RegionView* rv, uint8_t note, uint16_t chn_mask);
 	void extend_note_selection_region_view (RegionView*, uint8_t note, uint16_t chn_mask);
 	void toggle_note_selection_region_view (RegionView*, uint8_t note, uint16_t chn_mask);
+	void get_per_region_note_selection_region_view (RegionView*, std::list<std::pair<PBD::ID, std::set<boost::shared_ptr<Evoral::Note<Evoral::Beats> > > > >&);
 
 	void ensure_step_editor ();
 

--- a/gtk2_ardour/public_editor.h
+++ b/gtk2_ardour/public_editor.h
@@ -34,6 +34,7 @@
 #include <gtkmm/actiongroup.h>
 #include <sigc++/signal.h>
 
+#include "evoral/Note.hpp"
 #include "evoral/types.hpp"
 
 #include "pbd/statefuldestructible.h"
@@ -391,6 +392,8 @@ class PublicEditor : public Gtk::Window, public PBD::StatefulDestructible, publi
 	virtual void stop_canvas_autoscroll () = 0;
         virtual bool autoscroll_active() const = 0;
 
+	virtual void begin_reversible_selection_op (std::string cmd_name) = 0;
+	virtual void commit_reversible_selection_op () = 0;
 	virtual void begin_reversible_command (std::string cmd_name) = 0;
 	virtual void begin_reversible_command (GQuark) = 0;
 	virtual void commit_reversible_command () = 0;
@@ -412,7 +415,8 @@ class PublicEditor : public Gtk::Window, public PBD::StatefulDestructible, publi
 
 	virtual void get_regions_at (RegionSelection &, framepos_t where, TrackViewList const &) const = 0;
 	virtual RegionSelection get_regions_from_selection_and_mouse (framepos_t) = 0;
-	virtual void get_regionviews_by_id (PBD::ID const & id, RegionSelection & regions) const = 0;
+	virtual void get_regionviews_by_id (PBD::ID const id, RegionSelection & regions) const = 0;
+	virtual void get_per_region_note_selection (std::list<std::pair<PBD::ID, std::set<boost::shared_ptr<Evoral::Note<Evoral::Beats> > > > >&) const = 0;
 
 	/// Singleton instance, set up by Editor::Editor()
 

--- a/gtk2_ardour/selection.h
+++ b/gtk2_ardour/selection.h
@@ -223,6 +223,8 @@ class Selection : public sigc::trackable, public PBD::ScopedConnectionList
 
 	PBD::Signal0<void> ClearMidiNoteSelection;
 
+	std::list<std::pair<PBD::ID const, std::list<boost::shared_ptr<Evoral::Note<Evoral::Beats> > > > > pending_midi_note_selection;
+
   private:
 	PublicEditor const * editor;
 	uint32_t next_time_id;


### PR DESCRIPTION
Separate selection operations into their own temporary history mechanism.
    The user can now replay *all* earlier selection operations until the next
    session undo/redo command, or the completion of a new operation.
    Nothing relating to selection ops is stored, and selection operation history
    is begun on first idle.
    
    Selection operation history is fundamentally different from the history of
    operations which act on a selection in terms of both their viewport and the
    amount of information required to replay them.
    WRT undo, the user of a selection op doesn't care about the viewport state
    at the beginning of an op, but rather that at the end of the previous one.