### PR TITLE
Add in MXF file as a supported video format

### DIFF
--- a/gtk2_ardour/add_video_dialog.cc
+++ b/gtk2_ardour/add_video_dialog.cc
@@ -288,6 +288,7 @@ static bool check_video_file_extension(std::string file)
 		".webm"    , ".WEBM"    ,
 		".wmv"     , ".WMV"     ,
 		".ts"      , ".TS"      ,
+		".mxf"     , ".MXF"     ,
 	};
 
 	for (size_t n = 0; n < sizeof(suffixes)/sizeof(suffixes[0]); ++n) {


### PR DESCRIPTION
No reason that I can see MXF shouldn't be a supported format, it add in the option of using XAVC as an interchange format from Lightworks to work on audio in post.