### PR TITLE
Disable scrolling in the dropdown menus of midi region heads.

### DIFF
--- a/gtk2_ardour/ardour_dropdown.cc
+++ b/gtk2_ardour/ardour_dropdown.cc
@@ -49,6 +49,7 @@ using namespace std;
 
 
 ArdourDropdown::ArdourDropdown (Element e)
+	: _scrolling_disabled(false)
 {
 //	signal_button_press_event().connect (sigc::mem_fun(*this, &ArdourDropdown::on_mouse_pressed));
 
@@ -73,6 +74,10 @@ bool
 ArdourDropdown::on_scroll_event (GdkEventScroll* ev)
 {
 	using namespace Menu_Helpers;
+
+	if (_scrolling_disabled) {
+		return false;
+	}
 
 	const MenuItem * current_active = _menu.get_active();
 	const MenuList& items = _menu.items ();
@@ -142,4 +147,8 @@ ArdourDropdown::AddMenuElem (Menu_Helpers::Element e)
 	items.push_back (e);
 }
 
-
+void
+ArdourDropdown::disable_scrolling()
+{
+	_scrolling_disabled = true;
+}

--- a/gtk2_ardour/ardour_dropdown.h
+++ b/gtk2_ardour/ardour_dropdown.h
@@ -42,8 +42,12 @@ class ArdourDropdown : public ArdourButton
 	void clear_items ();
 	void AddMenuElem (Gtk::Menu_Helpers::Element e);
 
+	void disable_scrolling();
+
   private:
 	Gtk::Menu      _menu;
+
+	bool _scrolling_disabled;
 };
 
 #endif /* __gtk2_ardour_ardour_dropdown_h__ */

--- a/gtk2_ardour/midi_time_axis.cc
+++ b/gtk2_ardour/midi_time_axis.cc
@@ -121,6 +121,8 @@ MidiTimeAxisView::MidiTimeAxisView (PublicEditor& ed, Session* sess, ArdourCanva
 	, controller_menu (0)
 	, _step_editor (0)
 {
+	_midnam_model_selector.disable_scrolling();
+	_midnam_custom_device_mode_selector.disable_scrolling();
 }
 
 void


### PR DESCRIPTION
Instead pass it to the canvas as proposed by x42 in #6143 (first comment).