### PR TITLE
Strip silence issues

### DIFF
--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -5160,12 +5160,13 @@ Editor::strip_region_silence ()
 	StripSilenceDialog d (_session, audio_only);
 	int const r = d.run ();
 
-        d.drop_rects ();
+	d.drop_rects ();
 
-        if (r == Gtk::RESPONSE_OK) {
-                ARDOUR::AudioIntervalMap silences;
-                d.silences (silences);
+	if (r == Gtk::RESPONSE_OK) {
+		ARDOUR::AudioIntervalMap silences;
+		d.silences (silences);
 		StripSilence s (*_session, silences, d.fade_length());
+
 		apply_filter (s, _("strip silence"), &d);
 	}
 }
@@ -5440,6 +5441,11 @@ Editor::apply_filter (Filter& filter, string command, ProgressReporter* progress
 				playlist->clear_changes ();
 				playlist->clear_owned_changes ();
 
+				if (!in_command) {
+					begin_reversible_command (command);
+					in_command = true;
+				}
+
 				if (filter.results.empty ()) {
 
 					/* no regions returned; remove the old one */
@@ -5460,14 +5466,10 @@ Editor::apply_filter (Filter& filter, string command, ProgressReporter* progress
 					}
 
 				}
+
 				/* We might have removed regions, which alters other regions' layering_index,
 				   so we need to do a recursive diff here.
 				*/
-
-				if (!in_command) {
-					begin_reversible_command (command);
-					in_command = true;
-				}
 				vector<Command*> cmds;
 				playlist->rdiff (cmds);
 				_session->add_commands (cmds);

--- a/libs/ardour/audioregion.cc
+++ b/libs/ardour/audioregion.cc
@@ -1817,11 +1817,13 @@ AudioRegion::find_silence (Sample threshold, framecnt_t min_length, framecnt_t f
 	while (pos < end && !itt.cancel) {
 
 		framecnt_t cur_samples = 0;
+		framecnt_t const to_read = min (end - pos, block_size);
 		/* fill `loudest' with the loudest absolute sample at each instant, across all channels */
 		memset (loudest.get(), 0, sizeof (Sample) * block_size);
+
 		for (uint32_t n = 0; n < n_channels(); ++n) {
 
-			cur_samples = read_raw_internal (buf.get(), pos, block_size, n);
+			cur_samples = read_raw_internal (buf.get(), pos, to_read, n);
 			for (framecnt_t i = 0; i < cur_samples; ++i) {
 				loudest[i] = max (loudest[i], abs (buf[i]));
 			}


### PR DESCRIPTION
Proposed fixes for issues:

- #0006803: Assertion failed/core dump in Strip Silence dialog
- #0006806: Strip Silence dialog incorrectly splits regions.