### PR TITLE
remove bogus check from PortManager::port_name_prefix_is_unique()

### DIFF
--- a/libs/ardour/port_manager.cc
+++ b/libs/ardour/port_manager.cc
@@ -201,10 +201,6 @@ PortManager::n_physical_inputs () const
 bool
 PortManager::port_name_prefix_is_unique (const string& first_part_of_port_name) const
 {
-	if (!_backend) {
-		return boost::shared_ptr<Port>();
-	}
-
 	boost::shared_ptr<const Ports> pr = ports.reader();
 	const string::size_type len = first_part_of_port_name.length();
 	


### PR DESCRIPTION
The `_backend` member isn't even used in `PortManager::port_name_prefix_is_unique()`, and it breaks building here because gcc in Fedora 23 (with C++11 semantics FWIW) doesn't cast that into `bool`.