### PR TITLE
Gray out "strip silence" and "rhtyhm ferret" for midi regions. Fixes #6347.

### DIFF
--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -1278,6 +1278,8 @@ Editor::sensitize_the_right_region_actions ()
 		_region_actions->get_action("reset-region-gain-envelopes")->set_sensitive (false);
 		_region_actions->get_action("toggle-region-gain-envelope-active")->set_sensitive (false);
 		_region_actions->get_action("pitch-shift-region")->set_sensitive (false);
+		_region_actions->get_action("strip-region-silence")->set_sensitive (false);
+		_region_actions->get_action("show-rhythm-ferret")->set_sensitive (false);
 
 	}
 


### PR DESCRIPTION
The former even triggered a segfault.