### PR TITLE
Add support for portaudio callback API but keep blocking as default

### DIFF
--- a/libs/backends/portaudio/portaudio_io.h
+++ b/libs/backends/portaudio/portaudio_io.h
@@ -70,9 +70,17 @@ public:
 	void launch_control_app (int device_id);
 
 	PaErrorCode open_blocking_stream(int device_input,
-	                               int device_output,
-	                               double sample_rate,
-	                               uint32_t samples_per_period);
+	                                 int device_output,
+	                                 double sample_rate,
+	                                 uint32_t samples_per_period);
+
+	PaErrorCode open_callback_stream(int device_input,
+	                                 int device_output,
+	                                 double sample_rate,
+	                                 uint32_t samples_per_period,
+	                                 PaStreamCallback* callback,
+	                                 void* data);
+
 	PaErrorCode start_stream(void);
 
 	PaErrorCode close_stream(void);

--- a/libs/backends/portaudio/wscript
+++ b/libs/backends/portaudio/wscript
@@ -36,5 +36,6 @@ def build(bld):
     obj.install_path  = os.path.join(bld.env['LIBDIR'], 'backends')
     obj.defines = ['PACKAGE="' + I18N_PACKAGE + '"',
                    'ARDOURBACKEND_DLL_EXPORTS',
-                   'USE_MMCSS_THREAD_PRIORITIES'
+                   'USE_MMCSS_THREAD_PRIORITIES',
+                   'USE_BLOCKING_API'
                   ]


### PR DESCRIPTION
Enabling the callback API is a compile time option but keep blocking API as the default until further and wider testing.

I can push this when it is an appropriate time for this change.