### PR TITLE
Spelling correction patch from Debian

### DIFF
--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -4126,9 +4126,9 @@ MarkerDrag::finished (GdkEvent* event, bool movement_occurred)
 }
 
 void
-MarkerDrag::aborted (bool movement_occured)
+MarkerDrag::aborted (bool movement_occurred)
 {
-	if (!movement_occured) {
+	if (!movement_occurred) {
 		return;
 	}
 
@@ -4382,9 +4382,9 @@ LineDrag::motion (GdkEvent* event, bool first_move)
 }
 
 void
-LineDrag::finished (GdkEvent* event, bool movement_occured)
+LineDrag::finished (GdkEvent* event, bool movement_occurred)
 {
-	if (movement_occured) {
+	if (movement_occurred) {
 		motion (event, false);
 		_line->end_drag (false, 0);
 		_editor->commit_reversible_command ();
@@ -5361,9 +5361,9 @@ RangeMarkerBarDrag::finished (GdkEvent* event, bool movement_occurred)
 }
 
 void
-RangeMarkerBarDrag::aborted (bool movement_occured)
+RangeMarkerBarDrag::aborted (bool movement_occurred)
 {
-	if (movement_occured) {
+	if (movement_occurred) {
 		_drag_rect->hide ();
 	}
 }

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -4567,7 +4567,7 @@ Editor::cut_copy_regions (CutCopyOp op, RegionSelection& rs)
 
 		list<boost::shared_ptr<Playlist> > foo;
 
-		/* the pmap is in the same order as the tracks in which selected regions occured */
+		/* the pmap is in the same order as the tracks in which selected regions occurred */
 
 		for (vector<PlaylistMapping>::iterator i = pmap.begin(); i != pmap.end(); ++i) {
 			if ((*i).pl) {

--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -536,7 +536,7 @@ MidiRegionView::button_release (GdkEventButton* ev)
 
 		switch (editor.current_mouse_mode()) {
 		case MouseRange:
-			/* no motion occured - simple click */
+			/* no motion occurred - simple click */
 			clear_editor_note_selection ();
 			_mouse_changed_selection = true;
 			break;

--- a/gtk2_ardour/monitor_section.cc
+++ b/gtk2_ardour/monitor_section.cc
@@ -182,7 +182,7 @@ MonitorSection::MonitorSection (Session* s)
 	/* Processor Box hide/shos */
 	toggle_processorbox_button.set_text (_("Processors"));
 	toggle_processorbox_button.set_name (X_("monitor section processors toggle"));
-	set_tooltip (&toggle_processorbox_button, _("Allow to add monitor effect processors"));
+	set_tooltip (&toggle_processorbox_button, _("Allow one to add monitor effect processors"));
 
 	proctoggle = ToggleAction::create ();
 	toggle_processorbox_button.set_related_action (proctoggle);

--- a/gtk2_ardour/po/ru.po
+++ b/gtk2_ardour/po/ru.po
@@ -8518,7 +8518,7 @@ msgid "Processors"
 msgstr "Обработчики"
 
 #: monitor_section.cc:189
-msgid "Allow to add monitor effect processors"
+msgid "Allow one to add monitor effect processors"
 msgstr ""
 
 #: monitor_section.cc:205

--- a/libs/appleutility/CoreAudio/PublicUtility/CAAtomic.h
+++ b/libs/appleutility/CoreAudio/PublicUtility/CAAtomic.h
@@ -80,7 +80,7 @@ inline SInt32 CAAtomicAdd32Barrier(SInt32 theAmt, volatile SInt32* theValue)
 #if TARGET_OS_WIN32
 	long lRetVal = InterlockedExchangeAdd((volatile long*)theValue, theAmt);
 	// InterlockedExchangeAdd returns the original value which differs from OSX version. 
-	// At this point the addition would have occured and hence returning the new value
+	// At this point the addition would have occurred and hence returning the new value
 	// to keep it sync with OSX.
 	return lRetVal + theAmt;
 #else

--- a/libs/ardour/export_handler.cc
+++ b/libs/ardour/export_handler.cc
@@ -517,10 +517,10 @@ ExportHandler::export_cd_marker_file (ExportTimespanPtr timespan, ExportFormatSp
 		}
 
 	} catch (std::exception& e) {
-		error << string_compose (_("an error occured while writing a TOC/CUE file: %1"), e.what()) << endmsg;
+		error << string_compose (_("an error occurred while writing a TOC/CUE file: %1"), e.what()) << endmsg;
 		::g_unlink (filepath.c_str());
 	} catch (Glib::Exception& e) {
-		error << string_compose (_("an error occured while writing a TOC/CUE file: %1"), e.what()) << endmsg;
+		error << string_compose (_("an error occurred while writing a TOC/CUE file: %1"), e.what()) << endmsg;
 		::g_unlink (filepath.c_str());
 	}
 }

--- a/libs/ardour/playlist.cc
+++ b/libs/ardour/playlist.cc
@@ -3173,7 +3173,7 @@ Playlist::uncombine (boost::shared_ptr<Region> target)
 		}
 
 		/* check to see how the original region (in the
-		 * playlist before compounding occured) overlaps
+		 * playlist before compounding occurred) overlaps
 		 * with the new state of the compound region.
 		 */
 

--- a/libs/ardour/po/cs.po
+++ b/libs/ardour/po/cs.po
@@ -594,7 +594,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr "Editor: Nelze otevřít \"%1\" jako soubor vyvedení pro značku CD"
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr "Při zápisu souboru TOC/CUE se vyskytla chyba:%1"
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/de.po
+++ b/libs/ardour/po/de.po
@@ -790,7 +790,7 @@ msgstr ""
 "Adresse oder Passwort falsch?"
 
 #: export_handler.cc:503 export_handler.cc:506
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr "beim Schreiben einer TOC/CUE Datei trat ein Fehler auf:%1"
 
 #: export_handler.cc:796 export_handler.cc:854

--- a/libs/ardour/po/el.po
+++ b/libs/ardour/po/el.po
@@ -581,7 +581,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr ""
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/en_GB.po
+++ b/libs/ardour/po/en_GB.po
@@ -577,7 +577,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr ""
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/es.po
+++ b/libs/ardour/po/es.po
@@ -581,7 +581,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr ""
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/fr.po
+++ b/libs/ardour/po/fr.po
@@ -601,7 +601,7 @@ msgstr ""
 "de CD"
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr "Erreur lors de l'écriture du fichier TOC/CUE : %1"
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/it.po
+++ b/libs/ardour/po/it.po
@@ -569,7 +569,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr ""
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/nn.po
+++ b/libs/ardour/po/nn.po
@@ -586,7 +586,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr "Redigering: greier ikkje opna \"%1\" som eksportfil for CD-markørfil"
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/pl.po
+++ b/libs/ardour/po/pl.po
@@ -564,7 +564,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr ""
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/ardour/po/ru.po
+++ b/libs/ardour/po/ru.po
@@ -792,7 +792,7 @@ msgstr ""
 "пароль неверны.\n"
 
 #: export_handler.cc:503 export_handler.cc:506
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr "Произошла ошибка при записи TOC/CUE файла: %1"
 
 #: export_handler.cc:796 export_handler.cc:854

--- a/libs/ardour/po/sv.po
+++ b/libs/ardour/po/sv.po
@@ -564,7 +564,7 @@ msgid "Editor: cannot open \"%1\" as export file for CD marker file"
 msgstr ""
 
 #: export_handler.cc:492 export_handler.cc:495
-msgid "an error occured while writing a TOC/CUE file: %1"
+msgid "an error occurred while writing a TOC/CUE file: %1"
 msgstr ""
 
 #: export_handler.cc:744 export_handler.cc:802

--- a/libs/audiographer/src/general/sr_converter.cc
+++ b/libs/audiographer/src/general/sr_converter.cc
@@ -89,7 +89,7 @@ SampleRateConverter::allocate_buffers (framecnt_t max_frames)
 		max_leftover_frames = 4 * max_frames;
 		leftover_data = (float *) realloc (leftover_data, max_leftover_frames * sizeof (float));
 		if (throw_level (ThrowObject) && !leftover_data) {
-			throw Exception (*this, "A memory allocation error occured");
+			throw Exception (*this, "A memory allocation error occurred");
 		}
 
 		max_frames_in = max_frames;
@@ -164,7 +164,7 @@ SampleRateConverter::process (ProcessContext<float> const & c)
 		err = src_process (src_state, &src_data);
 		if (throw_level (ThrowProcess) && err) {
 			throw Exception (*this, str (format
-			("An error occured during sample rate conversion: %1%")
+			("An error occurred during sample rate conversion: %1%")
 			% src_strerror (err)));
 		}
 

--- a/libs/canvas/canvas.cc
+++ b/libs/canvas/canvas.cc
@@ -1161,7 +1161,7 @@ GtkCanvas::start_tooltip_timeout (Item* item)
 bool
 GtkCanvas::really_start_tooltip_timeout ()
 {
-	/* an idle has occured since we entered a tooltip-bearing widget. Now
+	/* an idle has occurred since we entered a tooltip-bearing widget. Now
 	 * wait 1 second and if the timeout isn't cancelled, show the tooltip.
 	 */
 

--- a/libs/midi++2/parser.cc
+++ b/libs/midi++2/parser.cc
@@ -100,7 +100,7 @@ Parser::midi_event_type_name (eventType t)
 		return "active sense";
 
 	default:
-		return "unknow MIDI event type";
+		return "unknown MIDI event type";
 	}
 }
 

--- a/libs/pbd/msvc/msvc_poll.cc
+++ b/libs/pbd/msvc/msvc_poll.cc
@@ -71,7 +71,7 @@ int   ret = 0;
 
 					if (0 > pos)
 					{
-						// An error occured ('errno' should have been set by '_tell()')
+						// An error occurred ('errno' should have been set by '_tell()')
 						ret = (-1);
 						fds[loop].revents = POLLERR;
 						if (fds[loop].events & POLLRDNORM)

--- a/tools/jacktest.c
+++ b/tools/jacktest.c
@@ -10,7 +10,7 @@ jack_port_t *input_port;
 jack_port_t *output_port;
 jack_client_t *client;
 int loopsize = 25000;
-int xrun_occured = 0;
+int xrun_occurred = 0;
 int consecutive_xruns = 0;
 float first_xrun = 0.0f;
 float last_load = 0.0f;
@@ -59,14 +59,14 @@ process (jack_nframes_t nframes, void *arg)
 		printf ("loopsize = %d\n", loopsize);
 	}
 
-	if (xrun_occured) {
+	if (xrun_occurred) {
 		if (consecutive_xruns == 0) {
 			first_xrun = last_load;
 		}
 		consecutive_xruns++;
 	}
 
-	xrun_occured = 0;
+	xrun_occurred = 0;
 
 	if (consecutive_xruns >= 10) {
 		fprintf (stderr, "Stopping with load = %f (first xrun at %f)\n", last_load, first_xrun);
@@ -90,8 +90,8 @@ jack_shutdown (void *arg)
 int
 jack_xrun (void *arg)
 {
-	fprintf (stderr, "xrun occured with loop size = %d\n", loopsize);
-	xrun_occured = 1;
+	fprintf (stderr, "xrun occurred with loop size = %d\n", loopsize);
+	xrun_occurred = 1;
 	return 0;
 }
 


### PR DESCRIPTION
Patch taken (and forward-ported to HEAD) from
<https://anonscm.debian.org/cgit/pkg-multimedia/ardour.git/plain/debian/patches/0100-fix-typos.patch>