### PR TITLE
Changes/Fixes to mouse scroll wheel behaviour in the Editor

### DIFF
--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -374,6 +374,9 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 	bool scroll_up_one_track (bool skip_child_views = false);
 	bool scroll_down_one_track (bool skip_child_views = false);
 
+	void scroll_left_step ();
+	void scroll_right_step ();
+
 	void prepare_for_cleanup ();
 	void finish_cleanup ();
 

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -295,6 +295,7 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 	framecnt_t         get_current_zoom () const { return samples_per_pixel; }
 	void               cycle_zoom_focus ();
 	void temporal_zoom_step (bool coarser);
+	void temporal_zoom_step_mouse_focus (bool coarser);
 	void ensure_time_axis_view_is_visible (TimeAxisView const & tav, bool at_top);
 	void tav_zoom_step (bool coarser);
 	void tav_zoom_smooth (bool coarser, bool force_all);

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -377,6 +377,9 @@ class Editor : public PublicEditor, public PBD::ScopedConnectionList, public ARD
 	void scroll_left_step ();
 	void scroll_right_step ();
 
+	void scroll_left_half_page ();
+	void scroll_right_half_page ();
+
 	void prepare_for_cleanup ();
 	void finish_cleanup ();
 

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -1018,7 +1018,6 @@ Editor::canvas_meter_marker_event (GdkEvent *event, ArdourCanvas::Item* item, Me
 bool
 Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType type)
 {
-	framepos_t xdelta;
 	bool handled = false;
 
 	if (event->type == GDK_SCROLL) {
@@ -1056,22 +1055,12 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 			break;
 
 		case GDK_SCROLL_LEFT:
-			xdelta = (current_page_samples() / 2);
-			if (leftmost_frame > xdelta) {
-				reset_x_origin (leftmost_frame - xdelta);
-			} else {
-				reset_x_origin (0);
-			}
+			scroll_left_half_page ();
 			handled = true;
 			break;
 
 		case GDK_SCROLL_RIGHT:
-			xdelta = (current_page_samples() / 2);
-			if (max_framepos - xdelta > leftmost_frame) {
-				reset_x_origin (leftmost_frame + xdelta);
-			} else {
-				reset_x_origin (max_framepos - current_page_samples());
-			}
+			scroll_right_half_page ();
 			handled = true;
 			break;
 

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -76,10 +76,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 	case GDK_SCROLL_UP:
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
 			//for mouse-wheel zoom, force zoom-focus to mouse
-			Editing::ZoomFocus temp_focus = zoom_focus;
-			zoom_focus = Editing::ZoomFocusMouse;
-			temporal_zoom_step (false);
-			zoom_focus = temp_focus;
+			temporal_zoom_step_mouse_focus (false);
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
 			scroll_left_step ();
@@ -105,10 +102,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 	case GDK_SCROLL_DOWN:
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
 			//for mouse-wheel zoom, force zoom-focus to mouse
-			Editing::ZoomFocus temp_focus = zoom_focus;
-			zoom_focus = Editing::ZoomFocusMouse;
-			temporal_zoom_step (true);
-			zoom_focus = temp_focus;
+			temporal_zoom_step_mouse_focus (true);
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
 			scroll_right_step ();
@@ -1033,10 +1027,7 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 				scroll_left_half_page ();
 			} else if (Profile->get_mixbus()) {
 				//for mouse-wheel zoom, force zoom-focus to mouse
-				Editing::ZoomFocus temp_focus = zoom_focus;
-				zoom_focus = Editing::ZoomFocusMouse;
-				temporal_zoom_step (false);
-				zoom_focus = temp_focus;
+				temporal_zoom_step_mouse_focus (false);
 			} else {
 				temporal_zoom_step (false);
 			}
@@ -1049,10 +1040,7 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 				scroll_right_half_page ();
 			} else if (Profile->get_mixbus()) {
 				//for mouse-wheel zoom, force zoom-focus to mouse
-				Editing::ZoomFocus temp_focus = zoom_focus;
-				zoom_focus = Editing::ZoomFocusMouse;
-				temporal_zoom_step (true);
-				zoom_focus = temp_focus;
+				temporal_zoom_step_mouse_focus (true);
 			} else {
 				temporal_zoom_step (true);
 			}

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -75,8 +75,11 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 	switch (direction) {
 	case GDK_SCROLL_UP:
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
-			//for mouse-wheel zoom, force zoom-focus to mouse
-			temporal_zoom_step_mouse_focus (false);
+			if (UIConfiguration::instance().get_use_mouse_position_as_zoom_focus_on_scroll()) {
+				temporal_zoom_step_mouse_focus (false);
+			} else {
+				temporal_zoom_step (false);
+			}
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
 			scroll_left_step ();
@@ -101,8 +104,11 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 
 	case GDK_SCROLL_DOWN:
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
-			//for mouse-wheel zoom, force zoom-focus to mouse
-			temporal_zoom_step_mouse_focus (true);
+			if (UIConfiguration::instance().get_use_mouse_position_as_zoom_focus_on_scroll()) {
+				temporal_zoom_step_mouse_focus (true);
+			} else {
+				temporal_zoom_step (true);
+			}
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
 			scroll_right_step ();
@@ -1025,8 +1031,7 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 			if (Keyboard::modifier_state_equals(event->scroll.state,
 			                                    Keyboard::ScrollHorizontalModifier)) {
 				scroll_left_half_page ();
-			} else if (Profile->get_mixbus()) {
-				//for mouse-wheel zoom, force zoom-focus to mouse
+			} else if (UIConfiguration::instance().get_use_mouse_position_as_zoom_focus_on_scroll()) {
 				temporal_zoom_step_mouse_focus (false);
 			} else {
 				temporal_zoom_step (false);
@@ -1038,8 +1043,7 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 			if (Keyboard::modifier_state_equals(event->scroll.state,
 			                                    Keyboard::ScrollHorizontalModifier)) {
 				scroll_right_half_page ();
-			} else if (Profile->get_mixbus()) {
-				//for mouse-wheel zoom, force zoom-focus to mouse
+			} else if (UIConfiguration::instance().get_use_mouse_position_as_zoom_focus_on_scroll()) {
 				temporal_zoom_step_mouse_focus (true);
 			} else {
 				temporal_zoom_step (true);

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -1028,8 +1028,10 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 
 		switch (event->scroll.direction) {
 		case GDK_SCROLL_UP:
-
-			if (Profile->get_mixbus()) {
+			if (Keyboard::modifier_state_equals(event->scroll.state,
+			                                    Keyboard::ScrollHorizontalModifier)) {
+				scroll_left_half_page ();
+			} else if (Profile->get_mixbus()) {
 				//for mouse-wheel zoom, force zoom-focus to mouse
 				Editing::ZoomFocus temp_focus = zoom_focus;
 				zoom_focus = Editing::ZoomFocusMouse;
@@ -1042,7 +1044,10 @@ Editor::canvas_ruler_event (GdkEvent *event, ArdourCanvas::Item* item, ItemType 
 			break;
 
 		case GDK_SCROLL_DOWN:
-			if (Profile->get_mixbus()) {
+			if (Keyboard::modifier_state_equals(event->scroll.state,
+			                                    Keyboard::ScrollHorizontalModifier)) {
+				scroll_right_half_page ();
+			} else if (Profile->get_mixbus()) {
 				//for mouse-wheel zoom, force zoom-focus to mouse
 				Editing::ZoomFocus temp_focus = zoom_focus;
 				zoom_focus = Editing::ZoomFocusMouse;

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -72,7 +72,6 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 
 	Duple event_coords = _track_canvas->window_to_canvas (Duple (ev->x, ev->y));
 
-  retry:
 	switch (direction) {
 	case GDK_SCROLL_UP:
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
@@ -83,8 +82,8 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 			zoom_focus = temp_focus;
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
-			direction = GDK_SCROLL_LEFT;
-			goto retry;
+			scroll_left_step ();
+			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomVerticalModifier)) {
 			if (!current_stepping_trackview) {
 				step_timeout = Glib::signal_timeout().connect (sigc::mem_fun(*this, &Editor::track_height_step_timeout), 500);
@@ -112,8 +111,8 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 			zoom_focus = temp_focus;
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
-			direction = GDK_SCROLL_RIGHT;
-			goto retry;
+			scroll_right_step ();
+			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomVerticalModifier)) {
 			if (!current_stepping_trackview) {
 				step_timeout = Glib::signal_timeout().connect (sigc::mem_fun(*this, &Editor::track_height_step_timeout), 500);

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -64,7 +64,6 @@ using Gtkmm2ext::Keyboard;
 bool
 Editor::track_canvas_scroll (GdkEventScroll* ev)
 {
-	framepos_t xdelta;
 	int direction = ev->direction;
 
 	/* this event arrives without transformation by the canvas, so we have
@@ -134,21 +133,13 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 		break;
 
 	case GDK_SCROLL_LEFT:
-		xdelta = (current_page_samples() / 8);
-		if (leftmost_frame > xdelta) {
-			reset_x_origin (leftmost_frame - xdelta);
-		} else {
-			reset_x_origin (0);
-		}
+		scroll_left_step ();
+		return true;
 		break;
 
 	case GDK_SCROLL_RIGHT:
-		xdelta = (current_page_samples() / 8);
-		if (max_framepos - xdelta > leftmost_frame) {
-			reset_x_origin (leftmost_frame + xdelta);
-		} else {
-			reset_x_origin (max_framepos - current_page_samples());
-		}
+		scroll_right_step ();
+		return true;
 		break;
 
 	default:

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -1614,6 +1614,28 @@ Editor::scroll_right_step ()
 	}
 }
 
+void
+Editor::scroll_left_half_page ()
+{
+	framepos_t xdelta = (current_page_samples() / 2);
+	if (leftmost_frame > xdelta) {
+		reset_x_origin (leftmost_frame - xdelta);
+	} else {
+		reset_x_origin (0);
+	}
+}
+
+void
+Editor::scroll_right_half_page ()
+{
+	framepos_t xdelta = (current_page_samples() / 2);
+	if (max_framepos - xdelta > leftmost_frame) {
+		reset_x_origin (leftmost_frame + xdelta);
+	} else {
+		reset_x_origin (max_framepos - current_page_samples());
+	}
+}
+
 /* ZOOM */
 
 void

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -1687,6 +1687,14 @@ Editor::tav_zoom_smooth (bool coarser, bool force_all)
 	}
 }
 
+void
+Editor::temporal_zoom_step_mouse_focus (bool coarser)
+{
+	Editing::ZoomFocus temp_focus = zoom_focus;
+	zoom_focus = Editing::ZoomFocusMouse;
+	temporal_zoom_step (coarser);
+	zoom_focus = temp_focus;
+}
 
 void
 Editor::temporal_zoom_step (bool coarser)

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -1589,6 +1589,31 @@ Editor::scroll_up_one_track (bool skip_child_views)
 	return false;
 }
 
+void
+Editor::scroll_left_step ()
+{
+	framepos_t xdelta = (current_page_samples() / 8);
+
+	if (leftmost_frame > xdelta) {
+		reset_x_origin (leftmost_frame - xdelta);
+	} else {
+		reset_x_origin (0);
+	}
+}
+
+
+void
+Editor::scroll_right_step ()
+{
+	framepos_t xdelta = (current_page_samples() / 8);
+
+	if (max_framepos - xdelta > leftmost_frame) {
+		reset_x_origin (leftmost_frame + xdelta);
+	} else {
+		reset_x_origin (max_framepos - current_page_samples());
+	}
+}
+
 /* ZOOM */
 
 void

--- a/gtk2_ardour/editor_summary.cc
+++ b/gtk2_ardour/editor_summary.cc
@@ -695,7 +695,8 @@ EditorSummary::on_scroll_event (GdkEventScroll* ev)
 	switch (ev->direction) {
 		case GDK_SCROLL_UP:
 			if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
-				x -= 64;
+				_editor->scroll_left_half_page ();
+				return true;
 			} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
 				_editor->temporal_zoom_step (false);
 			} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomVerticalModifier)) {
@@ -709,7 +710,8 @@ EditorSummary::on_scroll_event (GdkEventScroll* ev)
 			break;
 		case GDK_SCROLL_DOWN:
 			if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
-				x += 64;
+				_editor->scroll_right_half_page ();
+				return true;
 			} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
 				_editor->temporal_zoom_step (true);
 			} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomVerticalModifier)) {
@@ -727,7 +729,8 @@ EditorSummary::on_scroll_event (GdkEventScroll* ev)
 			} else if (Keyboard::modifier_state_contains (ev->state, Keyboard::TertiaryModifier)) {
 				x -= 1;
 			} else {
-				x -= 8;
+				_editor->scroll_left_half_page ();
+				return true;
 			}
 			break;
 		case GDK_SCROLL_RIGHT:
@@ -736,7 +739,8 @@ EditorSummary::on_scroll_event (GdkEventScroll* ev)
 			} else if (Keyboard::modifier_state_contains (ev->state, Keyboard::TertiaryModifier)) {
 				x += 1;
 			} else {
-				x += 8;
+				_editor->scroll_right_half_page ();
+				return true;
 			}
 			break;
 		default:

--- a/gtk2_ardour/rc_option_editor.cc
+++ b/gtk2_ardour/rc_option_editor.cc
@@ -2108,6 +2108,14 @@ if (!Profile->get_mixbus()) {
 			    sigc::mem_fun (UIConfiguration::instance(), &UIConfiguration::get_show_zoom_tools),
 			    sigc::mem_fun (UIConfiguration::instance(), &UIConfiguration::set_show_zoom_tools)
 			    ));
+
+	add_option (_("Editor"),
+		    new BoolOption (
+			    "use-mouse-position-as-zoom-focus-on-scroll",
+			    _("Always use mouse cursor position as zoom focus when zooming using mouse scroll wheel"),
+			    sigc::mem_fun (UIConfiguration::instance(), &UIConfiguration::get_use_mouse_position_as_zoom_focus_on_scroll),
+			    sigc::mem_fun (UIConfiguration::instance(), &UIConfiguration::set_use_mouse_position_as_zoom_focus_on_scroll)
+			    ));
 }  // !mixbus
 
 	add_option (_("Editor"),

--- a/gtk2_ardour/ui_config_vars.h
+++ b/gtk2_ardour/ui_config_vars.h
@@ -49,6 +49,7 @@ UI_CONFIG_VARIABLE (bool, never_display_periodic_midi, "never-display-periodic-m
 UI_CONFIG_VARIABLE (bool, sound_midi_notes, "sound-midi-notes", false)
 UI_CONFIG_VARIABLE (bool, show_plugin_scan_window, "show-plugin-scan-window", false)
 UI_CONFIG_VARIABLE (bool, show_zoom_tools, "show-zoom-tools", true)
+UI_CONFIG_VARIABLE (bool, use_mouse_position_as_zoom_focus_on_scroll, "use-mouse-position-as-zoom-focus-on-scroll", true)
 UI_CONFIG_VARIABLE (bool, widget_prelight, "widget-prelight", true)
 UI_CONFIG_VARIABLE (bool, use_tooltips, "use-tooltips", true)
 UI_CONFIG_VARIABLE (std::string, mixer_strip_visibility, "mixer-element-visibility", "Input,PhaseInvert,RecMon,SoloIsoLock,Output,Comments")


### PR DESCRIPTION
It would be good to get some feedback on these changes as there are some small changes in behaviour and perhaps reasons why these changes may not be appropriate but mostly it is is just some refactoring and fixes.

I'm not sure about adding an option for always using mouse position as zoom focus when scrolling but as Mixbus and Ardour did have different behaviours some people may want to always use the zoom focus setting when scrolling with the mouse wheel.