### PR TITLE
Fixed pt import start offsets and samplerate mismatch offsets

### DIFF
--- a/gtk2_ardour/editor_pt_import.cc
+++ b/gtk2_ardour/editor_pt_import.cc
@@ -127,7 +127,7 @@ Editor::do_ptimport (std::string ptpath,
 	vector<ptflookup_t> ptfwavpair;
 	vector<ptflookup_t> ptfregpair;
 
-	if (ptf.load(ptpath) == -1) {
+	if (ptf.load(ptpath, _session->frame_rate()) == -1) {
 		MessageDialog msg (_("Doesn't seem to be a valid PT session file (.ptf only currently supported)"));
 		msg.run ();
 		return;

--- a/libs/ptformat/ptfformat.h
+++ b/libs/ptformat/ptfformat.h
@@ -28,7 +28,7 @@ public:
 	/* Return values:	0            success
 				-1           could not open file as ptf
 	*/
-	int load(std::string path);
+	int load(std::string path, int64_t targetsr);
 
 	typedef struct wav {
 		std::string filename;
@@ -110,7 +110,8 @@ public:
 		return false;
 	}
 
-	uint32_t sessionrate;
+	int64_t sessionrate;
+	int64_t targetrate;
 	uint8_t version;
 
 	unsigned char c0;
@@ -121,10 +122,12 @@ public:
 private:
 	bool foundin(std::string haystack, std::string needle);
 	void parse(void);
+	void setrates(void);
 	void parse8header(void);
 	void parse9header(void);
 	void parserest(void);
 	std::vector<wav_t> actualwavs;
+	float ratefactor;
 };
 
 


### PR DESCRIPTION
Previously, the position of regions was off because the byte width of the offset was miscalculated.
This has been fixed.  Also when the samplerates of the original PT session mismatches with the current Ardour session rate, offsets are now precalculated to the correct size before being read by Ardour.