### PR TITLE
Allow any one midi event to control only one thing.

### DIFF
--- a/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
+++ b/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
@@ -772,7 +772,7 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 	MIDI::eventType ev;
 	int intval;
 	bool momentary;
-	bool encoder = false;
+	MIDIControllable::Encoder encoder = MIDIControllable::No_enc;
 
 	if ((prop = node.property (X_("ctl"))) != 0) {
 		ev = MIDI::controller;
@@ -782,8 +782,17 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 		ev = MIDI::program;
 	} else if ((prop = node.property (X_("pb"))) != 0) {
 		ev = MIDI::pitchbend;
-	} else if ((prop = node.property (X_("enc"))) != 0) {
-		encoder = true;
+	} else if ((prop = node.property (X_("enc-l"))) != 0) {
+		encoder = MIDIControllable::Enc_L;
+		ev = MIDI::controller;
+	} else if ((prop = node.property (X_("enc-r"))) != 0) {
+		encoder = MIDIControllable::Enc_R;
+		ev = MIDI::controller;
+	} else if ((prop = node.property (X_("enc-2"))) != 0) {
+		encoder = MIDIControllable::Enc_2;
+		ev = MIDI::controller;
+	} else if ((prop = node.property (X_("enc-b"))) != 0) {
+		encoder = MIDIControllable::Enc_B;
 		ev = MIDI::controller;
 	} else {
 		return 0;

--- a/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
+++ b/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
@@ -772,6 +772,7 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 	MIDI::eventType ev;
 	int intval;
 	bool momentary;
+	bool encoder = false;
 
 	if ((prop = node.property (X_("ctl"))) != 0) {
 		ev = MIDI::controller;
@@ -781,6 +782,9 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 		ev = MIDI::program;
 	} else if ((prop = node.property (X_("pb"))) != 0) {
 		ev = MIDI::pitchbend;
+	} else if ((prop = node.property (X_("enc"))) != 0) {
+		encoder = true;
+		ev = MIDI::controller;
 	} else {
 		return 0;
 	}
@@ -820,6 +824,7 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 		return 0;
 	}
 
+	mc->set_encoder (encoder);
 	mc->bind_midi (channel, ev, detail);
 
 	return mc;

--- a/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
+++ b/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
@@ -299,6 +299,7 @@ GenericMidiControlProtocol::start_learning (Controllable* c)
 	}
 
 	Glib::Threads::Mutex::Lock lm2 (controllables_lock);
+	DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("Learn binding: Controlable number: %1\n", c));
 
 	MIDIControllables::iterator tmp;
 	for (MIDIControllables::iterator i = controllables.begin(); i != controllables.end(); ) {
@@ -350,7 +351,6 @@ GenericMidiControlProtocol::start_learning (Controllable* c)
 
 		pending_controllables.push_back (element);
 	}
-
 	mc->learn_about_external_control ();
 	return true;
 }
@@ -425,6 +425,7 @@ GenericMidiControlProtocol::delete_binding (PBD::Controllable* control)
 	}
 }
 
+// This next function seems unused
 void
 GenericMidiControlProtocol::create_binding (PBD::Controllable* control, int pos, int control_number)
 {
@@ -460,6 +461,65 @@ GenericMidiControlProtocol::create_binding (PBD::Controllable* control, int pos,
 		DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("Create binding: Channel: %1 Controller: %2 Value: %3 \n", channel, MIDI::controller, value));
 		controllables.push_back (mc);
 	}
+}
+
+void
+GenericMidiControlProtocol::check_used_event (int pos, int control_number)
+{
+	Glib::Threads::Mutex::Lock lm2 (controllables_lock);
+
+	MIDI::channel_t channel = (pos & 0xf);
+	MIDI::byte value = control_number;
+
+	DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("checking for used event: Channel: %1 Controller: %2 value: %3\n", (int) channel, (pos & 0xf0), (int) value));
+
+	// Remove any old binding for this midi channel/type/value pair
+	// Note:  can't use delete_binding() here because we don't know the specific controllable we want to remove, only the midi information
+	for (MIDIControllables::iterator iter = controllables.begin(); iter != controllables.end();) {
+		MIDIControllable* existingBinding = (*iter);
+		if ( (existingBinding->get_control_type() & 0xf0 ) == (pos & 0xf0) && (existingBinding->get_control_channel() & 0xf ) == channel ) {
+			if ( ((int) existingBinding->get_control_additional() == (int) value) || ((pos & 0xf0) == MIDI::pitchbend)) {
+				DEBUG_TRACE (DEBUG::GenericMidi, "checking: found match, delete old binding.\n");
+				delete existingBinding;
+				iter = controllables.erase (iter);
+			} else {
+				++iter;
+			}
+		} else {
+			++iter;
+		}
+	}
+
+	for (MIDIFunctions::iterator iter = functions.begin(); iter != functions.end();) {
+		MIDIFunction* existingBinding = (*iter);
+		if ( (existingBinding->get_control_type() & 0xf0 ) == (pos & 0xf0) && (existingBinding->get_control_channel() & 0xf ) == channel ) {
+			if ( ((int) existingBinding->get_control_additional() == (int) value) || ((pos & 0xf0) == MIDI::pitchbend)) {
+				DEBUG_TRACE (DEBUG::GenericMidi, "checking: found match, delete old binding.\n");
+				delete existingBinding;
+				iter = functions.erase (iter);
+			} else {
+				++iter;
+			}
+		} else {
+			++iter;
+		}
+	}
+
+	for (MIDIActions::iterator iter = actions.begin(); iter != actions.end();) {
+		MIDIAction* existingBinding = (*iter);
+		if ( (existingBinding->get_control_type() & 0xf0 ) == (pos & 0xf0) && (existingBinding->get_control_channel() & 0xf ) == channel ) {
+			if ( ((int) existingBinding->get_control_additional() == (int) value) || ((pos & 0xf0) == MIDI::pitchbend)) {
+				DEBUG_TRACE (DEBUG::GenericMidi, "checking: found match, delete old binding.\n");
+				delete existingBinding;
+				iter = actions.erase (iter);
+			} else {
+				++iter;
+			}
+		} else {
+			++iter;
+		}
+	}
+
 }
 
 XMLNode&
@@ -550,7 +610,6 @@ GenericMidiControlProtocol::set_state (const XMLNode& node, int version)
 
 	{
 		Glib::Threads::Mutex::Lock lm2 (controllables_lock);
-		controllables.clear ();
 		nlist = node.children(); // "Controls"
 
 		if (!nlist.empty()) {

--- a/libs/surfaces/generic_midi/generic_midi_control_protocol.h
+++ b/libs/surfaces/generic_midi/generic_midi_control_protocol.h
@@ -71,6 +71,8 @@ class GenericMidiControlProtocol : public ARDOUR::ControlProtocol {
 
 	int load_bindings (const std::string&);
 	void drop_bindings ();
+
+	void check_used_event (int, int);
 	
 	std::string current_binding() const { return _current_binding; }
 

--- a/libs/surfaces/generic_midi/midicontrollable.cc
+++ b/libs/surfaces/generic_midi/midicontrollable.cc
@@ -394,6 +394,7 @@ MIDIControllable::midi_receiver (Parser &, MIDI::byte *msg, size_t /*len*/)
 		return;
 	}
 
+	_surface->check_used_event(msg[0], msg[1]);
 	bind_midi ((channel_t) (msg[0] & 0xf), eventType (msg[0] & 0xF0), msg[1]);
 
 	if (controllable) {

--- a/libs/surfaces/generic_midi/midicontrollable.cc
+++ b/libs/surfaces/generic_midi/midicontrollable.cc
@@ -347,14 +347,16 @@ MIDIControllable::midi_sense_program_change (Parser &, MIDI::byte msg)
 			return;
 		}
 	}
+	if (msg == control_additional) {
 
-	if (!controllable->is_toggle()) {
-		controllable->set_value (midi_to_control (msg));
-		DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("MIDI program %1 value %2  %3\n", (int) msg, (float) midi_to_control (msg), current_uri() ));
-	} else if (msg == control_additional) {
-		float new_value = controllable->get_value() > 0.5f ? 0.0f : 1.0f;
-		controllable->set_value (new_value);
-		DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("MIDI program %1 value %2  %3\n", (int) msg, (float) new_value, current_uri()));
+		if (!controllable->is_toggle()) {
+			controllable->set_value (1.0);
+			DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("MIDI program %1 value 1.0  %3\n", (int) msg, current_uri() ));
+		} else  {
+			float new_value = controllable->get_value() > 0.5f ? 0.0f : 1.0f;
+			controllable->set_value (new_value);
+			DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("MIDI program %1 value %2  %3\n", (int) msg, (float) new_value, current_uri()));
+		}
 	}
 
 	last_value = (MIDI::byte) (controllable->get_value() * 127.0); // to prevent feedback fights

--- a/libs/surfaces/generic_midi/midicontrollable.cc
+++ b/libs/surfaces/generic_midi/midicontrollable.cc
@@ -361,7 +361,6 @@ MIDIControllable::midi_sense_controller (Parser &, EventTwoBytes *msg)
 						break;
 					default:
 						break;
-					
 				}
 				DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("MIDI CC %1 value %2  %3\n", (int) msg->controller_number, (int) last_value, current_uri() ));
 

--- a/libs/surfaces/generic_midi/midicontrollable.h
+++ b/libs/surfaces/generic_midi/midicontrollable.h
@@ -75,6 +75,9 @@ class MIDIControllable : public PBD::Stateful
 
 	bool learned() const { return _learned; }
 
+	bool is_encoder() const { return _encoder; }
+	void set_encoder(bool val) { _encoder = val; }
+
         MIDI::Parser& get_parser() { return _parser; }
 	PBD::Controllable* get_controllable() const { return controllable; }
 	void set_controllable (PBD::Controllable*);
@@ -109,6 +112,7 @@ class MIDIControllable : public PBD::Stateful
 	bool            _momentary;
 	bool            _is_gain_controller;
 	bool            _learned;
+	bool		_encoder;
 	int              midi_msg_id;      /* controller ID or note number */
 	PBD::ScopedConnection midi_sense_connection[2];
 	PBD::ScopedConnection midi_learn_connection;

--- a/libs/surfaces/generic_midi/midicontrollable.h
+++ b/libs/surfaces/generic_midi/midicontrollable.h
@@ -59,6 +59,14 @@ class MIDIControllable : public PBD::Stateful
 	uint32_t rid() const { return _rid; }
 	std::string what() const { return _what; }
 
+	enum Encoder {
+		No_enc,
+		Enc_R,
+		Enc_L,
+		Enc_2,
+		Enc_B,
+	};
+
 	MIDI::byte* write_feedback (MIDI::byte* buf, int32_t& bufsize, bool force = false);
 	
 	void midi_rebind (MIDI::channel_t channel=-1);
@@ -75,10 +83,10 @@ class MIDIControllable : public PBD::Stateful
 
 	bool learned() const { return _learned; }
 
-	bool is_encoder() const { return _encoder; }
-	void set_encoder(bool val) { _encoder = val; }
+	Encoder get_encoder() const { return _encoder; }
+	void set_encoder (Encoder val) { _encoder = val; }
 
-        MIDI::Parser& get_parser() { return _parser; }
+	MIDI::Parser& get_parser() { return _parser; }
 	PBD::Controllable* get_controllable() const { return controllable; }
 	void set_controllable (PBD::Controllable*);
 	const std::string& current_uri() const { return _current_uri; }
@@ -112,7 +120,7 @@ class MIDIControllable : public PBD::Stateful
 	bool            _momentary;
 	bool            _is_gain_controller;
 	bool            _learned;
-	bool		_encoder;
+	Encoder			_encoder;
 	int              midi_msg_id;      /* controller ID or note number */
 	PBD::ScopedConnection midi_sense_connection[2];
 	PBD::ScopedConnection midi_learn_connection;

--- a/mcp/bcf2000.device
+++ b/mcp/bcf2000.device
@@ -6,6 +6,7 @@
   <TimecodeDisplay value="no"/>
   <TwoCharacterDisplay value="yes"/>
   <Extenders value="0"/>
+  <MasterPosition value="0"/>
   <GlobalControls value="yes"/>
   <JogWheel value="yes"/>
   <TouchSenseFaders value="no"/>

--- a/mcp/cmc.device
+++ b/mcp/cmc.device
@@ -2,6 +2,7 @@
   <Name value="Steinberg CMC series"/>
   <Strips value="1"/>
   <Extenders value="0"/>
+  <MasterPosition value="0"/>
   <MasterFader value="yes"/>
   <TimecodeDisplay value="no"/>
   <TwoCharacterDisplay value="no"/>

--- a/mcp/mc.device
+++ b/mcp/mc.device
@@ -6,6 +6,7 @@
   <TimecodeDisplay value="yes"/>
   <TwoCharacterDisplay value="yes"/>
   <Extenders value="0"/>
+  <MasterPosition value="0"/>
   <GlobalControls value="yes"/>
   <JogWheel value="yes"/>
   <TouchSenseFaders value="yes"/>

--- a/mcp/mcpro.device
+++ b/mcp/mcpro.device
@@ -6,6 +6,7 @@
   <TimecodeDisplay value="yes"/>
   <TwoCharacterDisplay value="yes"/>
   <Extenders value="0"/>
+  <MasterPosition value="0"/>
   <GlobalControls value="yes"/>
   <JogWheel value="yes"/>
   <TouchSenseFaders value="yes"/>

--- a/mcp/mcproxt.device
+++ b/mcp/mcproxt.device
@@ -6,6 +6,7 @@
   <TimecodeDisplay value="yes"/>
   <TwoCharacterDisplay value="yes"/>
   <Extenders value="0"/>
+  <MasterPosition value="0"/>
   <GlobalControls value="no"/>
   <JogWheel value="no"/>
   <TouchSenseFaders value="yes"/>

--- a/mcp/nucleus.device
+++ b/mcp/nucleus.device
@@ -3,6 +3,7 @@
   <Name value="SSL Nucleus"/>
   <Strips value="8"/>
   <Extenders value="1"/>
+  <MasterPosition value="0"/>
   <MasterFader value="no"/>
   <TimecodeDisplay value="no"/>
   <TwoCharacterDisplay value="yes"/>

--- a/mcp/qcon.device
+++ b/mcp/qcon.device
@@ -2,6 +2,7 @@
   <Name value="Qcon"/>
   <Strips value="8"/>
   <Extenders value="0"/>
+  <MasterPosition value="0"/>
   <MasterFader value="yes"/>
   <TimecodeDisplay value="yes"/>
   <TwoCharacterDisplay value="no"/>


### PR DESCRIPTION
 - When learning a MIDI control, make sure the new learned control only controls one thing by deleting any old bindings with the same midi event.
 - Program change events are treated as toggle or "on", rather than toggle or PC number is value.
 - Added MasterPosition=0 to all midi map files. Going from a two unit setup with master on right to a single surface setup will not reset position to zero otherwise. As with other values in this file.
 - Encoder events are added for the MIDI map files. Will handle the 4 common types known:
  * Relative signed bit
  * Relative signed bit 2 (above with switched directions - Like MCP)
  * Relative 2s complement
  * Relative bin offset
