### PR TITLE
use matching floating point types

### DIFF
--- a/libs/ardour/parameter_descriptor.cc
+++ b/libs/ardour/parameter_descriptor.cc
@@ -177,9 +177,9 @@ ParameterDescriptor::update_steps()
 			step      = step      / logf(30.0f);
 			largestep = largestep / logf(30.0f);
 		} else if (integer_step) {
-			smallstep = 1.0;
-			step      = std::max(1.0, rint(step));
-			largestep = std::max(1.0, rint(largestep));
+			smallstep = 1.0f;
+			step      = std::max(1.0f, rint(step));
+			largestep = std::max(1.0f, rint(largestep));
 		}
 	}
 }


### PR DESCRIPTION
I needed this change to compile Ardour with the GCC 6 prerelease which we have in Fedora Rawhide, without it, it would trip over the arguments to `std::max` having different types (`double` and `float` respectively).