### PR TITLE
Add support to signal the transport state by OSC

### DIFF
--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -336,7 +336,10 @@ OSC::register_callbacks()
 		REGISTER_CALLBACK (serv, "/ardour/transport_stop", "", transport_stop);
 		REGISTER_CALLBACK (serv, "/ardour/transport_play", "", transport_play);
 		REGISTER_CALLBACK (serv, "/ardour/transport_frame", "", transport_frame);
+		REGISTER_CALLBACK (serv, "/ardour/transport_speed", "", transport_speed);
+		REGISTER_CALLBACK (serv, "/ardour/record_enabled", "", record_enabled);
 		REGISTER_CALLBACK (serv, "/ardour/set_transport_speed", "f", set_transport_speed);
+
 		REGISTER_CALLBACK (serv, "/ardour/locate", "ii", locate);
 		REGISTER_CALLBACK (serv, "/ardour/save_state", "", save_state);
 		REGISTER_CALLBACK (serv, "/ardour/prev_marker", "", prev_marker);
@@ -787,6 +790,33 @@ OSC::transport_frame (lo_message msg)
 
 	lo_message_free (reply);
 }
+
+void
+OSC::transport_speed(lo_message msg)
+{
+	double ts = session->transport_speed ();
+
+	lo_message reply = lo_message_new ();
+	lo_message_add_double (reply, ts);
+
+	lo_send_message (lo_message_get_source (msg), "/ardour/transport_speed", reply);
+
+	lo_message_free (reply);
+}
+
+void
+OSC::record_enabled(lo_message msg)
+{
+	int re = (int)session->get_record_enabled ();
+
+	lo_message reply = lo_message_new ();
+	lo_message_add_int32 (reply, re);
+
+	lo_send_message (lo_message_get_source (msg), "/ardour/record_enabled", reply);
+
+	lo_message_free (reply);
+}
+
 
 int
 OSC::route_mute (int rid, int yn)

--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -339,7 +339,6 @@ OSC::register_callbacks()
 		REGISTER_CALLBACK (serv, "/ardour/transport_speed", "", transport_speed);
 		REGISTER_CALLBACK (serv, "/ardour/record_enabled", "", record_enabled);
 		REGISTER_CALLBACK (serv, "/ardour/set_transport_speed", "f", set_transport_speed);
-
 		REGISTER_CALLBACK (serv, "/ardour/locate", "ii", locate);
 		REGISTER_CALLBACK (serv, "/ardour/save_state", "", save_state);
 		REGISTER_CALLBACK (serv, "/ardour/prev_marker", "", prev_marker);
@@ -792,7 +791,7 @@ OSC::transport_frame (lo_message msg)
 }
 
 void
-OSC::transport_speed(lo_message msg)
+OSC::transport_speed (lo_message msg)
 {
 	double ts = session->transport_speed ();
 
@@ -805,7 +804,7 @@ OSC::transport_speed(lo_message msg)
 }
 
 void
-OSC::record_enabled(lo_message msg)
+OSC::record_enabled (lo_message msg)
 {
 	int re = (int)session->get_record_enabled ();
 

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -122,6 +122,8 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 
 	void routes_list (lo_message msg);
 	void transport_frame(lo_message msg);
+	void transport_speed(lo_message msg);
+	void record_enabled(lo_message msg);
 
 #define PATH_CALLBACK_MSG(name)					\
         static int _ ## name (const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) { \
@@ -134,6 +136,8 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 
 	PATH_CALLBACK_MSG(routes_list);
 	PATH_CALLBACK_MSG(transport_frame);
+	PATH_CALLBACK_MSG(transport_speed);
+	PATH_CALLBACK_MSG(record_enabled);
 
 #define PATH_CALLBACK(name) \
         static int _ ## name (const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) { \

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -121,9 +121,9 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 	static int _catchall (const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data);
 
 	void routes_list (lo_message msg);
-	void transport_frame(lo_message msg);
-	void transport_speed(lo_message msg);
-	void record_enabled(lo_message msg);
+	void transport_frame (lo_message msg);
+	void transport_speed (lo_message msg);
+	void record_enabled (lo_message msg);
 
 #define PATH_CALLBACK_MSG(name)					\
         static int _ ## name (const char *path, const char *types, lo_arg **argv, int argc, void *data, void *user_data) { \


### PR DESCRIPTION
Implement transport_speed in the same style like transport_frame. Up to
now transport_speed and record_enabled are implemented.

punch_in, punch_out and transport_locked are missing. Actually I don't know how to test transport_locked. I'd have to investigate what it exactly is first.

Please take a look to see whether you'd pull this. If yes would you want me to implement the missing queries first?