### PR TITLE
Reduce time to load and unload a Session

### DIFF
--- a/gtk2_ardour/audio_region_view.cc
+++ b/gtk2_ardour/audio_region_view.cc
@@ -1384,7 +1384,7 @@ AudioRegionView::add_ghost (TimeAxisView& tv)
 	assert(rtv);
 
 	double unit_position = _region->position () / samples_per_pixel;
-	AudioGhostRegion* ghost = new AudioGhostRegion (tv, trackview, unit_position);
+	AudioGhostRegion* ghost = new AudioGhostRegion (*this, tv, trackview, unit_position);
 	uint32_t nchans;
 
 	nchans = rtv->track()->n_channels().n_audio();

--- a/gtk2_ardour/ghostregion.h
+++ b/gtk2_ardour/ghostregion.h
@@ -32,11 +32,17 @@ class Note;
 class Hit;
 class MidiStreamView;
 class TimeAxisView;
+class RegionView;
 
 class GhostRegion : public sigc::trackable
 {
 public:
-	GhostRegion(ArdourCanvas::Container* parent, TimeAxisView& tv, TimeAxisView& source_tv, double initial_unit_pos);
+	GhostRegion(RegionView& rv,
+	            ArdourCanvas::Container* parent,
+	            TimeAxisView& tv,
+	            TimeAxisView& source_tv,
+	            double initial_unit_pos);
+
 	virtual ~GhostRegion();
 
 	virtual void set_samples_per_pixel (double) = 0;
@@ -48,19 +54,21 @@ public:
 	guint source_track_color(unsigned char alpha = 0xff);
 	bool is_automation_ghost();
 
+	RegionView& parent_rv;
 	/** TimeAxisView that is the AutomationTimeAxisView that we are on */
 	TimeAxisView& trackview;
 	/** TimeAxisView that we are a ghost for */
 	TimeAxisView& source_trackview;
 	ArdourCanvas::Container* group;
 	ArdourCanvas::Rectangle* base_rect;
-
-	static PBD::Signal1<void,GhostRegion*> CatchDeletion;
 };
 
 class AudioGhostRegion : public GhostRegion {
 public:
-	AudioGhostRegion(TimeAxisView& tv, TimeAxisView& source_tv, double initial_unit_pos);
+	AudioGhostRegion(RegionView& rv,
+	                 TimeAxisView& tv,
+	                 TimeAxisView& source_tv,
+	                 double initial_unit_pos);
 
 	void set_samples_per_pixel (double);
 	void set_height();
@@ -80,8 +88,16 @@ public:
 	    ArdourCanvas::Item* item;
 	};
 
-	MidiGhostRegion(TimeAxisView& tv, TimeAxisView& source_tv, double initial_unit_pos);
-	MidiGhostRegion(MidiStreamView& msv, TimeAxisView& source_tv, double initial_unit_pos);
+	MidiGhostRegion(RegionView& rv,
+	                TimeAxisView& tv,
+	                TimeAxisView& source_tv,
+	                double initial_unit_pos);
+
+	MidiGhostRegion(RegionView& rv,
+	                MidiStreamView& msv,
+	                TimeAxisView& source_tv,
+	                double initial_unit_pos);
+
 	~MidiGhostRegion();
 
 	MidiStreamView* midi_view();

--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -1532,9 +1532,9 @@ MidiRegionView::add_ghost (TimeAxisView& tv)
 		/* if ghost is inserted into midi track, use a dedicated midi ghost canvas group
 		   to allow having midi notes on top of note lines and waveforms.
 		*/
-		ghost = new MidiGhostRegion (*mtv->midi_view(), trackview, unit_position);
+		ghost = new MidiGhostRegion (*this, *mtv->midi_view(), trackview, unit_position);
 	} else {
-		ghost = new MidiGhostRegion (tv, trackview, unit_position);
+		ghost = new MidiGhostRegion (*this, tv, trackview, unit_position);
 	}
 
 	for (Events::iterator i = _events.begin(); i != _events.end(); ++i) {
@@ -1544,8 +1544,6 @@ MidiRegionView::add_ghost (TimeAxisView& tv)
 	ghost->set_height ();
 	ghost->set_duration (_region->length() / samples_per_pixel);
 	ghosts.push_back (ghost);
-
-	GhostRegion::CatchDeletion.connect (*this, invalidator (*this), boost::bind (&RegionView::remove_ghost, this, _1), gui_context());
 
 	return ghost;
 }

--- a/gtk2_ardour/region_view.cc
+++ b/gtk2_ardour/region_view.cc
@@ -84,7 +84,6 @@ RegionView::RegionView (ArdourCanvas::Container*          parent,
 	, wait_for_data(false)
 	, _silence_text (0)
 {
-	GhostRegion::CatchDeletion.connect (*this, invalidator (*this), boost::bind (&RegionView::remove_ghost, this, _1), gui_context());
 }
 
 RegionView::RegionView (const RegionView& other)
@@ -98,8 +97,6 @@ RegionView::RegionView (const RegionView& other)
 	current_visible_sync_position = other.current_visible_sync_position;
 	valid = false;
 	_pixel_width = other._pixel_width;
-
-	GhostRegion::CatchDeletion.connect (*this, invalidator (*this), boost::bind (&RegionView::remove_ghost, this, _1), gui_context());
 }
 
 RegionView::RegionView (const RegionView& other, boost::shared_ptr<Region> other_region)
@@ -117,8 +114,6 @@ RegionView::RegionView (const RegionView& other, boost::shared_ptr<Region> other
 	current_visible_sync_position = other.current_visible_sync_position;
 	valid = false;
 	_pixel_width = other._pixel_width;
-
-	GhostRegion::CatchDeletion.connect (*this, invalidator (*this), boost::bind (&RegionView::remove_ghost, this, _1), gui_context());
 }
 
 RegionView::RegionView (ArdourCanvas::Container*          parent,

--- a/gtk2_ardour/time_axis_view.cc
+++ b/gtk2_ardour/time_axis_view.cc
@@ -221,8 +221,6 @@ TimeAxisView::TimeAxisView (ARDOUR::Session* sess, PublicEditor& ed, TimeAxisVie
 	top_hbox.pack_start (scroomer_placeholder, false, false); // OR pack_end to move after meters ?
 
 	UIConfiguration::instance().ColorsChanged.connect (sigc::mem_fun (*this, &TimeAxisView::color_handler));
-
-	GhostRegion::CatchDeletion.connect (*this, invalidator (*this), boost::bind (&TimeAxisView::erase_ghost, this, _1), gui_context());
 }
 
 TimeAxisView::~TimeAxisView()

--- a/libs/ardour/ardour/midi_patch_manager.h
+++ b/libs/ardour/ardour/midi_patch_manager.h
@@ -142,6 +142,8 @@ private:
 	void refresh();
 	void add_session_patches();
 
+	bool add_midi_name_document(const std::string& file_path);
+
 	MidiNameDocuments                       _documents;
 	MIDINameDocument::MasterDeviceNamesList _master_devices_by_model;
 	DeviceNamesByMaker                      _devices_by_manufacturer;

--- a/libs/ardour/ardour/midi_patch_manager.h
+++ b/libs/ardour/ardour/midi_patch_manager.h
@@ -22,12 +22,11 @@
 #define MIDI_PATCH_MANAGER_H_
 
 #include "midi++/midnam_patch.h"
-#include "pbd/signals.h"
-#include "ardour/session_handle.h"
 
-namespace ARDOUR {
-	class Session;
-}
+#include "pbd/signals.h"
+#include "pbd/search_path.h"
+
+#include "ardour/libardour_visibility.h"
 
 namespace MIDI
 {
@@ -35,7 +34,7 @@ namespace MIDI
 namespace Name
 {
 
-class LIBARDOUR_API MidiPatchManager : public PBD::ScopedConnectionList, public ARDOUR::SessionHandlePtr
+class LIBARDOUR_API MidiPatchManager
 {
 	/// Singleton
 private:
@@ -58,7 +57,9 @@ public:
 		return *_manager;
 	}
 
-	void set_session (ARDOUR::Session*);
+	void add_search_path (const PBD::Searchpath& search_path);
+
+	void remove_search_path (const PBD::Searchpath& search_path);
 
 	boost::shared_ptr<MIDINameDocument> document_by_model(std::string model_name)
 		{ return _documents[model_name]; }
@@ -138,11 +139,12 @@ public:
 	const DeviceNamesByMaker& devices_by_manufacturer() const { return _devices_by_manufacturer; }
 
 private:
-	void session_going_away();
 	void refresh();
-	void add_session_patches();
 
 	bool add_midi_name_document(const std::string& file_path);
+
+private:
+	PBD::Searchpath                         _search_path;
 
 	MidiNameDocuments                       _documents;
 	MIDINameDocument::MasterDeviceNamesList _master_devices_by_model;

--- a/libs/ardour/ardour/midi_patch_manager.h
+++ b/libs/ardour/ardour/midi_patch_manager.h
@@ -139,9 +139,11 @@ public:
 	const DeviceNamesByMaker& devices_by_manufacturer() const { return _devices_by_manufacturer; }
 
 private:
-	void refresh();
-
 	bool add_midi_name_document(const std::string& file_path);
+	bool remove_midi_name_document(const std::string& file_path);
+
+	void add_midnam_files_from_directory(const std::string& directory_path);
+	void remove_midnam_files_from_directory(const std::string& directory_path);
 
 private:
 	PBD::Searchpath                         _search_path;

--- a/libs/ardour/midi_patch_manager.cc
+++ b/libs/ardour/midi_patch_manager.cc
@@ -50,7 +50,6 @@ MidiPatchManager::set_session (Session* s)
 {
 	SessionHandlePtr::set_session (s);
 	refresh ();
-	add_session_patches ();
 }
 
 bool

--- a/libs/ardour/midi_patch_manager.cc
+++ b/libs/ardour/midi_patch_manager.cc
@@ -74,8 +74,9 @@ MidiPatchManager::add_midnam_files_from_directory(const std::string& directory_p
 	vector<std::string> result;
 	find_files_matching_pattern (result, directory_path, "*.midnam");
 
-	info << "Loading " << result.size() << " MIDI patches from " << directory_path
-	     << endmsg;
+	info << string_compose(_("Loading %1 MIDI patches from %2"),
+	                       result.size(),
+	                       directory_path) << endmsg;
 
 	for (vector<std::string>::const_iterator i = result.begin(); i != result.end(); ++i) {
 		add_midi_name_document (*i);
@@ -103,8 +104,9 @@ MidiPatchManager::remove_midnam_files_from_directory(const std::string& director
 	vector<std::string> result;
 	find_files_matching_pattern (result, directory_path, "*.midnam");
 
-	info << "Unloading " << result.size() << " MIDI patches from "
-	     << directory_path << endmsg;
+	info << string_compose(_("Unloading %1 MIDI patches from %2"),
+	                       result.size(),
+	                       directory_path) << endmsg;
 
 	for (vector<std::string>::const_iterator i = result.begin(); i != result.end(); ++i) {
 		remove_midi_name_document (*i);
@@ -119,7 +121,8 @@ MidiPatchManager::add_midi_name_document (const std::string& file_path)
 		document = boost::shared_ptr<MIDINameDocument>(new MIDINameDocument(file_path));
 	}
 	catch (...) {
-		error << "Error parsing MIDI patch file " << file_path << endmsg;
+		error << string_compose(_("Error parsing MIDI patch file %1"), file_path)
+		      << endmsg;
 		return false;
 	}
 	for (MIDINameDocument::MasterDeviceNamesList::const_iterator device =
@@ -161,6 +164,8 @@ MidiPatchManager::remove_midi_name_document (const std::string& file_path)
 		if (i->second->file_path() == file_path) {
 
 			boost::shared_ptr<MIDINameDocument> document = i->second;
+
+			info << string_compose(_("Removing MIDI patch file %1"), file_path) << endmsg;
 
 			_documents.erase(i++);
 

--- a/libs/ardour/midi_patch_manager.cc
+++ b/libs/ardour/midi_patch_manager.cc
@@ -43,7 +43,6 @@ MidiPatchManager* MidiPatchManager::_manager = 0;
 
 MidiPatchManager::MidiPatchManager ()
 {
-	refresh ();
 }
 
 void

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -74,6 +74,7 @@
 #include "ardour/graph.h"
 #include "ardour/midiport_manager.h"
 #include "ardour/scene_changer.h"
+#include "ardour/midi_patch_manager.h"
 #include "ardour/midi_track.h"
 #include "ardour/midi_ui.h"
 #include "ardour/operations.h"
@@ -554,6 +555,8 @@ Session::destroy ()
 	*/
 
 	ControlProtocolManager::instance().drop_protocols ();
+
+	MIDI::Name::MidiPatchManager::instance().remove_search_path(session_directory().midi_patch_path());
 
 	_engine.remove_session ();
 

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -343,7 +343,7 @@ Session::post_engine_init ()
 	send_immediate_mmc (MIDI::MachineControlCommand (MIDI::MachineControl::cmdMmcReset));
 	send_immediate_mmc (MIDI::MachineControlCommand (Timecode::Time ()));
 
-	MIDI::Name::MidiPatchManager::instance().set_session (this);
+	MIDI::Name::MidiPatchManager::instance().add_search_path (session_directory().midi_patch_path() );
 
 	ltc_tx_initialize();
 	/* initial program change will be delivered later; see ::config_changed() */

--- a/libs/midi++2/midi++/midnam_patch.h
+++ b/libs/midi++2/midi++/midnam_patch.h
@@ -465,8 +465,10 @@ public:
 	typedef std::map<std::string, boost::shared_ptr<MasterDeviceNames> > MasterDeviceNamesList;
 
 	MIDINameDocument() {}
-	MIDINameDocument(const std::string& filename);
+	MIDINameDocument(const std::string& file_path);
 	virtual ~MIDINameDocument() {};
+
+	const std::string& file_path () const { return _file_path; }
 
 	const std::string& author() const { return _author; }
 	void set_author(const std::string& author) { _author = author; }
@@ -481,6 +483,7 @@ public:
 	int      set_state (const XMLTree&, const XMLNode&);
 
 private:
+	const std::string             _file_path;
 	std::string                   _author;
 	MasterDeviceNamesList         _master_device_names_list;
 	MasterDeviceNames::Models     _all_models;

--- a/libs/midi++2/midnam_patch.cc
+++ b/libs/midi++2/midnam_patch.cc
@@ -877,14 +877,15 @@ MasterDeviceNames::get_state(void)
 	return nothing;
 }
 
-MIDINameDocument::MIDINameDocument (const string& filename)
+MIDINameDocument::MIDINameDocument (const string& file_path)
+	: _file_path(file_path)
 {
 	XMLTree document;
-	if (!document.read (filename)) {
+	if (!document.read (file_path)) {
 		throw failed_constructor ();
 	}
 
-	document.set_filename (filename);
+	document.set_filename (file_path);
 	set_state (document, *document.root());
 }
 

--- a/libs/pbd/pbd/search_path.h
+++ b/libs/pbd/pbd/search_path.h
@@ -134,6 +134,10 @@ public:
 	 */
 	LIBPBD_TEMPLATE_MEMBER_API void remove_directories (const std::vector<std::string>& paths);
 
+	/**
+	 * @return true if Searchpath already contains path
+	 */
+	LIBPBD_TEMPLATE_MEMBER_API bool contains (const std::string& path) const;
 };
 
 LIBPBD_API void export_search_path (const std::string& base_dir, const char* varname, const char* dir);

--- a/libs/pbd/pbd/search_path.h
+++ b/libs/pbd/pbd/search_path.h
@@ -114,12 +114,26 @@ public:
 	 */
 	LIBPBD_TEMPLATE_MEMBER_API Searchpath& add_subdirectory_to_paths (const std::string& subdir);
 
-protected:
-
+	/**
+	 * Add directory_path to this Searchpath.
+	 */
 	LIBPBD_TEMPLATE_MEMBER_API void add_directory (const std::string& directory_path);
+
+	/**
+	 * Add directories in paths to this Searchpath.
+	 */
 	LIBPBD_TEMPLATE_MEMBER_API void add_directories (const std::vector<std::string>& paths);
+
+	/**
+	 * Remove directory_path from this Searchpath.
+	 */
 	LIBPBD_TEMPLATE_MEMBER_API void remove_directory (const std::string& directory_path);
+
+	/**
+	 * Remove all the directories in paths from this Searchpath.
+	 */
 	LIBPBD_TEMPLATE_MEMBER_API void remove_directories (const std::vector<std::string>& paths);
+
 };
 
 LIBPBD_API void export_search_path (const std::string& base_dir, const char* varname, const char* dir);

--- a/libs/pbd/search_path.cc
+++ b/libs/pbd/search_path.cc
@@ -163,6 +163,17 @@ Searchpath::add_subdirectory_to_paths (const string& subdir)
 	return *this;
 }
 
+bool
+Searchpath::contains (const string& path) const
+{
+	std::vector<std::string>::const_iterator i = find(begin(), end(), path);
+
+	if (i == end()) {
+		return false;
+	}
+	return true;
+}
+
 /* This is not part of the Searchpath object, but is closely related to the
  * whole idea, and we put it here for convenience.
  */


### PR DESCRIPTION
A series of patches focused on reducing the time to load and unload a session, more details in the commit log.

This is the second pull request for this branch, there was a problem with the changes in the last patch of the previous PR related to removing the static GhostRegion::CatchDeletion signal but it should now be correct. 