### PR TITLE
Add --program-exe-name option to waf build options

### DIFF
--- a/gtk2_ardour/ardour.sh.in
+++ b/gtk2_ardour/ardour.sh.in
@@ -23,7 +23,7 @@ fi
 
 ## Glib atomic test
 
-GLIB=$(ldd @LIBDIR@/ardour-@VERSION@ 2> /dev/null | grep glib-2.0 | sed 's/.*=> \([^ ]*\) .*/\1/')
+GLIB=$(ldd @LIBDIR@/@PROG_EXE_NAME@-@VERSION@ 2> /dev/null | grep glib-2.0 | sed 's/.*=> \([^ ]*\) .*/\1/')
 
 if [ "$GLIB" = "" ]; then
 	echo "WARNING: Could not check your glib-2.0 for mutex locking atomic operations."
@@ -59,6 +59,6 @@ if [ $# -gt 0 ] ; then
     esac
 fi
 
-exec $GDB @LIBDIR@/ardour-@VERSION@ "$@"
+exec $GDB @LIBDIR@/@PROG_EXE_NAME@-@VERSION@ "$@"
 
 

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -505,7 +505,8 @@ def build(bld):
             'CONFDIR'        : os.path.normpath(bld.env['CONFDIR']),
             'LIBS'           : 'build/libs',
             'VERSION'        : bld.env['VERSION'],
-            'EXECUTABLE'     : 'build/gtk2_ardour/' + bld.env['PROGRAM_EXE_NAME'] + '-' + str (bld.env['VERSION'])
+            'EXECUTABLE'     : 'build/gtk2_ardour/' + bld.env['PROGRAM_EXE_NAME'] + '-' + str (bld.env['VERSION']),
+            'PROG_EXE_NAME'  : bld.env['PROGRAM_EXE_NAME']
     }
 
     def set_subst_dict(obj, dict):

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -397,7 +397,7 @@ def build(bld):
                              'libgtkmm2ext',
                              'libcanvas',
                              ]
-        obj.target = 'ardour-' + str (bld.env['VERSION']) + '-vst.exe.so'
+        obj.target = bld.env['PROGRAM_EXE_NAME'] + str (bld.env['VERSION']) + '-vst.exe.so'
         obj.includes  = [ '../libs/fst', '.' ]
         obj.linkflags = ['-mwindows', '-Wl,--export-dynamic']
         obj.linkflags += bld.env['LDFLAGS']
@@ -418,7 +418,7 @@ def build(bld):
         else:
             obj = bld (features = 'cxx c cxxprogram')
         obj.source    = gtk2_ardour_sources
-        obj.target = 'ardour-' + str (bld.env['VERSION'])
+        obj.target =  bld.env['PROGRAM_EXE_NAME'] + '-' + str (bld.env['VERSION'])
         obj.includes = ['.']
         obj.ldflags = ['-no-undefined']
 
@@ -505,7 +505,7 @@ def build(bld):
             'CONFDIR'        : os.path.normpath(bld.env['CONFDIR']),
             'LIBS'           : 'build/libs',
             'VERSION'        : bld.env['VERSION'],
-            'EXECUTABLE'     : 'build/gtk2_ardour/ardour-' + str (bld.env['VERSION'])
+            'EXECUTABLE'     : 'build/gtk2_ardour/' + bld.env['PROGRAM_EXE_NAME'] + '-' + str (bld.env['VERSION'])
     }
 
     def set_subst_dict(obj, dict):
@@ -521,7 +521,7 @@ def build(bld):
 
     obj              = bld(features = 'subst')
     obj.source       = 'ardour.sh.in'
-    obj.target       = 'ardour3'
+    obj.target       = bld.env['PROGRAM_EXE_NAME'] + str (bld.env['MAJOR'])
     obj.chmod        = Utils.O755
     obj.dict         = wrapper_subst_dict
     obj.install_path = bld.env['BINDIR']
@@ -530,7 +530,7 @@ def build(bld):
     if bld.is_defined('WINDOWS_VST_SUPPORT'):
         obj              = bld(features = 'subst')
         obj.source       = '../vst/ardourvst.in'
-        obj.target       = 'ardourvst3'
+        obj.target       = bld.env['PROGRAM_EXE_NAME'] + 'vst' + str (bld.env['MAJOR'])
         obj.chmod        = Utils.O755
         obj.dict         = wrapper_subst_dict
         obj.install_path = bld.env['BINDIR']

--- a/wscript
+++ b/wscript
@@ -568,6 +568,8 @@ def options(opt):
     autowaf.set_options(opt, debug_by_default=True)
     opt.add_option('--program-name', type='string', action='store', default='Ardour', dest='program_name',
                     help='The user-visible name of the program being built')
+    opt.add_option('--program-exe-name', type='string', action='store', default='ardour', dest='program_exe_name',
+                    help='The executable name of the program being built')
     opt.add_option ('--trx', action='store_true', default=False, dest='trx_build',
                     help='Whether to build for TRX')
     opt.add_option('--arch', type='string', action='store', dest='arch',
@@ -691,6 +693,7 @@ def configure(conf):
     conf.env['VERSION'] = VERSION
     conf.env['MAJOR'] = MAJOR
     conf.env['MINOR'] = MINOR
+    conf.env['PROGRAM_EXE_NAME'] = Options.options.program_exe_name
     conf.line_just = 52
     autowaf.set_recursive()
     autowaf.configure(conf)
@@ -1082,7 +1085,7 @@ def build(bld):
     bld.path.find_dir ('libs/pbd/pbd')
 
     # set up target directories
-    lwrcase_dirname = 'ardour' + bld.env['MAJOR']
+    lwrcase_dirname = bld.env['PROGRAM_EXE_NAME'] + bld.env['MAJOR']
 
     if bld.is_defined ('TRX_BUILD'):
         lwrcase_dirname = 'trx'

--- a/wscript
+++ b/wscript
@@ -753,7 +753,7 @@ def configure(conf):
     if Options.options.lv2dir:
         conf.env['LV2DIR'] = Options.options.lv2dir
     else:
-        conf.env['LV2DIR'] = os.path.join(conf.env['LIBDIR'], 'ardour' + str(conf.env['MAJOR']), 'lv2')
+        conf.env['LV2DIR'] = os.path.join(conf.env['LIBDIR'], conf.env['PROGRAM_EXE_NAME'] + str(conf.env['MAJOR']), 'lv2')
 
     conf.env['LV2DIR'] = os.path.normpath(conf.env['LV2DIR'])
 


### PR DESCRIPTION
Use an option to determine executable name(prefix) and also use that for config dir names. Also fixed with this branch should be some hard coded version numbers. With --program-name and --program-exe-name left at the default options this should be a no-op change.

I have not tested the packaging scripts with this change, although there shouldn't be any problems with the defaults.