### PR TITLE
Fix fencepost error in duplication of regions.

### DIFF
--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -4774,7 +4774,7 @@ Editor::duplicate_some_regions (RegionSelection& regions, float times)
 
 	framepos_t const start_frame = regions.start ();
 	framepos_t const end_frame = regions.end_frame ();
-	framecnt_t const gap = end_frame - start_frame;
+	framecnt_t const gap = end_frame - start_frame + 1;
 
 	begin_reversible_command (Operations::duplicate_region);
 
@@ -4789,7 +4789,7 @@ Editor::duplicate_some_regions (RegionSelection& regions, float times)
 		latest_regionviews.clear ();
 		sigc::connection c = rtv->view()->RegionViewAdded.connect (sigc::mem_fun(*this, &Editor::collect_new_region_view));
 
-		framepos_t const position = end_frame + (r->first_frame() - start_frame);
+		framepos_t const position = end_frame + (r->first_frame() - start_frame + 1);
  		playlist = (*i)->region()->playlist();
 		playlist->clear_changes ();
 		playlist->duplicate (r, position, gap, times);
@@ -4840,7 +4840,7 @@ Editor::duplicate_selection (float times)
 		} else {
 			end = selection->time.end_frame();
 		}
-		playlist->duplicate (*ri, end, times);
+		playlist->duplicate (*ri, end + 1, times);
 
 		if (!in_command) {
 			begin_reversible_command (_("duplicate selection"));

--- a/libs/ardour/playlist.cc
+++ b/libs/ardour/playlist.cc
@@ -1256,13 +1256,12 @@ Playlist::flush_notifications (bool from_undo)
 
 	 RegionWriteLock rl (this);
 	 int itimes = (int) floor (times);
-	 framepos_t pos = position + 1;
 
 	 while (itimes--) {
 		 boost::shared_ptr<Region> copy = RegionFactory::create (region, true);
-		 add_region_internal (copy, pos);
+		 add_region_internal (copy, position);
 		 set_layer (copy, DBL_MAX);
-		 pos += gap;
+		 position += gap;
 	 }
 
 	 if (floor (times) != times) {
@@ -1278,7 +1277,7 @@ Playlist::flush_notifications (bool from_undo)
 			 plist.add (Properties::name, name);
 
 			 boost::shared_ptr<Region> sub = RegionFactory::create (region, plist);
-			 add_region_internal (sub, pos);
+			 add_region_internal (sub, position);
 			 set_layer (sub, DBL_MAX);
 		 }
 	 }

--- a/libs/ardour/test/profiling/lots_of_regions.cc
+++ b/libs/ardour/test/profiling/lots_of_regions.cc
@@ -35,7 +35,7 @@ main (int argc, char* argv[])
 	/* Duplicate it a lot */
 	session->begin_reversible_command ("foo");
 	playlist->clear_changes ();
-	playlist->duplicate (region, region->last_frame(), 1000);
+	playlist->duplicate (region, region->last_frame() + 1, 1000);
 	session->add_command (new StatefulDiffCommand (playlist));
 	session->commit_reversible_command ();
 
@@ -45,7 +45,7 @@ main (int argc, char* argv[])
 	/* And do it again */
 	session->begin_reversible_command ("foo");
 	playlist->clear_changes ();
-	playlist->duplicate (region, region->last_frame(), 1000);
+	playlist->duplicate (region, region->last_frame() + 1, 1000);
 	session->add_command (new StatefulDiffCommand (playlist));
 	session->commit_reversible_command ();
 }


### PR DESCRIPTION
Also duplicate gets as position parameter the first position the duplicated region should contain. Not the one before that.