### PR TITLE
Fix 6609: Right-click in active track name box crashes

### DIFF
--- a/gtk2_ardour/time_axis_view.cc
+++ b/gtk2_ardour/time_axis_view.cc
@@ -104,6 +104,7 @@ TimeAxisView::TimeAxisView (ARDOUR::Session* sess, PublicEditor& ed, TimeAxisVie
 	, _editor (ed)
 	, name_entry (0)
 	, ending_name_edit (false)
+	, by_popup_menu (false)
 	, control_parent (0)
 	, _order (0)
 	, _effective_height (0)
@@ -652,8 +653,18 @@ TimeAxisView::name_entry_key_release (GdkEventKey* ev)
 bool
 TimeAxisView::name_entry_focus_out (GdkEventFocus*)
 {
+	if (by_popup_menu) {
+		by_popup_menu = false;
+		return false;
+	}
 	end_name_edit (RESPONSE_OK);
 	return false;
+}
+
+void
+TimeAxisView::name_entry_populate_popup (Gtk::Menu *)
+{
+	by_popup_menu = true;
 }
 
 void
@@ -675,6 +686,7 @@ TimeAxisView::begin_name_edit ()
 		name_entry->signal_focus_out_event().connect (sigc::mem_fun (*this, &TimeAxisView::name_entry_focus_out));
 		name_entry->set_text (name_label.get_text());
 		name_entry->signal_activate().connect (sigc::bind (sigc::mem_fun (*this, &TimeAxisView::end_name_edit), RESPONSE_OK));
+		name_entry->signal_populate_popup().connect (sigc::mem_fun (*this, &TimeAxisView::name_entry_populate_popup));
 
 		if (name_label.is_ancestor (name_hbox)) {
 			name_hbox.remove (name_label);

--- a/gtk2_ardour/time_axis_view.h
+++ b/gtk2_ardour/time_axis_view.h
@@ -257,9 +257,11 @@ class TimeAxisView : public virtual AxisView
 	bool name_entry_key_release (GdkEventKey *ev);
 	bool name_entry_key_press (GdkEventKey *ev);
 	bool name_entry_focus_out (GdkEventFocus *ev);
+	void name_entry_populate_popup (Gtk::Menu *);
 
 	Gtk::Entry* name_entry;
 	bool ending_name_edit;
+	bool by_popup_menu;
 	void begin_name_edit ();
 	void end_name_edit (int);
 


### PR DESCRIPTION
When right-clicking in the text entry, popup menu grabs focus. Consequently, the "focus out" handler is called, destroys the text entry and replaces it by the label name of the track.
When menu pops up, it tries to access to a widget no longer available.