### PR TITLE
Fix to PT5 format, (stereo tracks still not fully supported)

### DIFF
--- a/libs/ptformat/ptfformat.cc
+++ b/libs/ptformat/ptfformat.cc
@@ -512,7 +512,6 @@ PTFFormat::parserest5(void) {
 			offsetbytes = (ptfunxored[j+1] & 0xf0) >> 4;
 			//somethingbytes = (ptfunxored[j+1] & 0xf);
 			findex = ptfunxored[k+14];
-			printf("findex=%x\n", findex);
 			j--;
 			uint32_t start = 0;
 			switch (startbytes) {

--- a/libs/ptformat/ptfformat.h
+++ b/libs/ptformat/ptfformat.h
@@ -38,7 +38,7 @@ public:
 		int64_t     length;
 
 		bool operator ==(const struct wav& other) {
-			return (this->filename != std::string("") &&
+			return (this->filename == other.filename ||
 				this->index == other.index);
 		}
 


### PR DESCRIPTION
Previously, all pt5 sessions had empty audio regions, except the one I was working on.  This has been fixed.  Stereo regions now get superimposed onto the one mono track, so still needs work.
Also a trivial change to the API has been done that improves detection of pt8 and pt9 regions.