### PR TITLE
Let Entry of FaderOption react on ENTER and allow only numerical input.

### DIFF
--- a/gtk2_ardour/option_editor.h
+++ b/gtk2_ardour/option_editor.h
@@ -582,6 +582,8 @@ public:
 
 private:
 	void db_changed ();
+	void on_activate ();
+	bool on_key_press (GdkEventKey* ev);
 
 	Gtk::Adjustment _db_adjustment;
 	Gtkmm2ext::HSliderController* _db_slider;


### PR DESCRIPTION
This enables setting click gain and solo gain in the preferences using
the text field. -- fixes #6668