### PR TITLE
Fix mixed spaces/tabs in wscripts

### DIFF
--- a/libs/backends/jack/wscript
+++ b/libs/backends/jack/wscript
@@ -70,8 +70,8 @@ def build(bld):
         obj.cflags   = [ '-fPIC' ]
 
     if bld.is_defined ('HAVE_JACK_METADATA'):
-	obj.cxxflags += [ '-DHAVE_JACK_METADATA' ]
-	obj.cflags += [ '-DHAVE_JACK_METADATA' ]
+        obj.cxxflags += [ '-DHAVE_JACK_METADATA' ]
+        obj.cflags += [ '-DHAVE_JACK_METADATA' ]
 
     if (bld.env['build_target'] == 'mingw'):
         obj.uselib   = [ 'PORTAUDIO' ]

--- a/wscript
+++ b/wscript
@@ -71,8 +71,8 @@ compiler_flags_dictionaries= {
         'ultra-strict' : ['-Wredundant-decls', '-Wstrict-prototypes', '-Wmissing-prototypes'],
         # Flag to turn on C99 compliance by itself 
         'c99': '-std=c99',
-	# Flag to enable AT&T assembler syntax
-	'attasm': '-masm=att',
+        # Flag to enable AT&T assembler syntax
+        'attasm': '-masm=att',
     },
     'msvc' : {
         'debuggable' : ['/DDEBUG', '/Od', '/Zi', '/MDd', '/Gd', '/EHsc'],


### PR DESCRIPTION
To prevent error when building with Python 3.