### PR TITLE
 Fix 6772: crash when clicked "plugin analysis" on any linux-vst plugin

### DIFF
--- a/libs/ardour/vst_plugin.cc
+++ b/libs/ardour/vst_plugin.cc
@@ -565,7 +565,12 @@ VSTPlugin::connect_and_run (BufferSet& bufs,
 
 	uint32_t out_index = 0;
 	for (i = 0; i < (int32_t) _plugin->numOutputs; ++i) {
-		outs[i] = scratch_bufs.get_audio(i).data(offset);
+		uint32_t  index;
+		bool      valid = false;
+		index = out_map.get(DataType::AUDIO, out_index++, &valid);
+		outs[i] = (valid)
+					? bufs.get_audio(index).data(offset)
+					: scratch_bufs.get_audio(0).data(offset);
 	}
 
 	if (bufs.count().n_midi() > 0) {


### PR DESCRIPTION
 In VSTPlugin::connect_and_run, make _plugin->processReplacing called
 with the right buffer.

 See notes on Mantis before merge.