### PR TITLE
Fix bug with PT5 and add preliminary PTX support

### DIFF
--- a/libs/ptformat/ptfformat.cc
+++ b/libs/ptformat/ptfformat.cc
@@ -631,6 +631,17 @@ PTFFormat::parserest5(void) {
 }
 
 void
+PTFFormat::resort(std::vector<wav_t> *ws) {
+	int j = 0;
+	std::sort((*ws).begin(), (*ws).end());
+	for (std::vector<wav_t>::iterator i = (*ws).begin();
+			i != (*ws).end(); ++i) {
+		(*i).index = j;
+		j++;
+	}
+}
+
+void
 PTFFormat::parseaudio5(void) {
 	int i,k,l;
 	int lengthofname, wavnumber;
@@ -670,6 +681,7 @@ PTFFormat::parseaudio5(void) {
 
 	wavnumber = 0;
 	i+=16;
+	char ext[5];
 	while (i < len && numberofwavs > 0) {
 		i++;
 		if (		(ptfunxored[i  ] == 0x5a) &&
@@ -684,11 +696,19 @@ PTFFormat::parseaudio5(void) {
 			wavname[l] = ptfunxored[i+l];
 			l++;
 		}
-		i+=lengthofname + 4;
+		i+=lengthofname;
+		ext[0] = ptfunxored[i++];
+		ext[1] = ptfunxored[i++];
+		ext[2] = ptfunxored[i++];
+		ext[3] = ptfunxored[i++];
+		ext[4] = '\0';
+
 		wavname[l] = 0;
-		if (foundin(wavname, ".wav")) {
+		if (foundin(wavname, ".L") || foundin(wavname, ".R")) {
+			extension = string("");
+		} else if (foundin(wavname, ".wav") || foundin(ext, "WAVE")) {
 			extension = string(".wav");
-		} else if (foundin(wavname, ".aif")) {
+		} else if (foundin(wavname, ".aif") || foundin(ext, "AIFF")) {
 			extension = string(".aif");
 		} else {
 			extension = string("");
@@ -707,6 +727,8 @@ PTFFormat::parseaudio5(void) {
 		numberofwavs--;
 		i += 7;
 	}
+	resort(&actualwavs);
+	resort(&audiofiles);
 }
 
 void

--- a/libs/ptformat/ptfformat.h
+++ b/libs/ptformat/ptfformat.h
@@ -16,10 +16,10 @@
 #define PTFFORMAT_H
 
 #include <string>
+#include <cstring>
 #include <algorithm>
 #include <vector>
 #include <stdint.h>
-
 #include "ptformat/visibility.h"
 
 class LIBPTFORMAT_API PTFFormat {
@@ -38,6 +38,11 @@ public:
 
 		int64_t     posabsolute;
 		int64_t     length;
+
+		bool operator <(const struct wav& other) {
+			return (strcasecmp(this->filename.c_str(),
+					other.filename.c_str()) < 0);
+		}
 
 		bool operator ==(const struct wav& other) {
 			return (this->filename == other.filename ||
@@ -125,6 +130,7 @@ private:
 	void parserest10(void);
 	void parseaudio5(void);
 	void parseaudio(void);
+	void resort(std::vector<wav_t> *ws);
 	std::vector<wav_t> actualwavs;
 	float ratefactor;
 	std::string extension;

--- a/libs/ptformat/ptfformat.h
+++ b/libs/ptformat/ptfformat.h
@@ -113,7 +113,7 @@ public:
 	unsigned char c0;
 	unsigned char c1;
 	unsigned char *ptfunxored;
-	int len;
+	uint64_t len;
 
 private:
 	bool foundin(std::string haystack, std::string needle);
@@ -131,6 +131,7 @@ private:
 	void parseaudio5(void);
 	void parseaudio(void);
 	void resort(std::vector<wav_t> *ws);
+	uint8_t mostfrequent(uint32_t start, uint32_t stop);
 	std::vector<wav_t> actualwavs;
 	float ratefactor;
 	std::string extension;


### PR DESCRIPTION
- Previously, the PT5 wav files would appear jumbled in the regions, they did not match up correctly, now they do.
- Previously, PTX support was non-functional, now PT10 and PT11 works with 3 point audio on files/regions/tracks.