### PR TITLE
Added support to set gain automation by OSC.

### DIFF
--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -362,6 +362,8 @@ OSC::register_callbacks()
 		REGISTER_CALLBACK (serv, "/ardour/routes/send/gainabs", "iif", route_set_send_gain_abs);
 		REGISTER_CALLBACK (serv, "/ardour/routes/send/gaindB", "iif", route_set_send_gain_dB);
 
+		REGISTER_CALLBACK (serv, "/ardour/routes/gain_automation", "is", route_set_gain_automation);
+
 		/* still not-really-standardized query interface */
 		//REGISTER_CALLBACK (serv, "/ardour/*/#current_value", "", current_value);
 		//REGISTER_CALLBACK (serv, "/ardour/set", "", set);
@@ -722,6 +724,7 @@ OSC::current_value (const char */*path*/, const char */*types*/, lo_arg **/*argv
 	return 0;
 }
 
+
 void
 OSC::routes_list (lo_message msg)
 {
@@ -854,6 +857,36 @@ OSC::route_set_gain_dB (int rid, float dB)
 
 
 int
+OSC::route_set_gain_automation(int rid, char& state)
+{
+	if (!session) return -1;
+
+	boost::shared_ptr<Route> r = session->route_by_remote_id (rid);
+
+	if (r) {
+		switch(state) {
+		case 'p':
+			r->gain_control()->set_automation_state(Play);
+			break;
+		case 'm':
+			r->gain_control()->set_automation_state(Off);
+			break;
+		case 'w':
+			r->gain_control()->set_automation_state(Write);
+			break;
+		case 't':
+			r->gain_control()->set_automation_state(Touch);
+			break;
+		default:
+			break;
+		}
+	}
+
+	return 0;
+}
+
+
+int
 OSC::route_set_trim_abs (int rid, float level)
 {
 	if (!session) return -1;
@@ -866,6 +899,9 @@ OSC::route_set_trim_abs (int rid, float level)
 
 	return 0;
 }
+
+
+
 
 int
 OSC::route_set_trim_dB (int rid, float dB)

--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -857,25 +857,25 @@ OSC::route_set_gain_dB (int rid, float dB)
 
 
 int
-OSC::route_set_gain_automation(int rid, char& state)
+OSC::route_set_gain_automation (int rid, char& state)
 {
 	if (!session) return -1;
 
 	boost::shared_ptr<Route> r = session->route_by_remote_id (rid);
 
 	if (r) {
-		switch(state) {
+		switch (state) {
 		case 'p':
-			r->gain_control()->set_automation_state(Play);
+			r->gain_control()->set_automation_state (Play);
 			break;
 		case 'm':
-			r->gain_control()->set_automation_state(Off);
+			r->gain_control()->set_automation_state (Off);
 			break;
 		case 'w':
-			r->gain_control()->set_automation_state(Write);
+			r->gain_control()->set_automation_state (Write);
 			break;
 		case 't':
-			r->gain_control()->set_automation_state(Touch);
+			r->gain_control()->set_automation_state (Touch);
 			break;
 		default:
 			break;
@@ -899,9 +899,6 @@ OSC::route_set_trim_abs (int rid, float level)
 
 	return 0;
 }
-
-
-
 
 int
 OSC::route_set_trim_dB (int rid, float dB)

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -220,6 +220,7 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 	PATH_CALLBACK2(route_set_trim_dB,i,f);
 	PATH_CALLBACK2(route_set_pan_stereo_position,i,f);
 	PATH_CALLBACK2(route_set_pan_stereo_width,i,f);
+	PATH_CALLBACK2(route_set_gain_automation,i,s);
         PATH_CALLBACK3(route_set_send_gain_abs,i,i,f);
         PATH_CALLBACK3(route_set_send_gain_dB,i,i,f);
         PATH_CALLBACK4(route_plugin_parameter,i,i,i,f);
@@ -234,6 +235,7 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 	int route_set_trim_dB (int rid, float dB);
 	int route_set_pan_stereo_position (int rid, float left_right_fraction);
 	int route_set_pan_stereo_width (int rid, float percent);
+	int route_set_gain_automation(int rid, char& state);
 	int route_set_send_gain_abs (int rid, int sid, float val);
 	int route_set_send_gain_dB (int rid, int sid, float val);
 	int route_plugin_parameter (int rid, int piid,int par, float val);

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -235,7 +235,7 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 	int route_set_trim_dB (int rid, float dB);
 	int route_set_pan_stereo_position (int rid, float left_right_fraction);
 	int route_set_pan_stereo_width (int rid, float percent);
-	int route_set_gain_automation(int rid, char& state);
+	int route_set_gain_automation (int rid, char& state);
 	int route_set_send_gain_abs (int rid, int sid, float val);
 	int route_set_send_gain_dB (int rid, int sid, float val);
 	int route_plugin_parameter (int rid, int piid,int par, float val);


### PR DESCRIPTION
Added support for OSC message

"/ardour/routes/gain_automation" rid state

where rid is the remote route id and state is a character representing
the desired gain automation state:

'm': Manual (Off)
'p': Play
'w': Write
't': Touch