### PR TITLE
Fixes broken files after "bring media into session"

### DIFF
--- a/libs/ardour/audiofilesource.cc
+++ b/libs/ardour/audiofilesource.cc
@@ -143,7 +143,7 @@ AudioFileSource::AudioFileSource (Session& s, const XMLNode& node, bool must_exi
 		throw failed_constructor ();
 	}
 
-	if (init (_path, must_exist)) {
+	if (init (_origin, must_exist)) {
 		throw failed_constructor ();
 	}
 }


### PR DESCRIPTION
This one fixes broken audiosources after "bringing them into the session folder": 
- Create a session
- Add audiofile named X from path Y via drag and drop to some track
- Add audiofile named X from path Z via drag and drop to some track
- Trigger "Bring all media into session folder"
- Save and reload
-> Audiosource from path Z is broken

