### PR TITLE
Use the same default SCHED_FIFO priority as jack in ALSA backend

### DIFF
--- a/libs/backends/alsa/alsa_audiobackend.cc
+++ b/libs/backends/alsa/alsa_audiobackend.cc
@@ -826,7 +826,8 @@ AlsaAudioBackend::_start (bool for_latency_measurement)
 	_run = true;
 	_port_change_flag = false;
 
-	if (_realtime_pthread_create (SCHED_FIFO, -20, 100000,
+	// Use the same priority as the jack default(10)
+	if (_realtime_pthread_create (SCHED_FIFO, 9, 100000,
 				&_main_thread, pthread_process, this))
 	{
 		if (pthread_create (&_main_thread, NULL, pthread_process, this))

--- a/libs/backends/alsa/rt_thread.h
+++ b/libs/backends/alsa/rt_thread.h
@@ -36,7 +36,7 @@ _realtime_pthread_create (
 
 	const int p_min = sched_get_priority_min (policy);
 	const int p_max = sched_get_priority_max (policy);
-	priority += p_max;
+	priority += p_min;
 	if (priority > p_max) priority = p_max;
 	if (priority < p_min) priority = p_min;
 	parm.sched_priority = priority;


### PR DESCRIPTION
Here is a patch for bug #6585