### PR TITLE
No longer shorten note by one tick

### DIFF
--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -1702,9 +1702,9 @@ MidiRegionView::update_sustained (Note* ev, bool update_ghost_regions)
 
 	if (note->length() > 0) {
 		const framepos_t note_end_frames = min (source_beats_to_region_frames (note->end_time()), _region->length());
-		ev->set_x1 (trackview.editor().sample_to_pixel (note_end_frames));
+		ev->set_x1 (std::max(1., trackview.editor().sample_to_pixel (note_end_frames)) - 1);
 	} else {
-		ev->set_x1 (trackview.editor().sample_to_pixel (_region->length()));
+		ev->set_x1 (std::max(1., trackview.editor().sample_to_pixel (_region->length())) - 1);
 	}
 
 	ev->set_y1 (y0 + std::max(1., floor(midi_stream_view()->note_height()) - 1));

--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -554,12 +554,6 @@ MidiRegionView::button_release (GdkEventButton* ev)
 					group->canvas_to_item (event_x, event_y);
 
 					Evoral::Beats beats = get_grid_beats(editor.pixel_to_sample(event_x));
-
-					/* Shorten the length by 1 tick so that we can add a new note at the next
-					   grid snap without it overlapping this one.
-					*/
-					beats -= Evoral::Beats::tick();
-
 					create_note_at (editor.pixel_to_sample (event_x), event_y, beats, true);
 				} else {
 					clear_selection ();
@@ -570,14 +564,7 @@ MidiRegionView::button_release (GdkEventButton* ev)
 		case MouseDraw:
 			{
 				Evoral::Beats beats = get_grid_beats(editor.pixel_to_sample(event_x));
-
-				/* Shorten the length by 1 tick so that we can add a new note at the next
-				   grid snap without it overlapping this one.
-				*/
-				beats -= Evoral::Beats::tick();
-
 				create_note_at (editor.pixel_to_sample (event_x), event_y, beats, true);
-
 				break;
 			}
 		default:

--- a/gtk2_ardour/note.h
+++ b/gtk2_ardour/note.h
@@ -51,8 +51,8 @@ public:
 	void set_x1 (ArdourCanvas::Coord);
 	void set_y1 (ArdourCanvas::Coord);
 
-        void set_outline_what (ArdourCanvas::Rectangle::What);
-        void set_outline_all ();
+	void set_outline_what (ArdourCanvas::Rectangle::What);
+	void set_outline_all ();
 
 	void set_outline_color (uint32_t);
 	void set_fill_color (uint32_t);

--- a/gtk2_ardour/note_base.cc
+++ b/gtk2_ardour/note_base.cc
@@ -238,14 +238,14 @@ NoteBase::set_mouse_fractions (GdkEvent* ev)
 	_mouse_y_fraction = yf;
 
 	if (notify) {
-                if (big_enough_to_trim()) {
-                        _region.note_mouse_position (_mouse_x_fraction, _mouse_y_fraction, set_cursor);
-                } else {
-                        /* pretend the mouse is in the middle, because this is not big enough
-                           to trim right now.
-                        */
-                        _region.note_mouse_position (0.5, 0.5, set_cursor);
-                }
+		if (big_enough_to_trim()) {
+			_region.note_mouse_position (_mouse_x_fraction, _mouse_y_fraction, set_cursor);
+		} else {
+			/* pretend the mouse is in the middle, because this is not big enough
+			   to trim right now.
+			*/
+			_region.note_mouse_position (0.5, 0.5, set_cursor);
+		}
 	}
 }
 

--- a/gtk2_ardour/note_base.h
+++ b/gtk2_ardour/note_base.h
@@ -59,7 +59,7 @@ class NoteBase : public sigc::trackable
 	virtual ~NoteBase ();
 
 	void set_item (ArdourCanvas::Item *);
-        ArdourCanvas::Item* item() const { return _item; }
+	ArdourCanvas::Item* item() const { return _item; }
 
 	virtual void show() = 0;
 	virtual void hide() = 0;
@@ -94,8 +94,8 @@ class NoteBase : public sigc::trackable
 	virtual ArdourCanvas::Coord x1 () const = 0;
 	virtual ArdourCanvas::Coord y1 () const = 0;
 
-        float mouse_x_fraction() const { return _mouse_x_fraction; }
-        float mouse_y_fraction() const { return _mouse_y_fraction; }
+	float mouse_x_fraction() const { return _mouse_x_fraction; }
+	float mouse_y_fraction() const { return _mouse_y_fraction; }
 
 	const boost::shared_ptr<NoteType> note() const { return _note; }
 	MidiRegionView& region_view() const { return _region; }
@@ -128,8 +128,8 @@ class NoteBase : public sigc::trackable
 	/// hue circle divided into 16 equal-looking parts, courtesy Thorsten Wilms
 	static const uint32_t midi_channel_colors[16];
 
-        bool mouse_near_ends () const;
-        virtual bool big_enough_to_trim () const;
+	bool mouse_near_ends () const;
+	virtual bool big_enough_to_trim () const;
 
 protected:
 	enum State { None, Pressed, Dragging };
@@ -143,10 +143,10 @@ protected:
 	bool                              _own_note;
 	bool                              _selected;
 	bool                              _valid;
-        float                             _mouse_x_fraction;
-        float                             _mouse_y_fraction;
+	float                             _mouse_x_fraction;
+	float                             _mouse_y_fraction;
 
-        void set_mouse_fractions (GdkEvent*);
+	void set_mouse_fractions (GdkEvent*);
 
 private:
 	bool event_handler (GdkEvent *);

--- a/libs/ardour/enums.cc
+++ b/libs/ardour/enums.cc
@@ -308,12 +308,12 @@ setup_enum_writer ()
 	REGISTER (_LayerModel);
 
 	REGISTER_ENUM (InsertMergeReject);
-        REGISTER_ENUM (InsertMergeRelax);
-        REGISTER_ENUM (InsertMergeReplace);
-        REGISTER_ENUM (InsertMergeTruncateExisting);
-        REGISTER_ENUM (InsertMergeTruncateAddition);
-        REGISTER_ENUM (InsertMergeExtend);
-        REGISTER (_InsertMergePolicy);
+	REGISTER_ENUM (InsertMergeRelax);
+	REGISTER_ENUM (InsertMergeReplace);
+	REGISTER_ENUM (InsertMergeTruncateExisting);
+	REGISTER_ENUM (InsertMergeTruncateAddition);
+	REGISTER_ENUM (InsertMergeExtend);
+	REGISTER (_InsertMergePolicy);
 
 	REGISTER_ENUM (AfterFaderListen);
 	REGISTER_ENUM (PreFaderListen);

--- a/libs/ardour/midi_model.cc
+++ b/libs/ardour/midi_model.cc
@@ -1665,9 +1665,9 @@ MidiModel::resolve_overlaps_unlocked (const NotePtr note, void* arg)
 
 		if ((sb > sa) && (eb <= ea)) {
 			overlap = OverlapInternal;
-		} else if ((eb >= sa) && (eb <= ea)) {
+		} else if ((eb > sa) && (eb <= ea)) {
 			overlap = OverlapStart;
-		} else if ((sb > sa) && (sb <= ea)) {
+		} else if ((sb > sa) && (sb < ea)) {
 			overlap = OverlapEnd;
 		} else if ((sa >= sb) && (sa <= eb) && (ea <= eb)) {
 			overlap = OverlapExternal;


### PR DESCRIPTION
# Overview

This PR contains
1. removes shorting by one tick notes inserted in the midi region
2. minor indentation fix in the NodeBase class

# Motivation

I don't think shortening the notes in the sequencer is right, for the following reasons
1. It is inconsistent with other behaviors such as resizing a note, and naming a note length in the midi list editor. See the image attached, 
![ardour](https://cloud.githubusercontent.com/assets/819225/11457519/d11535a8-96b3-11e5-8696-72590bd1b6a4.png)
the first 3 notes and the last ones have been inserted before the fix. The 2 in the middle have been inserted after the fix, and have their lengths correctly named.
2. Even though the note off and note on can have same timestamps, I believe Ardour can still strive to send them is the right order (I didn't check what it's doing though). Then assuming they are sent in the right order, it's up to the client (the synth) to implement the correct behavior.
3. If that really remains an issue then I suggest to add an option to silently shorten notes off preceding the same notes on. In any case,  we do want to add eventually on-the-fly control over note lengths, this can be useful to shorten or lengthen notes (convenient for some portamento effect for instance). But I don't think it should be represented explicitly in the note off bbt. What if for instance the note is moved and no longer overlaps with the same following note on? So this should be more considered as sanity post-processing.
