### PR TITLE
When a session or track template already exists, ask if it should be overwritten.

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -2494,16 +2494,8 @@ ARDOUR_UI::snapshot_session (bool switch_to_it)
 		vector<string> n = get_file_names_no_extension (p);
 		if (find (n.begin(), n.end(), snapname) != n.end()) {
 
-			ArdourDialog confirm (_("Confirm Snapshot Overwrite"), true);
-			Label m (_("A snapshot already exists with that name.  Do you want to overwrite it?"));
-			confirm.get_vbox()->pack_start (m, true, true);
-			confirm.add_button (Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-			confirm.add_button (_("Overwrite"), Gtk::RESPONSE_ACCEPT);
-			confirm.show_all ();
-			switch (confirm.run()) {
-			case RESPONSE_CANCEL:
-				do_save = false;
-			}
+			do_save = overwrite_file_dialog (_("Confirm Snapshot Overwrite"),
+			                                 _("A snapshot already exists with that name. Do you want to overwrite it?"));
 		}
 
 		if (do_save) {
@@ -2693,7 +2685,16 @@ ARDOUR_UI::save_template ()
 		prompter.get_result (name);
 
 		if (name.length()) {
-			_session->save_template (name);
+			int failed = _session->save_template (name);
+
+			if (failed == -2) { /* file already exists. */
+				bool overwrite = overwrite_file_dialog (_("Confirm Template Overwrite"),
+							                _("A template already exists with that name. Do you want to overwrite it?"));
+
+				if (overwrite) {
+					_session->save_template (name, true);
+				}
+			}
 		}
 		break;
 

--- a/gtk2_ardour/editor_export_audio.cc
+++ b/gtk2_ardour/editor_export_audio.cc
@@ -51,6 +51,7 @@
 #include "public_editor.h"
 #include "selection.h"
 #include "time_axis_view.h"
+#include "utils.h"
 
 #include "i18n.h"
 
@@ -141,35 +142,18 @@ Editor::export_region ()
 		string path = dialog.get_path ();
 
 		if (Glib::file_test (path, Glib::FILE_TEST_EXISTS)) {
+			bool overwrite = ARDOUR_UI_UTILS::overwrite_file_dialog (_("Confirm MIDI File Overwrite"),
+								                 _("A file with the same name already exists. Do you want to overwrite it?"));
 
-			MessageDialog checker (_("File Exists!"),
-					       true,
-					       Gtk::MESSAGE_WARNING,
-					       Gtk::BUTTONS_NONE);
-
-			checker.set_title (_("File Exists!"));
-
-			checker.add_button (Stock::CANCEL, RESPONSE_CANCEL);
-			checker.add_button (_("Overwrite Existing File"), RESPONSE_ACCEPT);
-			checker.set_default_response (RESPONSE_CANCEL);
-
-			checker.set_wmclass (X_("midi_export_file_exists"), PROGRAM_NAME);
-			checker.set_position (Gtk::WIN_POS_MOUSE);
-
-			ret = checker.run ();
-
-			switch (ret) {
-			case Gtk::RESPONSE_ACCEPT:
-				/* force ::g_unlink because the backend code will
-				   go wrong if it tries to open an existing
-				   file for writing.
-				*/
-				::g_unlink (path.c_str());
-				break;
-			default:
+			if (!overwrite) {
 				return;
 			}
 
+			/* force ::g_unlink because the backend code will
+			   go wrong if it tries to open an existing
+			   file for writing.
+			*/
+			::g_unlink (path.c_str());
 		}
 
 		(void) midi_region->clone (path);

--- a/gtk2_ardour/route_ui.cc
+++ b/gtk2_ardour/route_ui.cc
@@ -1863,13 +1863,20 @@ RouteUI::save_as_template ()
 		return;
 	}
 
-	p.hide ();
 	p.get_result (name, true);
 
 	safe_name = legalize_for_path (name);
 	safe_name += template_suffix;
 
 	path = Glib::build_filename (path, safe_name);
+	if (Glib::file_test (path, Glib::FILE_TEST_EXISTS)) {
+		bool overwrite = overwrite_file_dialog (_("Confirm Template Overwrite"),
+							_("A template already exists with that name. Do you want to overwrite it?"));
+
+		if (!overwrite) {
+			return;
+		}
+	}
 
 	_route->save_as_template (path, name);
 }

--- a/gtk2_ardour/utils.cc
+++ b/gtk2_ardour/utils.cc
@@ -53,6 +53,7 @@
 #include "rgb_macros.h"
 #include "gui_thread.h"
 #include "ui_config.h"
+#include "ardour_dialog.h"
 
 using namespace std;
 using namespace Gtk;
@@ -925,4 +926,25 @@ ARDOUR_UI_UTILS::windows_overlap (Gtk::Window *a, Gtk::Window *b)
 		}
 	}
 	return false;
+}
+
+bool
+ARDOUR_UI_UTILS::overwrite_file_dialog (string title, string text)
+{
+	ArdourDialog dialog (title, true);
+	Label label (text);
+
+	dialog.get_vbox()->pack_start (label, true, true);
+	dialog.add_button (Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	dialog.add_button (_("Overwrite"), Gtk::RESPONSE_ACCEPT);
+	dialog.set_position (Gtk::WIN_POS_MOUSE);
+	dialog.show_all ();
+
+	switch (dialog.run()) {
+	case RESPONSE_ACCEPT:
+		return true;
+	case RESPONSE_CANCEL:
+	default:
+		return false;
+	}
 }

--- a/gtk2_ardour/utils.h
+++ b/gtk2_ardour/utils.h
@@ -92,5 +92,7 @@ std::string rate_as_string (float r);
 
 bool windows_overlap (Gtk::Window *a, Gtk::Window *b);
 
+bool overwrite_file_dialog (std::string title, std::string text);
+
 } // namespace
 #endif /* __ardour_gtk_utils_h__ */

--- a/gtk2_ardour/utils_videotl.cc
+++ b/gtk2_ardour/utils_videotl.cc
@@ -28,6 +28,7 @@
 #include "ardour/session_directory.h"
 #include "video_image_frame.h"
 #include "utils_videotl.h"
+#include "utils.h"
 
 #ifdef WAF_BUILD
 #include "gtk2ardour-version.h"
@@ -67,13 +68,12 @@ VideoUtils::confirm_video_outfn (std::string outfn, std::string docroot)
 	}
 
 	if (Glib::file_test(outfn, Glib::FILE_TEST_EXISTS)) {
-		ArdourDialog confirm (_("Confirm Overwrite"), true);
-		Label m (_("A file with the same name already exists.  Do you want to overwrite it?"));
-		confirm.get_vbox()->pack_start (m, true, true);
-		confirm.add_button (Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
-		confirm.add_button (_("Overwrite"), Gtk::RESPONSE_ACCEPT);
-		confirm.show_all ();
-		if (confirm.run() == RESPONSE_CANCEL) { return false; }
+		bool overwrite = ARDOUR_UI_UTILS::overwrite_file_dialog (_("Confirm Overwrite"),
+		                                                         _("A file with the same name already exists. Do you want to overwrite it?"));
+
+		if (!overwrite) {
+			return false;
+		}
 	}
 
 	std::string dir = Glib::path_get_dirname (outfn);

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -459,7 +459,7 @@ class LIBARDOUR_API Session : public PBD::StatefulDestructible, public PBD::Scop
 	int save_as (SaveAs&);
 	int save_state (std::string snapshot_name, bool pending = false, bool switch_to_snapshot = false, bool template_only = false);
 	int restore_state (std::string snapshot_name);
-	int save_template (std::string template_name);
+	int save_template (std::string template_name, bool replace_existing = false);
 	int save_history (std::string snapshot_name = "");
 	int restore_history (std::string snapshot_name);
 	void remove_state (std::string snapshot_name);

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -2091,7 +2091,7 @@ Session::XMLSourceFactory (const XMLNode& node)
 }
 
 int
-Session::save_template (string template_name)
+Session::save_template (string template_name, bool replace_existing)
 {
 	if ((_state_of_the_state & CannotSave) || template_name.empty ()) {
 		return -1;
@@ -2117,10 +2117,10 @@ Session::save_template (string template_name)
 	}
 
 	if (!ARDOUR::Profile->get_trx()) {
-		if (Glib::file_test (template_dir_path, Glib::FILE_TEST_EXISTS)) {
+		if (!replace_existing && Glib::file_test (template_dir_path, Glib::FILE_TEST_EXISTS)) {
 			warning << string_compose(_("Template \"%1\" already exists - new version not created"),
 									  template_dir_path) << endmsg;
-			return -1;
+			return -2;
 		}
 
 		if (g_mkdir_with_parents (template_dir_path.c_str(), 0755) != 0) {


### PR DESCRIPTION
These commits fix #6587. They also introduce a dialog overwrite_file_dialog (in utils.cc) for such purposes which I then also introduce at other places in the code.