### PR TITLE
Don't install static library libsmf.a

### DIFF
--- a/libs/evoral/wscript
+++ b/libs/evoral/wscript
@@ -71,7 +71,7 @@ def build(bld):
     libsmf.name         = 'libsmf'
     libsmf.target       = 'smf'
     libsmf.uselib       = 'GLIB'
-    libsmf.install_path = bld.env['LIBDIR']
+    libsmf.install_path = None
     if bld.env['build_target'] != 'mingw':
         libsmf.cxxflags     = [ '-fPIC' ]
         libsmf.cflags       = [ '-fPIC' ]


### PR DESCRIPTION
As the subject says: if libsmf is built statically and linked into libevoral.so, it doesn't need to be installed.