### PR TITLE
Keyeditor improvements

### DIFF
--- a/gtk2_ardour/ardour_ui_ed.cc
+++ b/gtk2_ardour/ardour_ui_ed.cc
@@ -530,7 +530,7 @@ ARDOUR_UI::install_actions ()
 	shuttle_actions->add (Action::create (X_("SetShuttleUnitsPercentage"), _("Percentage")), hide_return (sigc::bind (sigc::mem_fun (*Config, &RCConfiguration::set_shuttle_units), Percentage)));
 	shuttle_actions->add (Action::create (X_("SetShuttleUnitsSemitones"), _("Semitones")), hide_return (sigc::bind (sigc::mem_fun (*Config, &RCConfiguration::set_shuttle_units), Semitones)));
 
-	Glib::RefPtr<ActionGroup> option_actions = global_actions.create_action_group ("options");
+	Glib::RefPtr<ActionGroup> option_actions = global_actions.create_action_group ("Options");
 
 	act = global_actions.register_toggle_action (option_actions, X_("SendMTC"), _("Send MTC"), sigc::mem_fun (*this, &ARDOUR_UI::toggle_send_mtc));
 	ActionManager::session_sensitive_actions.push_back (act);

--- a/gtk2_ardour/ardour_ui_options.cc
+++ b/gtk2_ardour/ardour_ui_options.cc
@@ -83,31 +83,31 @@ ARDOUR_UI::toggle_time_master ()
 void
 ARDOUR_UI::toggle_send_mtc ()
 {
-	ActionManager::toggle_config_state ("options", "SendMTC", &RCConfiguration::set_send_mtc, &RCConfiguration::get_send_mtc);
+	ActionManager::toggle_config_state ("Options", "SendMTC", &RCConfiguration::set_send_mtc, &RCConfiguration::get_send_mtc);
 }
 
 void
 ARDOUR_UI::toggle_send_mmc ()
 {
-	ActionManager::toggle_config_state ("options", "SendMMC", &RCConfiguration::set_send_mmc, &RCConfiguration::get_send_mmc);
+	ActionManager::toggle_config_state ("Options", "SendMMC", &RCConfiguration::set_send_mmc, &RCConfiguration::get_send_mmc);
 }
 
 void
 ARDOUR_UI::toggle_send_midi_clock ()
 {
-	ActionManager::toggle_config_state ("options", "SendMidiClock", &RCConfiguration::set_send_midi_clock, &RCConfiguration::get_send_midi_clock);
+	ActionManager::toggle_config_state ("Options", "SendMidiClock", &RCConfiguration::set_send_midi_clock, &RCConfiguration::get_send_midi_clock);
 }
 
 void
 ARDOUR_UI::toggle_use_mmc ()
 {
-	ActionManager::toggle_config_state ("options", "UseMMC", &RCConfiguration::set_mmc_control, &RCConfiguration::get_mmc_control);
+	ActionManager::toggle_config_state ("Options", "UseMMC", &RCConfiguration::set_mmc_control, &RCConfiguration::get_mmc_control);
 }
 
 void
 ARDOUR_UI::toggle_send_midi_feedback ()
 {
-	ActionManager::toggle_config_state ("options", "SendMIDIfeedback", &RCConfiguration::set_midi_feedback, &RCConfiguration::get_midi_feedback);
+	ActionManager::toggle_config_state ("Options", "SendMIDIfeedback", &RCConfiguration::set_midi_feedback, &RCConfiguration::get_midi_feedback);
 }
 
 void
@@ -332,16 +332,16 @@ ARDOUR_UI::parameter_changed (std::string p)
 
 	} else if (p == "send-mtc") {
 
-		ActionManager::map_some_state ("options", "SendMTC", &RCConfiguration::get_send_mtc);
+		ActionManager::map_some_state ("Options", "SendMTC", &RCConfiguration::get_send_mtc);
 
 	} else if (p == "send-mmc") {
 
-		ActionManager::map_some_state ("options", "SendMMC", &RCConfiguration::get_send_mmc);
+		ActionManager::map_some_state ("Options", "SendMMC", &RCConfiguration::get_send_mmc);
 
 	} else if (p == "mmc-control") {
-		ActionManager::map_some_state ("options", "UseMMC", &RCConfiguration::get_mmc_control);
+		ActionManager::map_some_state ("Options", "UseMMC", &RCConfiguration::get_mmc_control);
 	} else if (p == "midi-feedback") {
-		ActionManager::map_some_state ("options", "SendMIDIfeedback", &RCConfiguration::get_midi_feedback);
+		ActionManager::map_some_state ("Options", "SendMIDIfeedback", &RCConfiguration::get_midi_feedback);
 	} else if (p == "auto-play") {
 		ActionManager::map_some_state ("Transport", "ToggleAutoPlay", sigc::mem_fun (_session->config, &SessionConfiguration::get_auto_play));
 	} else if (p == "auto-return") {

--- a/gtk2_ardour/keyeditor.h
+++ b/gtk2_ardour/keyeditor.h
@@ -55,6 +55,8 @@ class KeyEditor : public ArdourWindow
 		void unbind ();
 		void bind (GdkEventKey* release_event, guint pressed_key);
 		void action_selected ();
+		void sort_column_changed ();
+		void tab_mapped ();
 
 		struct KeyEditorColumns : public Gtk::TreeModel::ColumnRecord {
 			KeyEditorColumns () {
@@ -104,6 +106,10 @@ class KeyEditor : public ArdourWindow
 	void unbind ();
 	void reset ();
 	void page_change (GtkNotebookPage*, guint);
+
+	unsigned int sort_column;
+	Gtk::SortType sort_type;
+	void toggle_sort_type ();
 };
 
 #endif /* __ardour_gtk_key_editor_h__ */

--- a/libs/gtkmm2ext/gtkmm2ext/bindings.h
+++ b/libs/gtkmm2ext/gtkmm2ext/bindings.h
@@ -136,7 +136,7 @@ class LIBGTKMM2EXT_API ActionMap {
 };
 
 class LIBGTKMM2EXT_API Bindings {
-  public:
+	public:
         enum Operation {
                 Press,
                 Release
@@ -148,6 +148,7 @@ class LIBGTKMM2EXT_API Bindings {
 	        std::string action_name;
 	        Glib::RefPtr<Gtk::Action> action;
         };
+		typedef std::map<KeyboardKey,ActionInfo> KeybindingMap;
 
         Bindings (std::string const& name);
         ~Bindings ();
@@ -161,16 +162,18 @@ class LIBGTKMM2EXT_API Bindings {
         bool empty_keys () const;
         bool empty_mouse () const;
 
-        void add (KeyboardKey, Operation, std::string const&, bool can_save = false);
+        bool add (KeyboardKey, Operation, std::string const&, bool can_save = false);
         bool replace (KeyboardKey, Operation, std::string const& action_name, bool can_save = true);
-        void remove (KeyboardKey, Operation, bool can_save = false);
-        void remove (Glib::RefPtr<Gtk::Action>, Operation, bool can_save = false);
+        bool remove (Operation, std::string const& action_name, bool can_save = false);
 
         bool activate (KeyboardKey, Operation);
 
         void add (MouseButton, Operation, std::string const&);
         void remove (MouseButton, Operation);
         bool activate (MouseButton, Operation);
+
+		bool is_bound (KeyboardKey const&, Operation) const;
+		bool is_registered (Operation op, std::string const& action_name) const;
 
         KeyboardKey get_binding_for_action (Glib::RefPtr<Gtk::Action>, Operation& op);
 
@@ -209,9 +212,7 @@ class LIBGTKMM2EXT_API Bindings {
 
 	static PBD::Signal1<void,Bindings*> BindingsChanged;
 
-  private:
-        typedef std::map<KeyboardKey,ActionInfo> KeybindingMap;
-
+	private:
         std::string  _name;
         ActionMap*   _action_map;
         KeybindingMap press_bindings;
@@ -222,6 +223,10 @@ class LIBGTKMM2EXT_API Bindings {
         MouseButtonBindingMap button_release_bindings;
 
         void push_to_gtk (KeyboardKey, Glib::RefPtr<Gtk::Action>);
+
+		KeybindingMap& get_keymap (Operation op);
+		const KeybindingMap& get_keymap (Operation op) const;
+		MouseButtonBindingMap& get_mousemap (Operation op);
 };
 
 } // namespace


### PR DESCRIPTION
This PR:
- fixes a minor typo in one of the action groups
- adds sorting to the keybinding editor for both columns
- fixes a bug that prevents removing newly created bindings (to reproduce: add a binding, remove it, 
restart ardour, binding is still there but can now be deleted properly)
- adds a dialog for colliding keybindings

TODO:
A few things I'd like to do in the near future
- the indentation in bindings.* is messy. I'd like to create a NOP commit / PR to fix this
- allow alternate keybindings (as separate column, probably just 1) and remove the *-alt actions
- filtering in keyeditor
- find a way to display the multiple [show, attach, detach, etc.] entries in keyeditor properly

Please comment if there are any thoughts about the TODO list :) 