### PR TITLE
Bugfix/invalid read on new session

### DIFF
--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -432,6 +432,8 @@ Mixer_UI::add_strips (RouteList& routes)
 		}
 
 	} catch (const std::exception& e) {
+		// this should never happen as it leaks memory and leaves connections established
+		assert(false);
 		error << string_compose (_("Error adding GUI elements for new tracks/busses %1"), e.what()) << endmsg;
 	}
 

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -432,8 +432,6 @@ Mixer_UI::add_strips (RouteList& routes)
 		}
 
 	} catch (const std::exception& e) {
-		// this should never happen as it leaks memory and leaves connections established
-		assert(false);
 		error << string_compose (_("Error adding GUI elements for new tracks/busses %1"), e.what()) << endmsg;
 	}
 

--- a/gtk2_ardour/monitor_section.cc
+++ b/gtk2_ardour/monitor_section.cc
@@ -185,8 +185,8 @@ MonitorSection::MonitorSection (Session* s)
 	toggle_processorbox_button.set_name (X_("monitor section processors toggle"));
 	set_tooltip (&toggle_processorbox_button, _("Allow one to add monitor effect processors"));
 
-	proctoggle = myactions.register_toggle_action (monitor_actions, "toggle-monitor-processor-box", _("Toggle Monitor Section Processor Box"),
-	                                               sigc::mem_fun(*this, &MonitorSection::update_processor_box));
+	proctoggle = ActionManager::get_action (X_("Monitor"), X_("toggle-monitor-processor-box"));
+	assert(proctoggle);
 	toggle_processorbox_button.set_related_action (proctoggle);
 
 	/* Knobs */
@@ -910,6 +910,9 @@ MonitorSection::register_actions ()
 			sigc::mem_fun (*this, &MonitorSection::solo_use_afl));
 	myactions.register_radio_action (solo_actions, solo_group, "solo-use-pfl", _("Pre Fade Listen (PFL) solo"),
 			sigc::mem_fun (*this, &MonitorSection::solo_use_pfl));
+
+	proctoggle = myactions.register_toggle_action (monitor_actions, "toggle-monitor-processor-box", _("Toggle Monitor Section Processor Box"),
+			sigc::mem_fun(*this, &MonitorSection::update_processor_box));
 }
 
 void

--- a/gtk2_ardour/monitor_section.cc
+++ b/gtk2_ardour/monitor_section.cc
@@ -186,7 +186,6 @@ MonitorSection::MonitorSection (Session* s)
 	set_tooltip (&toggle_processorbox_button, _("Allow one to add monitor effect processors"));
 
 	proctoggle = ActionManager::get_action (X_("Monitor"), X_("toggle-monitor-processor-box"));
-	assert(proctoggle);
 	toggle_processorbox_button.set_related_action (proctoggle);
 
 	/* Knobs */
@@ -911,7 +910,7 @@ MonitorSection::register_actions ()
 	myactions.register_radio_action (solo_actions, solo_group, "solo-use-pfl", _("Pre Fade Listen (PFL) solo"),
 			sigc::mem_fun (*this, &MonitorSection::solo_use_pfl));
 
-	proctoggle = myactions.register_toggle_action (monitor_actions, "toggle-monitor-processor-box", _("Toggle Monitor Section Processor Box"),
+	myactions.register_toggle_action (monitor_actions, "toggle-monitor-processor-box", _("Toggle Monitor Section Processor Box"),
 			sigc::mem_fun(*this, &MonitorSection::update_processor_box));
 }
 


### PR DESCRIPTION
This fixes an invalid access (via Timer -> ProcessorEntry::Control::slider_adjusted () ->  AutomationControl::get_value) to a now longer existing session. 
The monitor section failed to instantiate upon opening the 2nd session due to an exception that occurred when registering the monitor actions (action already registered). |monitor_actions| has static storage-class and must be initialized only once. 