### PR TITLE
Don't allow user to change function of modifier buttons.

### DIFF
--- a/libs/surfaces/mackie/button.h
+++ b/libs/surfaces/mackie/button.h
@@ -70,10 +70,6 @@ public:
 		Busses,
 		Outputs,
 		User,
-		Shift,
-		Option,
-		Ctrl,
-		CmdAlt,
 		Read,
 		Write,
 		Trim,
@@ -106,6 +102,13 @@ public:
 		UserB,
 
 		FinalGlobalButton,
+
+		/* Global buttons that users should not redefine */
+
+		Shift,
+		Option,
+		Ctrl,
+		CmdAlt,
 
 		/* Strip buttons */
 		


### PR DESCRIPTION
Shift, Control, Alt and Option keys on the mackie control surface should not be user changable.