### PR TITLE
Fixes preferences context menu not being shown

### DIFF
--- a/gtk2_ardour/ardour.menus.in
+++ b/gtk2_ardour/ardour.menus.in
@@ -601,7 +601,7 @@
           <menuitem action='detach-mixer'/>
   </popup>
 
-  <popup action="prefsTabbableButtonMenu">
+  <popup action="preferencesTabbableButtonMenu">
           <menuitem action='show-preferences'/>
           <menuitem action='hide-preferences'/>
           <menuitem action='attach-preferences'/>


### PR DESCRIPTION
The preferences button of the new "tabbed" feature did not show the context menu. The preferences dialog could not be reattached. This PR fixes it. 