### PR TITLE
make copies of global lists before extending

### DIFF
--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -420,7 +420,8 @@ def build(bld):
 
         # now the shared library containing the GTK GUI for ardour
         obj = bld (features = 'cxx c cxxshlib')
-        obj.source    = gtk2_ardour_sources
+        # operate on copy to avoid adding sources twice
+        obj.source    = list(gtk2_ardour_sources)
         obj.includes  = [ '../libs/fst', '.' ]
         obj.name      = 'libgtk2_ardour'
         obj.target    = 'gtk2_ardour'
@@ -431,7 +432,8 @@ def build(bld):
             obj = bld (features = 'cxx c cxxprogram winres')
         else:
             obj = bld (features = 'cxx c cxxprogram')
-        obj.source    = gtk2_ardour_sources
+        # operate on copy to avoid adding sources twice
+        obj.source    = list(gtk2_ardour_sources)
         obj.target = 'ardour-' + str (bld.env['VERSION'])
         obj.includes = ['.']
         obj.ldflags = ['-no-undefined']

--- a/libs/ardour/wscript
+++ b/libs/ardour/wscript
@@ -335,7 +335,8 @@ def build(bld):
     # micro increment <=> no interface changes
     LIBARDOUR_LIB_VERSION = "3.0.0"
 
-    sources = libardour_sources
+    # operate on copy to avoid adding sources twice
+    sources = list(libardour_sources)
     if bld.is_tracks_build():
         sources += [ 'engine_state_controller.cc' ]
     

--- a/libs/gtkmm2ext/wscript
+++ b/libs/gtkmm2ext/wscript
@@ -84,7 +84,8 @@ def configure(conf):
 
 
 def build(bld):
-    sources = gtkmm2ext_sources
+    # operate on copy to avoid adding sources twice
+    sources = list(gtkmm2ext_sources)
     if bld.is_tracks_build():
         sources += [ 'waves_fastmeter.cc', 'fader.cc' ]
     else:


### PR DESCRIPTION
Not doing so can make source or object files appear multiple times in
the list of files to be compiled or linked, e.g. when doing './waf build
install', subsequently leading to linker errors.