### PR TITLE
Old session loading

### DIFF
--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -846,7 +846,7 @@ Session::load_state (string snapshot_name)
 	} else {
 		if (prop->value().find ('.') != string::npos) {
 			/* old school version format */
-			if (prop->value()[0] == '2') {
+			if (prop->value()[0] < '3') {
 				Stateful::loading_state_version = 2000;
 			} else {
 				Stateful::loading_state_version = 3000;

--- a/libs/pbd/pbd/statefulidpredicates.h
+++ b/libs/pbd/pbd/statefulidpredicates.h
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2015 Paul Davis 
+    Author: Sakari Bergen
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#ifndef __pbd_statefulidpredicate_h__
+#define __pbd_statefulidpredicate_h__
+
+#include "pbd/libpbd_visibility.h"
+#include "pbd/id.h"
+#include "pbd/stateful.h"
+
+namespace PBD {
+
+struct LIBPBD_TEMPLATE_MEMBER_API StatefulIdEquals
+{
+	StatefulIdEquals(ID const & id)
+	  : id(id)
+	{}
+
+	template<typename StatefulPtr>
+	bool operator() (StatefulPtr p)
+	{
+		return p && compare(*p);
+	}
+
+	bool operator() (Stateful const & s)
+	{
+		return compare(s);
+	}
+
+private:
+
+	bool compare(Stateful const & s)
+	{
+		return s.id() == id;
+	}
+
+	ID const & id;
+};
+
+} // namespace PBD
+
+#endif // __pbd_statefulidpredicate_h__


### PR DESCRIPTION
Fixed some issues I found with loading an old session file.

The file had &lt;Session version="0.908.2" ... &gt; in it and it was recorded with some version of A2 IIRC. Not sure if the code is 100% correct even like this...

While at it, I added a utility class for finding Statefuls by id with standard algorithms, as the code is much more readable like this IMO.
