### PR TITLE
Ctrl+shift functionality (toggle all) for plugin leds.

### DIFF
--- a/gtk2_ardour/ardour_button.cc
+++ b/gtk2_ardour/ardour_button.cc
@@ -759,7 +759,7 @@ ArdourButton::on_button_release_event (GdkEventButton *ev)
 	if (ev->button == 1 && _hovering && (_elements & Indicator) && _led_rect && _distinct_led_click) {
 		if (ev->x >= _led_rect->x && ev->x < _led_rect->x + _led_rect->width &&
 		    ev->y >= _led_rect->y && ev->y < _led_rect->y + _led_rect->height) {
-			signal_led_clicked(); /* EMIT SIGNAL */
+			signal_led_clicked(ev); /* EMIT SIGNAL */
 			return true;
 		}
 	}

--- a/gtk2_ardour/ardour_button.h
+++ b/gtk2_ardour/ardour_button.h
@@ -90,7 +90,7 @@ class ArdourButton : public CairoWidget , public Gtkmm2ext::Activatable
 	void set_layout_font (const Pango::FontDescription&);
 	void set_text_ellipsize (Pango::EllipsizeMode);
 
-	sigc::signal<void> signal_led_clicked;
+	sigc::signal<void, GdkEventButton*> signal_led_clicked;
 	sigc::signal<void> signal_clicked;
 
 	boost::shared_ptr<PBD::Controllable> get_controllable() { return binding_proxy.get_controllable(); }

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -275,13 +275,39 @@ ProcessorEntry::set_enum_width (Width w)
 }
 
 void
-ProcessorEntry::led_clicked()
+ProcessorEntry::led_clicked(GdkEventButton *ev)
 {
+	bool ctrl_shift_pressed = false;
+	Keyboard::ModifierMask ctrl_shift_mask = Keyboard::ModifierMask (Keyboard::PrimaryModifier|Keyboard::TertiaryModifier);
+
+	if (Keyboard::modifier_state_equals (ev->state, ctrl_shift_mask)) {
+		ctrl_shift_pressed = true;
+	}
+
 	if (_processor) {
 		if (_button.get_active ()) {
-			_processor->deactivate ();
+			if (ctrl_shift_pressed) {
+				_parent->all_visible_processors_active(false);
+
+				if (_position == Fader) {
+					_processor->deactivate ();
+				}
+			}
+			else {
+				_processor->deactivate ();
+			}
+
 		} else {
-			_processor->activate ();
+			if (ctrl_shift_pressed) {
+				_parent->all_visible_processors_active(true);
+
+				if (_position == Fader) {
+					_processor->activate ();
+				}
+			}
+			else {
+				_processor->activate ();
+			}
 		}
 	}
 }
@@ -533,7 +559,7 @@ ProcessorEntry::Control::Control (boost::shared_ptr<AutomationControl> c, string
 		_button.show ();
 
 		_button.signal_clicked.connect (sigc::mem_fun (*this, &Control::button_clicked));
-		_button.signal_led_clicked.connect (sigc::mem_fun (*this, &Control::button_clicked));
+		_button.signal_led_clicked.connect (sigc::mem_fun (*this, &Control::button_clicked_event));
 		// dup. currently timers are used :(
 		//c->Changed.connect (_connection, MISSING_INVALIDATOR, boost::bind (&Control::control_changed, this), gui_context ());
 
@@ -642,6 +668,14 @@ ProcessorEntry::Control::button_clicked ()
 	c->set_value (n ? 0 : 1);
 	_button.set_active (!n);
 	set_tooltip ();
+}
+
+void
+ProcessorEntry::Control::button_clicked_event (GdkEventButton *ev)
+{
+	(void) ev;
+
+	button_clicked ();
 }
 
 void

--- a/gtk2_ardour/processor_box.h
+++ b/gtk2_ardour/processor_box.h
@@ -152,7 +152,7 @@ protected:
 private:
 	bool _selectable;
 	bool _unknown_processor;
-	void led_clicked();
+	void led_clicked(GdkEventButton *);
 	void processor_active_changed ();
 	void processor_property_changed (const PBD::PropertyChange&);
 	void processor_configuration_changed (const ARDOUR::ChanCount in, const ARDOUR::ChanCount out);
@@ -189,6 +189,7 @@ private:
 	private:
 		void slider_adjusted ();
 		void button_clicked ();
+		void button_clicked_event (GdkEventButton *);
 		void control_changed ();
 		std::string state_id () const;
 		void set_tooltip ();
@@ -290,6 +291,8 @@ class ProcessorBox : public Gtk::HBox, public PluginInterestedObject, public ARD
 	void select_all_inserts ();
 	void select_all_sends ();
 
+	void all_visible_processors_active(bool state);
+
 	void hide_things ();
 
 	bool edit_aux_send(boost::shared_ptr<ARDOUR::Processor>);
@@ -381,7 +384,6 @@ class ProcessorBox : public Gtk::HBox, public PluginInterestedObject, public ARD
 	void processors_reordered (const Gtk::TreeModel::Path&, const Gtk::TreeModel::iterator&, int*);
 	void compute_processor_sort_keys ();
 
-	void all_visible_processors_active(bool state);
 	void ab_plugins ();
 
 	typedef std::vector<boost::shared_ptr<ARDOUR::Processor> > ProcSelection;


### PR DESCRIPTION
The Fader led has special behavior and is only toggled when clicked
explicitly. When the Fader led is clicked with ctrl+shift then it's toggled and all the other plugin leds are set accordingly.