### PR TITLE
Fix 6677: Post-export script reinterprets timestamp format placeholde…

### DIFF
--- a/libs/ardour/ardour/export_filename.h
+++ b/libs/ardour/ardour/export_filename.h
@@ -112,8 +112,7 @@ class LIBARDOUR_API ExportFilename {
 	TimeFormat time_format;
 
 	std::string get_formatted_time (std::string const & format) const;
-	// Due to the static allocation used in strftime(), no destructor or copy-ctor is needed for this
-	struct tm * time_struct;
+	struct tm time_struct;
 
 	ExportTimespanPtr timespan;
 	ExportChannelConfigPtr channel_config;

--- a/libs/ardour/export_filename.cc
+++ b/libs/ardour/export_filename.cc
@@ -26,6 +26,7 @@
 #include "pbd/xml++.h"
 #include "pbd/convert.h"
 #include "pbd/enumwriter.h"
+#include "pbd/localtime_r.h"
 
 #include "ardour/libardour_visibility.h"
 #include "ardour/session.h"
@@ -62,7 +63,7 @@ ExportFilename::ExportFilename (Session & session) :
 {
 	time_t rawtime;
 	std::time (&rawtime);
-	time_struct = localtime (&rawtime);
+	localtime_r (&rawtime, &time_struct);
 
 	folder = session.session_directory().export_path();
 
@@ -319,7 +320,7 @@ string
 ExportFilename::get_formatted_time (string const & format) const
 {
 	char buffer [80];
-	strftime (buffer, 80, format.c_str(), time_struct);
+	strftime (buffer, 80, format.c_str(), &time_struct);
 
 	string return_value (buffer);
 	return return_value;


### PR DESCRIPTION
…r giving incorrect filename

Due to localtime and its statically allocated buffer, time_struct variable is
set at construct time but its value changes over time due to subsequent calls to localtime
in ardour process. Replacing localtime by localtime_r fix the problem.

This also fix 6713: Name of Audio (timestamp) does not match with written Filename in CD-Cue file