### PR TITLE
Peaks

### DIFF
--- a/libs/ardour/ardour/audio_playlist_source.h
+++ b/libs/ardour/ardour/audio_playlist_source.h
@@ -37,7 +37,7 @@ public:
 	virtual ~AudioPlaylistSource ();
 
 	bool empty() const;
-	std::string peak_path (std::string audio_path);
+	std::string generate_peak_path (const std::string& audio_path);
 	uint32_t   n_channels() const;
 	bool clamped_at_unity () const { return false; }
 

--- a/libs/ardour/ardour/audio_playlist_source.h
+++ b/libs/ardour/ardour/audio_playlist_source.h
@@ -37,7 +37,7 @@ public:
 	virtual ~AudioPlaylistSource ();
 
 	bool empty() const;
-	std::string generate_peak_path (const std::string& audio_path);
+	std::string construct_peak_filepath (const std::string& audio_path) const;
 	uint32_t   n_channels() const;
 	bool clamped_at_unity () const { return false; }
 

--- a/libs/ardour/ardour/audiofilesource.h
+++ b/libs/ardour/ardour/audiofilesource.h
@@ -39,13 +39,13 @@ class LIBARDOUR_API AudioFileSource : public AudioSource, public FileSource {
 public:
 	virtual ~AudioFileSource ();
 
-	std::string peak_path (std::string audio_path);
-	std::string find_broken_peakfile (std::string missing_peak_path,
-	                                  std::string audio_path);
+	std::string generate_peak_path (const std::string& audio_path);
+	std::string find_broken_peakfile (const std::string& missing_peak_path,
+	                                  const std::string& audio_path);
 
-	static void set_peak_dir (std::string dir) { peak_dir = dir; }
+	static void set_peak_dir (const std::string& dir) { peak_dir = dir; }
 
-	static bool get_soundfile_info (std::string path, SoundFileInfo& _info, std::string& error);
+	static bool get_soundfile_info (const std::string& path, SoundFileInfo& _info, std::string& error);
 
 	bool safe_file_extension (const std::string& path) const {
 		return safe_audio_file_extension(path);
@@ -119,8 +119,8 @@ protected:
 	static framecnt_t header_position_offset;
 
   private:
-	std::string old_peak_path (std::string audio_path);
-	std::string broken_peak_path (std::string audio_path);
+	std::string old_peak_path (const std::string& audio_path);
+	std::string broken_peak_path (const std::string& audio_path);
 };
 
 } // namespace ARDOUR

--- a/libs/ardour/ardour/audiofilesource.h
+++ b/libs/ardour/ardour/audiofilesource.h
@@ -39,7 +39,7 @@ class LIBARDOUR_API AudioFileSource : public AudioSource, public FileSource {
 public:
 	virtual ~AudioFileSource ();
 
-	std::string generate_peak_path (const std::string& audio_path);
+	std::string construct_peak_filepath (const std::string& audio_filepath) const;
 	std::string find_broken_peakfile (const std::string& missing_peak_path,
 	                                  const std::string& audio_path);
 

--- a/libs/ardour/ardour/audiosource.h
+++ b/libs/ardour/ardour/audiosource.h
@@ -43,7 +43,7 @@ class LIBARDOUR_API AudioSource : virtual public Source,
 		public boost::enable_shared_from_this<ARDOUR::AudioSource>
 {
   public:
-	AudioSource (Session&, std::string name);
+	AudioSource (Session&, const std::string& name);
 	AudioSource (Session&, const XMLNode&);
 	virtual ~AudioSource ();
 
@@ -115,18 +115,18 @@ class LIBARDOUR_API AudioSource : virtual public Source,
 	   thread, or a lock around calls that use them.
 	*/
 
-        static std::vector<boost::shared_array<Sample> > _mixdown_buffers;
+	static std::vector<boost::shared_array<Sample> > _mixdown_buffers;
 	static std::vector<boost::shared_array<gain_t> > _gain_buffers;
-        static Glib::Threads::Mutex    _level_buffer_lock;
+	static Glib::Threads::Mutex    _level_buffer_lock;
 
 	static void ensure_buffers_for_level (uint32_t, framecnt_t);
 	static void ensure_buffers_for_level_locked (uint32_t, framecnt_t);
 
 	framecnt_t           _length;
-	std::string         peakpath;
+	std::string         _peakpath;
 	std::string        _captured_for;
 
-	int initialize_peakfile (std::string path);
+	int initialize_peakfile (const std::string& path);
 	int build_peaks_from_scratch ();
 	int compute_and_write_peaks (Sample* buf, framecnt_t first_frame, framecnt_t cnt,
 	bool force, bool intermediate_peaks_ready_signal);
@@ -136,9 +136,9 @@ class LIBARDOUR_API AudioSource : virtual public Source,
 
 	virtual framecnt_t read_unlocked (Sample *dst, framepos_t start, framecnt_t cnt) const = 0;
 	virtual framecnt_t write_unlocked (Sample *dst, framecnt_t cnt) = 0;
-	virtual std::string peak_path(std::string audio_path) = 0;
+	virtual std::string generate_peak_path(const std::string& audio_path) = 0;
 	virtual std::string find_broken_peakfile (std::string /* missing_peak_path */,
-	                                          std::string audio_path) { return peak_path (audio_path); }
+	                                          std::string audio_path) { return generate_peak_path (audio_path); }
 
 	virtual int read_peaks_with_fpp (PeakData *peaks,
 					 framecnt_t npeaks, framepos_t start, framecnt_t cnt,

--- a/libs/ardour/ardour/audiosource.h
+++ b/libs/ardour/ardour/audiosource.h
@@ -137,8 +137,8 @@ class LIBARDOUR_API AudioSource : virtual public Source,
 	virtual framecnt_t read_unlocked (Sample *dst, framepos_t start, framecnt_t cnt) const = 0;
 	virtual framecnt_t write_unlocked (Sample *dst, framecnt_t cnt) = 0;
 	virtual std::string construct_peak_filepath(const std::string& audio_filepath) const = 0;
-	virtual std::string find_broken_peakfile (std::string /* missing_peak_path */,
-	                                          std::string audio_path) { return construct_peak_filepath (audio_path); }
+	virtual std::string find_broken_peakfile (const std::string& /* missing_peak_path */,
+	                                          const std::string& audio_path) { return construct_peak_filepath (audio_path); }
 
 	virtual int read_peaks_with_fpp (PeakData *peaks,
 					 framecnt_t npeaks, framepos_t start, framecnt_t cnt,

--- a/libs/ardour/ardour/audiosource.h
+++ b/libs/ardour/ardour/audiosource.h
@@ -136,9 +136,9 @@ class LIBARDOUR_API AudioSource : virtual public Source,
 
 	virtual framecnt_t read_unlocked (Sample *dst, framepos_t start, framecnt_t cnt) const = 0;
 	virtual framecnt_t write_unlocked (Sample *dst, framecnt_t cnt) = 0;
-	virtual std::string generate_peak_path(const std::string& audio_path) = 0;
+	virtual std::string construct_peak_filepath(const std::string& audio_filepath) const = 0;
 	virtual std::string find_broken_peakfile (std::string /* missing_peak_path */,
-	                                          std::string audio_path) { return generate_peak_path (audio_path); }
+	                                          std::string audio_path) { return construct_peak_filepath (audio_path); }
 
 	virtual int read_peaks_with_fpp (PeakData *peaks,
 					 framecnt_t npeaks, framepos_t start, framecnt_t cnt,

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -198,9 +198,8 @@ class LIBARDOUR_API Session : public PBD::StatefulDestructible, public PBD::Scop
 	std::string plugins_dir () const;     ///< Plugin state
 	std::string externals_dir () const;   ///< Links to external files
 
-	std::string peak_path (std::string) const;
+	std::string peak_path (const std::string&) const;
 
-	std::string peak_path_from_audio_path (std::string) const;
 	bool audio_source_name_is_unique (const std::string& name);
 	std::string format_audio_source_name (const std::string& legalized_base, uint32_t nchan, uint32_t chan, bool destructive, bool take_required, uint32_t cnt, bool related_exists);
 	std::string new_audio_source_path_for_embedded (const std::string& existing_path);

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -198,7 +198,7 @@ class LIBARDOUR_API Session : public PBD::StatefulDestructible, public PBD::Scop
 	std::string plugins_dir () const;     ///< Plugin state
 	std::string externals_dir () const;   ///< Links to external files
 
-	std::string peak_path (const std::string&) const;
+	std::string construct_peak_filepath (const std::string&) const;
 
 	bool audio_source_name_is_unique (const std::string& name);
 	std::string format_audio_source_name (const std::string& legalized_base, uint32_t nchan, uint32_t chan, bool destructive, bool take_required, uint32_t cnt, bool related_exists);

--- a/libs/ardour/audio_playlist_source.cc
+++ b/libs/ardour/audio_playlist_source.cc
@@ -217,7 +217,7 @@ AudioPlaylistSource::setup_peakfile ()
 }
 
 string
-AudioPlaylistSource::peak_path (string /*audio_path_IGNORED*/)
+AudioPlaylistSource::generate_peak_path (const string& /*audio_path_IGNORED*/)
 {
 	return _peak_path;
 }

--- a/libs/ardour/audio_playlist_source.cc
+++ b/libs/ardour/audio_playlist_source.cc
@@ -217,7 +217,7 @@ AudioPlaylistSource::setup_peakfile ()
 }
 
 string
-AudioPlaylistSource::generate_peak_path (const string& /*audio_path_IGNORED*/)
+AudioPlaylistSource::construct_peak_filepath (const string& /*audio_path_IGNORED*/) const
 {
 	return _peak_path;
 }

--- a/libs/ardour/audiofilesource.cc
+++ b/libs/ardour/audiofilesource.cc
@@ -164,26 +164,9 @@ AudioFileSource::init (const string& pathstr, bool must_exist)
 }
 
 string
-AudioFileSource::generate_peak_path (const string& audio_path)
+AudioFileSource::construct_peak_filepath (const string& audio_path) const
 {
-	string base;
-
-	string::size_type suffix = audio_path.find_last_of ('.');
-
-	if (suffix != string::npos) {
-		base = audio_path.substr (0, suffix);
-	} else {
-		warning << string_compose (_("Odd audio file path: %1"), audio_path) << endmsg;
-		base = audio_path;
-	}
-
-	base += '%';
-	base += (char) ('A' + _channel);
-
-	/* pass in the name/path of the source, with no audio file type suffix
-	 */
-	
-	return _session.peak_path (base);
+	return _session.construct_peak_filepath (audio_path);
 }
 
 string
@@ -230,7 +213,7 @@ AudioFileSource::find_broken_peakfile (const string& peak_path, const string& au
 string
 AudioFileSource::broken_peak_path (const string& audio_path)
 {
-	return _session.peak_path (basename_nosuffix (audio_path));
+	return _session.construct_peak_filepath (basename_nosuffix (audio_path));
 }
 
 string

--- a/libs/ardour/audiofilesource.cc
+++ b/libs/ardour/audiofilesource.cc
@@ -153,7 +153,7 @@ AudioFileSource::~AudioFileSource ()
 	DEBUG_TRACE (DEBUG::Destruction, string_compose ("AudioFileSource destructor %1, removable? %2\n", _path, removable()));
 	if (removable()) {
 		::g_unlink (_path.c_str());
-		::g_unlink (peakpath.c_str());
+		::g_unlink (_peakpath.c_str());
 	}
 }
 
@@ -164,7 +164,7 @@ AudioFileSource::init (const string& pathstr, bool must_exist)
 }
 
 string
-AudioFileSource::peak_path (string audio_path)
+AudioFileSource::generate_peak_path (const string& audio_path)
 {
 	string base;
 
@@ -187,7 +187,7 @@ AudioFileSource::peak_path (string audio_path)
 }
 
 string
-AudioFileSource::find_broken_peakfile (string peak_path, string audio_path)
+AudioFileSource::find_broken_peakfile (const string& peak_path, const string& audio_path)
 {
 	string str;
 
@@ -203,7 +203,7 @@ AudioFileSource::find_broken_peakfile (string peak_path, string audio_path)
 			   the bug means that we can't reliably use it.
 			*/
 
-			peak_path = str;
+			return str;
 
 		} else {
 			/* all native files are mono, so we can just rename
@@ -219,7 +219,7 @@ AudioFileSource::find_broken_peakfile (string peak_path, string audio_path)
 #ifndef PLATFORM_WINDOWS // there's no old_peak_path() for windows
 		str = old_peak_path (audio_path);
 		if (Glib::file_test (str, Glib::FILE_TEST_EXISTS)) {
-			peak_path = str;
+			return str;
 		}
 #endif
 	}
@@ -228,13 +228,13 @@ AudioFileSource::find_broken_peakfile (string peak_path, string audio_path)
 }
 
 string
-AudioFileSource::broken_peak_path (string audio_path)
+AudioFileSource::broken_peak_path (const string& audio_path)
 {
 	return _session.peak_path (basename_nosuffix (audio_path));
 }
 
 string
-AudioFileSource::old_peak_path (string audio_path)
+AudioFileSource::old_peak_path (const string& audio_path)
 {
 	/* XXX hardly bombproof! fix me */
 
@@ -264,7 +264,7 @@ AudioFileSource::old_peak_path (string audio_path)
 }
 
 bool
-AudioFileSource::get_soundfile_info (string path, SoundFileInfo& _info, string& error_msg)
+AudioFileSource::get_soundfile_info (const string& path, SoundFileInfo& _info, string& error_msg)
 {
         /* try sndfile first because it gets timecode info from .wav (BWF) if it exists,
            which at present, ExtAudioFile from Apple seems unable to do.
@@ -325,7 +325,7 @@ AudioFileSource::mark_streaming_write_completed (const Lock& lock)
 int
 AudioFileSource::move_dependents_to_trash()
 {
-	return ::g_unlink (peakpath.c_str());
+	return ::g_unlink (_peakpath.c_str());
 }
 
 void

--- a/libs/ardour/audiosource.cc
+++ b/libs/ardour/audiosource.cc
@@ -239,7 +239,7 @@ AudioSource::initialize_peakfile (const string& audio_path)
 {
 	GStatBuf statbuf;
 
-	_peakpath = generate_peak_path (audio_path);
+	_peakpath = construct_peak_filepath (audio_path);
 
 	DEBUG_TRACE(DEBUG::Peaks, string_compose ("Initialize Peakfile %1 for Audio file %2\n", _peakpath, audio_path));
 

--- a/libs/ardour/file_source.cc
+++ b/libs/ardour/file_source.cc
@@ -58,7 +58,7 @@ FileSource::FileSource (Session& session, DataType type, const string& path, con
 	, _path (path)
 	, _file_is_new (!origin.empty()) // if origin is left unspecified (empty string) then file must exist
 	, _channel (0)
-        , _origin (origin)
+	, _origin (origin)
 {
 	set_within_session_from_path (path);
 }
@@ -148,9 +148,9 @@ FileSource::set_state (const XMLNode& node, int /*version*/)
 		_channel = 0;
 	}
 
-        if ((prop = node.property (X_("origin"))) != 0) {
-                _origin = prop->value();
-        }
+	if ((prop = node.property (X_("origin"))) != 0) {
+		_origin = prop->value();
+	}
 
 	return 0;
 }

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -4362,7 +4362,7 @@ Session::count_sources_by_origin (const string& path)
 }
 
 string
-Session::peak_path (string base) const
+Session::peak_path (const string& base) const
 {
 	if (Glib::path_is_absolute (base)) {
 
@@ -4398,8 +4398,8 @@ Session::peak_path (string base) const
 		}
 	}
 
-	base = Glib::path_get_basename (base);
-	return Glib::build_filename (_session_dir->peak_path(), base + peakfile_suffix);
+	std::string basename = Glib::path_get_basename (base);
+	return Glib::build_filename (_session_dir->peak_path(), basename + peakfile_suffix);
 }
 
 string

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -4412,17 +4412,9 @@ Session::construct_peak_filepath (const string& filepath) const
 	
 	string::size_type suffix = filename.find_last_of ('.');
 
-	std::string filename_unsuffixed;
-	if (suffix != string::npos) {
-		filename_unsuffixed = filename.substr (0, suffix);
-	} else {
-		warning << string_compose (_("Odd audio file path: %1"), filepath) << endmsg;
-		filename_unsuffixed = filename;
-	}
+	std::string checksum = Glib::Checksum::compute_checksum(Glib::Checksum::CHECKSUM_SHA1, path + G_DIR_SEPARATOR + filename);
 
-	std::string checksum = "_" + Glib::Checksum::compute_checksum(Glib::Checksum::CHECKSUM_MD5, path + G_DIR_SEPARATOR + filename);
-
-	return Glib::build_filename (_session_dir->peak_path(), filename_unsuffixed + checksum + peakfile_suffix);
+	return Glib::build_filename (_session_dir->peak_path(), checksum + peakfile_suffix);
 }
 
 string

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -3052,7 +3052,7 @@ Session::cleanup_sources (CleanupReport& rep)
                                  or for the first channel of embedded files. it will miss
                                  some peakfiles for other channels
                               */
-		string peakpath = peak_path (base);
+		string peakpath = construct_peak_filepath (base);
 
 		if (Glib::file_test (peakpath.c_str(), Glib::FILE_TEST_EXISTS)) {
 			if (::g_unlink (peakpath.c_str()) != 0) {


### PR DESCRIPTION
This fixes cases where audiosources could end up using the wrong peakfile:
Mantis issue: 0005745
- Create a session
- Drag and drop sourcefile 1 named X from Path A	to track Y
- Drag and drop sourcefile 2 named X from Path B to track Y
- Save and reopen session
- Media item for sourcefile 2 will rendered using peakfile from sourcefile 1

Notes: 
- This renders existing peakfiles invalid. New files will be created.
- Embedded sources do not trigger recreation of peakfiles when project folder has been moved.

Thanks and let me know if there is anything wrong. 
