### PR TITLE
Use a range of values for ASIO buffer sizes if provided by driver

### DIFF
--- a/libs/backends/portaudio/portaudio_io.h
+++ b/libs/backends/portaudio/portaudio_io.h
@@ -63,7 +63,9 @@ public:
 	                                 long& preferred_size_frames,
 	                                 long& granularity);
 
-	bool get_asio_buffer_sizes (int device_id, std::vector<uint32_t>& buffer_size);
+	bool get_asio_buffer_sizes(int device_id,
+	                           std::vector<uint32_t>& buffer_size,
+	                           bool preferred_only);
 #endif
 
 	std::string control_app_name (int device_id) const;


### PR DESCRIPTION
This has been tested on four devices:

- A RME HDSP Multiface
- A Yamaha AG06
- A Focusrite 2i2
- A built-in soundcard running ASIO4ALL

The HDSP and the AG06 only return one buffer size when queried so the preferred
size is used as before.

The Focusrite returns a min corresponding to the position of the slider in the
control dialog and the max is 1024. The granularity is 1 so this means that the
number of values needs to be reduced for the current UI design with a combo
box so the granularity is increased until there are around 8-9 buffer sizes to
choose from evenly spaced between min and max(but we could easily change this
if the UI changes etc).

The ASIO4ALL driver returns a min of 64 and a max of 2048 and a granularity of
8. So where the minimum buffer size and granularity is a power of 2 use only
buffer sizes that are power of 2.

If the driver returns different values for min and max it is not currently
possible to indicate which is the driver preferred value. A checkbox or other
UI element could be added to the AudioSetup dialog to only use the preferred
value but that is more work and perhaps not necessary.