### PR TITLE
Workaround Bug #6602, limited to dragging a midi event and pressing the delete key

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -3556,9 +3556,9 @@ Editor::commit_reversible_command ()
 			cerr << "Please call begin_reversible_command() before commit_reversible_command()." << endl;
 		} else {
 			before.pop_back();
+			_session->commit_reversible_command ();
 		}
 
-		_session->commit_reversible_command ();
 	}
 }
 

--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -2120,6 +2120,10 @@ MidiRegionView::delete_selection()
 		return;
 	}
 
+	if (trackview.editor().drags()->active()) {
+		return;
+	}
+
 	start_note_diff_command (_("delete selection"));
 
 	for (Selection::iterator i = _selection.begin(); i != _selection.end(); ++i) {


### PR DESCRIPTION
This is a workaround for #6602 till a better solution is found, and a proposed patch to make Editor::commit_reversible_command more robust.