### PR TITLE
Add "-" to cpp arguments

### DIFF
--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -662,7 +662,7 @@ def build(bld):
     # Menus
     menus_argv = []
     if bld.is_defined('GTKOSX'):
-        menus_argv = [ '-E', '-P', '-DGTKOSX' ]
+        menus_argv = [ '-E', '-P', '-DGTKOSX', '-' ]
     else:
         menus_argv = [ '-E', '-P' ]
 


### PR DESCRIPTION
Compliing on OS X with homebrew shows the following error:

```
[729/860] subst: gtk2_ardour/default_ui_config.in -> build/gtk2_ardour/default_ui_config
[730/860] command_output: gtk2_ardour/ardour.menus.in -> build/gtk2_ardour/ardour.menus
clang: error: no input files
In file included from ../gtk2_ardour/au_pluginui.mm:21:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAAudioUnit.h:61:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAComponent.h:53:
/private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAComponentDescription.h:114:30: warning: 'CountComponents' is deprecated: first deprecated in OS X 10.8 [-Wdeprecated-declarations]
        int             Count() const { return CountComponents(const_cast<CAComponentDescription*>(this)); }
                                               ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Components.h:487:1: note: 'CountComponents' has been explicitly marked deprecated here
CountComponents(ComponentDescription * looking)               __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_0, __MAC_10_8, __IPHONE_NA, __IPHONE_NA);
^
In file included from ../gtk2_ardour/au_pluginui.mm:21:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAAudioUnit.h:61:
/private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAComponent.h:96:10: warning: 'OpenAComponent' is deprecated: first deprecated in OS X 10.8 [-Wdeprecated-declarations]
                return OpenAComponent (Comp(), &outInst);
                       ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Components.h:559:1: note: 'OpenAComponent' has been explicitly marked deprecated here
OpenAComponent(
^
In file included from ../gtk2_ardour/au_pluginui.mm:21:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAAudioUnit.h:62:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAAudioChannelLayout.h:62:
/private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAReferenceCounted.h:61:18: warning: 'IncrementAtomic' is deprecated: first deprecated in OS X 10.8 [-Wdeprecated-declarations]
        void    retain() { IncrementAtomic(&mRefCount); }
                           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/DriverSynchronization.h:638:1: note: 'IncrementAtomic' has been explicitly marked deprecated here
IncrementAtomic(SInt32 * address)                             __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_0, __MAC_10_8, __IPHONE_NA, __IPHONE_NA);
^
In file included from ../gtk2_ardour/au_pluginui.mm:21:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAAudioUnit.h:62:
In file included from /private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAAudioChannelLayout.h:62:
/private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/libs/appleutility/CAReferenceCounted.h:66:17: warning: 'DecrementAtomic' is deprecated: first deprecated in OS X 10.8 [-Wdeprecated-declarations]
                                SInt32 rc = DecrementAtomic(&mRefCount);
                                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/DriverSynchronization.h:671:1: note: 'DecrementAtomic' has been explicitly marked deprecated here
DecrementAtomic(SInt32 * address)                             __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_0, __MAC_10_8, __IPHONE_NA, __IPHONE_NA);
^
../gtk2_ardour/au_pluginui.mm:264:3: warning: 'CloseComponent' is deprecated: first deprecated in OS X 10.8 [-Wdeprecated-declarations]
                CloseComponent (editView);
                ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/System/Library/Frameworks/CoreServices.framework/Frameworks/CarbonCore.framework/Headers/Components.h:593:1: note: 'CloseComponent' has been explicitly marked deprecated here
CloseComponent(ComponentInstance aComponentInstance)          __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_0, __MAC_10_8, __IPHONE_NA, __IPHONE_NA);
^
../gtk2_ardour/au_pluginui.mm:51:1: warning: function 'dump_view_tree' is not needed and will not be emitted [-Wunneeded-internal-declaration]
dump_view_tree (NSView* view, int depth, int maxdepth)
^
6 warnings generated.
Waf: Leaving directory `/private/tmp/ardour20151211-5887-1hnvkb0/ardour-4.4/build'
Build failed
 -> task in '' failed (exit status 1): 
	{task 4513041744: command_output ardour.menus.in -> ardour.menus}
''
```
Homebrews superenv cpp on OS X will not work without "-":

```
$ echo Foo|cpp
clang: error: no input files
$ echo Foo|cpp - 
# 1 "<stdin>"
# 1 "<built-in>" 1
# 1 "<built-in>" 3
# 324 "<built-in>" 3
# 1 "<command line>" 1
# 1 "<built-in>" 2
# 1 "<stdin>" 2
Foo
```
