### PR TITLE
Hide MIDI ghost note when over existing note.

### DIFF
--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -3324,6 +3324,8 @@ MidiRegionView::note_entered(NoteBase* ev)
 	} else if (editor->current_mouse_mode() == MouseDraw) {
 		show_verbose_cursor (ev->note ());
 	}
+
+	remove_ghost_note ();
 }
 
 void
@@ -3334,6 +3336,8 @@ MidiRegionView::note_left (NoteBase*)
 	}
 
 	hide_verbose_cursor ();
+
+	create_ghost_note (_last_ghost_x, _last_ghost_y);
 }
 
 void


### PR DESCRIPTION
Currently a ghost note is always drawn -- independent from if the mouse cursor is over a note or not. This commit changes this behavior such that a ghost note is _not_ drawn, when the cursor is over a note. Then only the note information of the not under the cursor is displayed.

This PR fixes 6625.