### PR TITLE
Fixes a double mutex unlock for Linux VSTs

### DIFF
--- a/gtk2_ardour/linux_vst_gui_support.cc
+++ b/gtk2_ardour/linux_vst_gui_support.cc
@@ -669,10 +669,6 @@ int vstfx_create_editor (VSTState* vstfx)
 	
 	XSendEvent(LXVST_XDisplay, parent_window, FALSE, NoEventMask, (XEvent*)&event);
 
-	/*Unlock - and we are done for the first part of staring the Editor...*/
-	
-	pthread_mutex_unlock (&vstfx->lock);
-	
 	return 0;
 }
 


### PR DESCRIPTION
Fixes a double mutex unlock / undefined behavior / crash for linux VSTs that could occur upon opening the VST GUI.  Line 470 unlocks the mutex correctly.