### PR TITLE
Overwrite file dialog improvements

### DIFF
--- a/gtk2_ardour/ardour_ui.h
+++ b/gtk2_ardour/ardour_ui.h
@@ -114,6 +114,7 @@ class ButtonJoiner;
 class ConnectionEditor;
 class MainClock;
 class Mixer_UI;
+class ArdourPrompter;
 class PublicEditor;
 class SaveAsDialog;
 class SessionDialog;
@@ -555,6 +556,7 @@ class ARDOUR_UI : public Gtkmm2ext::UI, public ARDOUR::SessionHandlePtr
 
 	void open_session ();
 	void open_recent_session ();
+	bool process_save_template_prompter (ArdourPrompter& prompter);
 	void save_template ();
 
 	void edit_metadata ();
@@ -598,6 +600,7 @@ class ARDOUR_UI : public Gtkmm2ext::UI, public ARDOUR::SessionHandlePtr
 
 	guint32  last_key_press_time;
 
+	bool process_snapshot_session_prompter (ArdourPrompter& prompter, bool switch_to_it);
 	void snapshot_session (bool switch_to_it);
 
 	SaveAsDialog* save_as_dialog;

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -67,20 +67,20 @@ namespace Gtkmm2ext {
 }
 
 namespace ARDOUR {
-	class RouteGroup;
-	class Playlist;
 	class AudioPlaylist;
 	class AudioRegion;
-	class Region;
-	class Location;
-	class TempoSection;
-	class Session;
-	class Filter;
-	class ChanCount;
-	class MidiOperator;
-	class Track;
-	class MidiTrack;
 	class AudioTrack;
+	class ChanCount;
+	class Filter;
+	class Location;
+	class MidiOperator;
+	class MidiTrack;
+	class Playlist;
+	class Region;
+	class RouteGroup;
+	class Session;
+	class TempoSection;
+	class Track;
 }
 
 namespace LADSPA {

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -74,6 +74,7 @@ namespace ARDOUR {
 	class Filter;
 	class Location;
 	class MidiOperator;
+	class MidiRegion;
 	class MidiTrack;
 	class Playlist;
 	class Region;
@@ -113,6 +114,7 @@ class GroupedButtons;
 class GUIObjectState;
 class ArdourMarker;
 class MidiRegionView;
+class MidiExportDialog;
 class MixerStrip;
 class MouseCursors;
 class NoteBase;
@@ -281,6 +283,8 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 	void export_selection ();
 	void export_range ();
 	void export_region ();
+
+	bool process_midi_export_dialog (MidiExportDialog& dialog, boost::shared_ptr<ARDOUR::MidiRegion> midi_region);
 
 	void add_transport_frame (Gtk::Container&);
 	void add_toplevel_menu (Gtk::Container&);

--- a/gtk2_ardour/export_video_dialog.cc
+++ b/gtk2_ardour/export_video_dialog.cc
@@ -619,7 +619,7 @@ ExportVideoDialog::launch_export ()
 	_session->add_extra_xml (get_state());
 
 	std::string outfn = outfn_path_entry.get_text();
-	if (!confirm_video_outfn(outfn)) { return; }
+	if (!confirm_video_outfn(*this, outfn)) { return; }
 
 	vbox->hide();
 	cancel_button->hide();

--- a/gtk2_ardour/midi_export_dialog.cc
+++ b/gtk2_ardour/midi_export_dialog.cc
@@ -37,8 +37,8 @@ MidiExportDialog::MidiExportDialog (PublicEditor&, boost::shared_ptr<MidiRegion>
 {
 	set_border_width (12);
 
-	add_button (Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT);
 	add_button (Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	add_button (Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT);
 
 	get_vbox()->set_border_width (12);
 	get_vbox()->pack_start (file_chooser);

--- a/gtk2_ardour/route_ui.h
+++ b/gtk2_ardour/route_ui.h
@@ -219,6 +219,7 @@ class RouteUI : public virtual AxisView
 	virtual void map_frozen ();
 
 	void adjust_latency ();
+	bool process_save_template_prompter (ArdourPrompter& prompter, const std::string& dir);
 	void save_as_template ();
 	void open_remote_control_id_dialog ();
 

--- a/gtk2_ardour/transcode_video_dialog.cc
+++ b/gtk2_ardour/transcode_video_dialog.cc
@@ -404,7 +404,7 @@ TranscodeVideoDialog::launch_transcode ()
 		return;
 	}
 	std::string outfn = path_entry.get_text();
-	if (!confirm_video_outfn(outfn, video_get_docroot(Config))) return;
+	if (!confirm_video_outfn(*this, outfn, video_get_docroot(Config))) return;
 	progress_label.set_text (_("Transcoding Video.."));
 	dialog_progress_mode();
 #if 1 /* tentative debug mode */

--- a/gtk2_ardour/utils.cc
+++ b/gtk2_ardour/utils.cc
@@ -929,9 +929,9 @@ ARDOUR_UI_UTILS::windows_overlap (Gtk::Window *a, Gtk::Window *b)
 }
 
 bool
-ARDOUR_UI_UTILS::overwrite_file_dialog (string title, string text)
+ARDOUR_UI_UTILS::overwrite_file_dialog (Gtk::Window& parent, string title, string text)
 {
-	ArdourDialog dialog (title, true);
+	ArdourDialog dialog (parent, title, true);
 	Label label (text);
 
 	dialog.get_vbox()->pack_start (label, true, true);

--- a/gtk2_ardour/utils.cc
+++ b/gtk2_ardour/utils.cc
@@ -937,7 +937,6 @@ ARDOUR_UI_UTILS::overwrite_file_dialog (Gtk::Window& parent, string title, strin
 	dialog.get_vbox()->pack_start (label, true, true);
 	dialog.add_button (Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
 	dialog.add_button (_("Overwrite"), Gtk::RESPONSE_ACCEPT);
-	dialog.set_position (Gtk::WIN_POS_MOUSE);
 	dialog.show_all ();
 
 	switch (dialog.run()) {

--- a/gtk2_ardour/utils.h
+++ b/gtk2_ardour/utils.h
@@ -92,7 +92,7 @@ std::string rate_as_string (float r);
 
 bool windows_overlap (Gtk::Window *a, Gtk::Window *b);
 
-bool overwrite_file_dialog (std::string title, std::string text);
+bool overwrite_file_dialog (Gtk::Window& parent, std::string title, std::string text);
 
 } // namespace
 #endif /* __ardour_gtk_utils_h__ */

--- a/gtk2_ardour/utils_videotl.cc
+++ b/gtk2_ardour/utils_videotl.cc
@@ -46,7 +46,7 @@ using namespace ARDOUR;
 using namespace VideoUtils;
 
 bool
-VideoUtils::confirm_video_outfn (std::string outfn, std::string docroot)
+VideoUtils::confirm_video_outfn (Gtk::Window& parent, std::string outfn, std::string docroot)
 {
 	/* replace docroot's '/' to G_DIR_SEPARATOR for the comparison */
 	size_t look_here = 0;
@@ -68,7 +68,8 @@ VideoUtils::confirm_video_outfn (std::string outfn, std::string docroot)
 	}
 
 	if (Glib::file_test(outfn, Glib::FILE_TEST_EXISTS)) {
-		bool overwrite = ARDOUR_UI_UTILS::overwrite_file_dialog (_("Confirm Overwrite"),
+		bool overwrite = ARDOUR_UI_UTILS::overwrite_file_dialog (parent,
+		                                                         _("Confirm Overwrite"),
 		                                                         _("A file with the same name already exists. Do you want to overwrite it?"));
 
 		if (!overwrite) {

--- a/gtk2_ardour/utils_videotl.h
+++ b/gtk2_ardour/utils_videotl.h
@@ -34,7 +34,7 @@
 
 namespace VideoUtils {
 
-bool confirm_video_outfn (std::string, std::string docroot="");
+bool confirm_video_outfn (Gtk::Window& parent, std::string, std::string docroot="");
 std::string video_dest_dir (const std::string, const std::string);
 std::string video_dest_file (const std::string, const std::string);
 std::string strip_file_extension (const std::string infile);


### PR DESCRIPTION
- Make the overwrite file dialog transient.
- Don't close the initial dialog when the overwrite dialog is cancelled.
- Put prompter/dialog processing into own functions to improve readability.
- Reorder the save and cancel buttons in the export midi region dialog.

Many of the committed lines are just moving code around and then adapting it to being in an own function.

If the one large commit is too large/unhandy to review tell me and I'll try (again) to split it. I already tried but didn't find a nicer way.