### PR TITLE
Change the tap tempo estimator to least-squares regression

### DIFF
--- a/gtk2_ardour/tempo_dialog.h
+++ b/gtk2_ardour/tempo_dialog.h
@@ -60,8 +60,10 @@ private:
 	NoteTypes note_types;
 
 	bool tapped;      // whether the tap-tempo button has been clicked
-	gint64 last_tap;
-	double average_interval;
+	double sum_x, sum_xx, sum_xy, sum_y;
+	double tap_count;
+	double last_t;
+	gint64 first_t;
 
 	Gtk::ComboBoxText pulse_selector;
 	Gtk::Adjustment   bpm_adjustment;


### PR DESCRIPTION
The previous estimator had a very bad performance. The bpm value did not converge with a sufficient number of taps*. This change is to use a well-known unbiased estimator, least-squares linear regression. It is now possible to tap tempo correctly to a fraction of a bpm.

*) the error limit is equal to 58% of the error af a single tap, assuming normally i.i.d. errors.
