### PR TITLE
Use libc++ instead of libstdc++ on Mac

### DIFF
--- a/wscript
+++ b/wscript
@@ -389,19 +389,26 @@ int main() { return 0; }''',
         #
         compiler_flags.append ('-U__STRICT_ANSI__')
 
+    if opt.use_libcpp:
+       cxx_flags.append('--stdlib=libc++')
+       linker_flags.append('--stdlib=libc++')
+
     if conf.options.cxx11 or conf.env['build_host'] in [ 'mavericks', 'yosemite', 'el_capitan' ]:
         conf.check_cxx(cxxflags=["-std=c++11"])
         cxx_flags.append('-std=c++11')
         if platform == "darwin":
-            cxx_flags.append('--stdlib=libstdc++')
             # Mavericks and later changed the syntax to be used when including Carbon headers,
             # from requiring a full path to requiring just the header name.
             cxx_flags.append('-DCARBON_FLAT_HEADERS')
-            linker_flags.append('--stdlib=libstdc++')
+
+            if not opt.use_libcpp:
+                cxx_flags.append('--stdlib=libstdc++')
+                linker_flags.append('--stdlib=libstdc++')
             # Prevents visibility issues in standard headers
             conf.define("_DARWIN_C_SOURCE", 1)
         else:
             cxx_flags.append('-DBOOST_NO_AUTO_PTR')
+
 
     if (is_clang and platform == "darwin") or conf.env['build_host'] in ['mavericks', 'yosemite', 'el_capitan']:
         # Silence warnings about the non-existing osx clang compiler flags
@@ -728,6 +735,8 @@ def options(opt):
                     help='Do not ask questions that require confirmation during the build')
     opt.add_option('--cxx11', action='store_true', default=False, dest='cxx11',
                     help='Turn on c++11 compiler flags (-std=c++11)')
+    opt.add_option('--use-libc++', action='store_true', default=False, dest='use_libcpp',
+                    help='use libc++ instead of default or auto-detected stdlib')
     opt.add_option('--address-sanitizer', action='store_true', default=False, dest='asan',
                     help='Turn on AddressSanitizer (requires GCC >= 4.8 or clang >= 3.1)')
     opt.add_option('--ptformat', action='store_true', default=False, dest='ptformat',


### PR DESCRIPTION
Compiling against libsigc++-2.6.2 fails because the header `type_traits` can not be found.  
```
[ 62/860] cxx: libs/pbd/convert.cc -> build/libs/pbd/convert.cc.2.o
In file included from ../libs/pbd/basename.cc:21:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/miscutils.h:25:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/arrayhandle.h:23:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/containerhandle_shared.h:23:
/usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/refptr.h:368:34: error: no type named 'move' in namespace 'std'
  RefPtr<T_CppObject> temp (std::move(src));
                            ~~~~~^
/usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/refptr.h:368:28: warning: parentheses were disambiguated as a function declaration [-Wvexing-parse]
  RefPtr<T_CppObject> temp (std::move(src));
                           ^~~~~~~~~~~~~~~~
/usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/refptr.h:368:29: note: add a pair of parentheses to declare a variable
  RefPtr<T_CppObject> temp (std::move(src));
                            ^
                            (
In file included from ../libs/pbd/basename.cc:21:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/miscutils.h:25:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/arrayhandle.h:23:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/containerhandle_shared.h:26:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/wrap.h:23:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/objectbase.h:23:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/signalproxy.h:12:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/sigc++.h:86:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/signal.h:8:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/signal_base.h:27:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/functors/slot.h:6:
/usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/visit_each.h:22:10: fatal error: 'type_traits' file not found
#include <type_traits>
         ^
In file included from ../libs/pbd/boost_debug.cc:32:
In file included from /usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4/glibmm/threads.h:29:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/sigc++.h:86:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/signal.h:8:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/signal_base.h:27:
In file included from /usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/functors/slot.h:6:
/usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0/sigc++/visit_each.h:22:10: fatal error: 'type_traits' file not found
#include <type_traits>
         ^
1 warning and 2 errors generated.
1 error generated.
Waf: Leaving directory `/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/build'
Build failed
 -> task in 'libpbd' failed (exit status 1): 
        {task 4494103696: cxx basename.cc -> basename.cc.2.o}
['clang++', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4', '-DWAF_BUILD', '-O0', '-g', '-fshow-column', '-DARCH_X86', '-DBUILD_VECLIB_OPTIMIZATIONS', '-DMAC_OS_X_VERSION_MAX_ALLOWED=1090', '-mmacosx-version-min=10.8', '-Wall', '-Wpointer-arith', '-Wcast-qual', '-Wcast-align', '-Wno-unused-parameter', '-DBOOST_SYSTEM_NO_DEPRECATED', '-D_ISOC9X_SOURCE', '-D_LARGEFILE64_SOURCE', '-D_FILE_OFFSET_BITS=64', '-DENABLE_NLS', '-DPROGRAM_NAME="Ardour"', u'-DPROGRAM_VERSION="4"', '-std=c++11', '--stdlib=libstdc++', '-DCARBON_FLAT_HEADERS', '-Qunused-arguments', '-Woverloaded-virtual', '-Wno-mismatched-tags', '-D__STDC_LIMIT_MACROS', '-D__STDC_FORMAT_MACROS', '-DCANVAS_COMPATIBILITY', '-DCANVAS_DEBUG', '-fPIC', '-compatibility_version', '1', '-current_version', '1', '-fPIC', '-compatibility_version', '1', '-current_version', '1', '-msse', '-msse2', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/build/libs/pbd', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/libs/pbd', '-I/usr/local/Cellar/glib/2.46.2/include/glib-2.0', '-I/usr/local/Cellar/glib/2.46.2/lib/glib-2.0/include', '-I/usr/local/opt/gettext/include', '-I/usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0', '-I/usr/local/Cellar/libsigc++/2.6.2/lib/sigc++-2.0/include', '-I/usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4', '-I/usr/local/Cellar/glibmm/2.46.2/lib/glibmm-2.4/include', '-I/usr/include/libxml2', '-I/usr/local/Cellar/libsndfile/1.0.25/include', '-I/usr/local/Cellar/glibmm/2.46.2/include/giomm-2.4', '-I/usr/local/Cellar/glibmm/2.46.2/lib/giomm-2.4/include', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/build', '-DNEED_INTL=1', '-DHAVE_COREAUDIO=1', '-DAUDIOUNIT_SUPPORT=1', '-DGTKOSX=1', '-DTOP_MENUBAR=1', '-DINTERNAL_SHARED_LIBS=1', '-DHAVE_DLOPEN=1', '-DHAVE_GLIB=1', '-DHAVE_GTHREAD=1', '-DHAVE_GLIBMM=1', '-DHAVE_SNDFILE=1', '-DHAVE_GIOMM=1', '-DHAVE_CURL=1', '-DHAVE_LO=1', '-DHAVE_TAGLIB=1', '-DHAVE_VAMPSDK=1', '-DHAVE_VAMPHOSTSDK=1', '-DHAVE_RUBBERBAND=1', '-DEXPORT_VISIBILITY_HIDDEN=False', '-DPHONE_HOME=1', '-DENABLE_NLS=1', '-D_DARWIN_C_SOURCE=1', '-DCONFIG_ARCH="x86_64"', '-DHAVE_LIBS_APPLEUTILITY=1', '-DHAVE_LIBS_CLEARLOOKS_NEWER=1', '-DHAVE_LIBS_QM_DSP=1', '-DHAVE_FFTW3F=1', '-DHAVE_AUBIO=1', '-DHAVE_AUBIO4=1', '-DHAVE_LIBS_VAMP_PLUGINS=1', '-DHAVE_LIBS_LIBLTC=1', '-DHAVE_LIBS_PTFORMAT=1', '-DHAVE_XML=1', '-DHAVE_SIGCPP=1', '-DHAVE_EXECINFO=1', '-DHAVE_POSIX_MEMALIGN=1', '-DHAVE_LOCALTIME_R=1', '-DHAVE_LIBS_PBD=1', '-DHAVE_LIBS_MIDIPP2=1', '-DHAVE_LIBS_EVORAL=1', '-DHAVE_CONTROL_PROTOCOL=1', '-DHAVE_GENERIC_MIDI=1', '-DHAVE_MACKIE=1', '-DHAVE_LIBS_SURFACES=1', '-DHAVE_2IN2OUT=1', '-DHAVE_1IN2OUT=1', '-DHAVE_VBAP=1', '-DHAVE_STEREOBALANCE=1', '-DHAVE_LIBS_PANNERS=1', '-DHAVE_JACK=1', '-DHAVE_JACK_METADATA=1', '-DHAVE_LIBS_BACKENDS=1', '-DHAVE_LIBS_TIMECODE=1', '-DHAVE_LRDF=1', '-DHAVE_SAMPLERATE=1', '-DHAVE_LV2=1', '-DHAVE_LV2_1_2_0=1', '-DHAVE_LV2_1_10_0=1', '-DHAVE_SERD=1', '-DHAVE_SORD=1', '-DHAVE_SRATOM=1', '-DHAVE_LILV=1', '-DHAVE_LILV_0_16_0=1', '-DHAVE_LILV_0_19_2=1', '-DHAVE_SUIL=1', '-DLV2_SUPPORT=1', '-DHAVE_OGG=1', '-DHAVE_FLAC=1', '-DUSE_RUBBERBAND=1', '-DCURRENT_SESSION_FILE_VERSION=3001', '-DHAVE_SYS_STATVFS_H=1', '-DHAVE_UNISTD=1', '-DHAVE_BOOST_SCOPED_PTR_HPP=1', '-DHAVE_BOOST_PTR_CONTAINER_PTR_LIST_HPP=1', '-DHAVE_LIBS_ARDOUR=1', '-DHAVE_GTKMM=1', '-DHAVE_GTK=1', '-DHAVE_LIBS_GTKMM2EXT=1', '-DHAVE_BOOST_FORMAT_HPP=1', '-DHAVE_LIBS_AUDIOGRAPHER=1', '-DHAVE_CAIROMM=1', '-DHAVE_LIBS_CANVAS=1', '-DHAVE_LV2_1_0_0=1', '-DHAVE_LIBS_PLUGINS_REASONABLESYNTH_LV2=1', '-DHAVE_FONTCONFIG=1', '-DHAVE_BOOST_SHARED_PTR_HPP=1', '-DHAVE_BOOST_WEAK_PTR_HPP=1', '-DHAVE_GTK2_ARDOUR=1', '-DHAVE_EXPORT=1', '-DHAVE_MIDI_MAPS=1', '-DHAVE_MCP=1', '-DHAVE_PATCHFILES=1', '-DHAVE_HEADLESS=1', '-DHAVE_LIBS_FST=1', '-DHAVE_LIBS_VFORK=1', '-DHAVE_LIBS_ARDOURALSAUTIL=1', '-DHAVE_CFGTOOL=1', '-DLIBPBD_DLL_EXPORTS=1', '-DPACKAGE="libpbd4"', '-D_REENTRANT', '../libs/pbd/basename.cc', '-c', '-o', 'libs/pbd/basename.cc.2.o']
 -> task in 'libpbd' failed (exit status 1): 
        {task 4494103952: cxx boost_debug.cc -> boost_debug.cc.2.o}
['clang++', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4', '-DWAF_BUILD', '-O0', '-g', '-fshow-column', '-DARCH_X86', '-DBUILD_VECLIB_OPTIMIZATIONS', '-DMAC_OS_X_VERSION_MAX_ALLOWED=1090', '-mmacosx-version-min=10.8', '-Wall', '-Wpointer-arith', '-Wcast-qual', '-Wcast-align', '-Wno-unused-parameter', '-DBOOST_SYSTEM_NO_DEPRECATED', '-D_ISOC9X_SOURCE', '-D_LARGEFILE64_SOURCE', '-D_FILE_OFFSET_BITS=64', '-DENABLE_NLS', '-DPROGRAM_NAME="Ardour"', u'-DPROGRAM_VERSION="4"', '-std=c++11', '--stdlib=libstdc++', '-DCARBON_FLAT_HEADERS', '-Qunused-arguments', '-Woverloaded-virtual', '-Wno-mismatched-tags', '-D__STDC_LIMIT_MACROS', '-D__STDC_FORMAT_MACROS', '-DCANVAS_COMPATIBILITY', '-DCANVAS_DEBUG', '-fPIC', '-compatibility_version', '1', '-current_version', '1', '-fPIC', '-compatibility_version', '1', '-current_version', '1', '-msse', '-msse2', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/build/libs/pbd', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/libs/pbd', '-I/usr/local/Cellar/glib/2.46.2/include/glib-2.0', '-I/usr/local/Cellar/glib/2.46.2/lib/glib-2.0/include', '-I/usr/local/opt/gettext/include', '-I/usr/local/Cellar/libsigc++/2.6.2/include/sigc++-2.0', '-I/usr/local/Cellar/libsigc++/2.6.2/lib/sigc++-2.0/include', '-I/usr/local/Cellar/glibmm/2.46.2/include/glibmm-2.4', '-I/usr/local/Cellar/glibmm/2.46.2/lib/glibmm-2.4/include', '-I/usr/include/libxml2', '-I/usr/local/Cellar/libsndfile/1.0.25/include', '-I/usr/local/Cellar/glibmm/2.46.2/include/giomm-2.4', '-I/usr/local/Cellar/glibmm/2.46.2/lib/giomm-2.4/include', '-I/private/tmp/ardour20151212-33494-1j9lz4k/ardour-4.4/build', '-DNEED_INTL=1', '-DHAVE_COREAUDIO=1', '-DAUDIOUNIT_SUPPORT=1', '-DGTKOSX=1', '-DTOP_MENUBAR=1', '-DINTERNAL_SHARED_LIBS=1', '-DHAVE_DLOPEN=1', '-DHAVE_GLIB=1', '-DHAVE_GTHREAD=1', '-DHAVE_GLIBMM=1', '-DHAVE_SNDFILE=1', '-DHAVE_GIOMM=1', '-DHAVE_CURL=1', '-DHAVE_LO=1', '-DHAVE_TAGLIB=1', '-DHAVE_VAMPSDK=1', '-DHAVE_VAMPHOSTSDK=1', '-DHAVE_RUBBERBAND=1', '-DEXPORT_VISIBILITY_HIDDEN=False', '-DPHONE_HOME=1', '-DENABLE_NLS=1', '-D_DARWIN_C_SOURCE=1', '-DCONFIG_ARCH="x86_64"', '-DHAVE_LIBS_APPLEUTILITY=1', '-DHAVE_LIBS_CLEARLOOKS_NEWER=1', '-DHAVE_LIBS_QM_DSP=1', '-DHAVE_FFTW3F=1', '-DHAVE_AUBIO=1', '-DHAVE_AUBIO4=1', '-DHAVE_LIBS_VAMP_PLUGINS=1', '-DHAVE_LIBS_LIBLTC=1', '-DHAVE_LIBS_PTFORMAT=1', '-DHAVE_XML=1', '-DHAVE_SIGCPP=1', '-DHAVE_EXECINFO=1', '-DHAVE_POSIX_MEMALIGN=1', '-DHAVE_LOCALTIME_R=1', '-DHAVE_LIBS_PBD=1', '-DHAVE_LIBS_MIDIPP2=1', '-DHAVE_LIBS_EVORAL=1', '-DHAVE_CONTROL_PROTOCOL=1', '-DHAVE_GENERIC_MIDI=1', '-DHAVE_MACKIE=1', '-DHAVE_LIBS_SURFACES=1', '-DHAVE_2IN2OUT=1', '-DHAVE_1IN2OUT=1', '-DHAVE_VBAP=1', '-DHAVE_STEREOBALANCE=1', '-DHAVE_LIBS_PANNERS=1', '-DHAVE_JACK=1', '-DHAVE_JACK_METADATA=1', '-DHAVE_LIBS_BACKENDS=1', '-DHAVE_LIBS_TIMECODE=1', '-DHAVE_LRDF=1', '-DHAVE_SAMPLERATE=1', '-DHAVE_LV2=1', '-DHAVE_LV2_1_2_0=1', '-DHAVE_LV2_1_10_0=1', '-DHAVE_SERD=1', '-DHAVE_SORD=1', '-DHAVE_SRATOM=1', '-DHAVE_LILV=1', '-DHAVE_LILV_0_16_0=1', '-DHAVE_LILV_0_19_2=1', '-DHAVE_SUIL=1', '-DLV2_SUPPORT=1', '-DHAVE_OGG=1', '-DHAVE_FLAC=1', '-DUSE_RUBBERBAND=1', '-DCURRENT_SESSION_FILE_VERSION=3001', '-DHAVE_SYS_STATVFS_H=1', '-DHAVE_UNISTD=1', '-DHAVE_BOOST_SCOPED_PTR_HPP=1', '-DHAVE_BOOST_PTR_CONTAINER_PTR_LIST_HPP=1', '-DHAVE_LIBS_ARDOUR=1', '-DHAVE_GTKMM=1', '-DHAVE_GTK=1', '-DHAVE_LIBS_GTKMM2EXT=1', '-DHAVE_BOOST_FORMAT_HPP=1', '-DHAVE_LIBS_AUDIOGRAPHER=1', '-DHAVE_CAIROMM=1', '-DHAVE_LIBS_CANVAS=1', '-DHAVE_LV2_1_0_0=1', '-DHAVE_LIBS_PLUGINS_REASONABLESYNTH_LV2=1', '-DHAVE_FONTCONFIG=1', '-DHAVE_BOOST_SHARED_PTR_HPP=1', '-DHAVE_BOOST_WEAK_PTR_HPP=1', '-DHAVE_GTK2_ARDOUR=1', '-DHAVE_EXPORT=1', '-DHAVE_MIDI_MAPS=1', '-DHAVE_MCP=1', '-DHAVE_PATCHFILES=1', '-DHAVE_HEADLESS=1', '-DHAVE_LIBS_FST=1', '-DHAVE_LIBS_VFORK=1', '-DHAVE_LIBS_ARDOURALSAUTIL=1', '-DHAVE_CFGTOOL=1', '-DLIBPBD_DLL_EXPORTS=1', '-DPACKAGE="libpbd4"', '-D_REENTRANT', '../libs/pbd/boost_debug.cc', '-c', '-o', 'libs/pbd/boost_debug.cc.2.o']
```

Using `libc++` instead of `libsigc++` fixes this and does not have any other side effects for me (on El Capitan (clang-700.1.81))