### PR TITLE
Improved pop up menu display in editor regions list

### DIFF
--- a/gtk2_ardour/editor_regions.cc
+++ b/gtk2_ardour/editor_regions.cc
@@ -189,6 +189,7 @@ EditorRegions::EditorRegions (Editor* e)
 	_display.get_selection()->set_mode (SELECTION_MULTIPLE);
 	_display.add_object_drag (_columns.region.index(), "regions");
 	_display.set_drag_column (_columns.name.index());
+	_display.set_drag_button_mask(Gdk::BUTTON1_MASK);
 
 	/* setup DnD handling */
 
@@ -995,6 +996,8 @@ EditorRegions::set_full (bool f)
 void
 EditorRegions::show_context_menu (int button, int time)
 {
+	_editor->_drags->abort ();
+
 	if (_menu == 0) {
 		_menu = dynamic_cast<Menu*> (ActionManager::get_widget ("/RegionListMenu"));
 	}

--- a/gtk2_ardour/editor_regions.h
+++ b/gtk2_ardour/editor_regions.h
@@ -127,9 +127,9 @@ private:
 
 	bool selection_filter (const Glib::RefPtr<Gtk::TreeModel>& model, const Gtk::TreeModel::Path& path, bool yn);
 
-        Gtk::Widget* old_focus;
-        Gtk::CellEditable* name_editable;
-        void name_editing_started (Gtk::CellEditable*, const Glib::ustring&);
+	Gtk::Widget* old_focus;
+	Gtk::CellEditable* name_editable;
+	void name_editing_started (Gtk::CellEditable*, const Glib::ustring&);
 
 	void name_edit (const std::string&, const std::string&);
 	void locked_changed (std::string const &);
@@ -140,33 +140,33 @@ private:
 	bool key_press (GdkEventKey *);
 	bool button_press (GdkEventButton *);
 
-        bool focus_in (GdkEventFocus*);
-        bool focus_out (GdkEventFocus*);
-        bool enter_notify (GdkEventCrossing*);
-        bool leave_notify (GdkEventCrossing*);
+	bool focus_in (GdkEventFocus*);
+	bool focus_out (GdkEventFocus*);
+	bool enter_notify (GdkEventCrossing*);
+	bool leave_notify (GdkEventCrossing*);
 
 	void show_context_menu (int button, int time);
 
 	int sorter (Gtk::TreeModel::iterator, Gtk::TreeModel::iterator);
 
-        void format_position (ARDOUR::framepos_t pos, char* buf, size_t bufsize, bool onoff = true);
+	void format_position (ARDOUR::framepos_t pos, char* buf, size_t bufsize, bool onoff = true);
 
 	void add_region (boost::shared_ptr<ARDOUR::Region>);
 
 	void populate_row (boost::shared_ptr<ARDOUR::Region>, Gtk::TreeModel::Row const &);
-        void populate_row_used (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_position (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_end (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_sync (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_fade_in (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used, boost::shared_ptr<ARDOUR::AudioRegion>);
-        void populate_row_fade_out (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used, boost::shared_ptr<ARDOUR::AudioRegion>);
-        void populate_row_locked (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_muted (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_glued (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_opaque (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
-        void populate_row_length (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row);
-        void populate_row_name (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row);
-        void populate_row_source (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row);
+	void populate_row_used (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_position (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_end (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_sync (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_fade_in (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used, boost::shared_ptr<ARDOUR::AudioRegion>);
+	void populate_row_fade_out (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used, boost::shared_ptr<ARDOUR::AudioRegion>);
+	void populate_row_locked (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_muted (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_glued (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_opaque (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row, uint32_t used);
+	void populate_row_length (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row);
+	void populate_row_name (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row);
+	void populate_row_source (boost::shared_ptr<ARDOUR::Region> region, Gtk::TreeModel::Row const& row);
 
 	void update_row (boost::shared_ptr<ARDOUR::Region>);
 	void update_all_rows ();
@@ -215,7 +215,7 @@ private:
 	PBD::ScopedConnection editor_freeze_connection;
 	PBD::ScopedConnection editor_thaw_connection;
 
-        bool expanded;
+	bool expanded;
 };
 
 #endif /* __gtk_ardour_editor_regions_h__ */

--- a/libs/gtkmm2ext/dndtreeview.cc
+++ b/libs/gtkmm2ext/dndtreeview.cc
@@ -34,11 +34,12 @@ DnDTreeViewBase::DragData DnDTreeViewBase::drag_data;
 DnDTreeViewBase::DnDTreeViewBase ()
 	: TreeView ()
 	, _drag_column (-1)
+	, _drag_button_mask(Gdk::MODIFIER_MASK)
 {
 	draggable.push_back (TargetEntry ("GTK_TREE_MODEL_ROW", TARGET_SAME_WIDGET));
 	data_column = -1;
 
-	enable_model_drag_source (draggable);
+	enable_model_drag_source (draggable, _drag_button_mask);
 	enable_model_drag_dest (draggable);
 
  	suggested_action = Gdk::DragAction (0);
@@ -119,7 +120,7 @@ DnDTreeViewBase::add_drop_targets (list<TargetEntry>& targets)
 		draggable.push_back (*i);
 	}
 
-	enable_model_drag_source (draggable);
+	enable_model_drag_source (draggable, _drag_button_mask);
 	enable_model_drag_dest (draggable);
 }
 
@@ -130,7 +131,7 @@ DnDTreeViewBase::add_object_drag (int column, string type_name)
 	data_column = column;
 	object_type = type_name;
 
-	enable_model_drag_source (draggable);
+	enable_model_drag_source (draggable, _drag_button_mask);
 	enable_model_drag_dest (draggable);
 }
 
@@ -142,4 +143,9 @@ DnDTreeViewBase::on_drag_drop(const Glib::RefPtr<Gdk::DragContext>& context, int
 	return TreeView::on_drag_drop (context, x, y, time);
 }
 
+void DnDTreeViewBase::set_drag_button_mask(Gdk::ModifierType mask)
+{
+	_drag_button_mask = mask;
+	enable_model_drag_source (draggable, _drag_button_mask);
+}
 

--- a/libs/gtkmm2ext/gtkmm2ext/dndtreeview.h
+++ b/libs/gtkmm2ext/gtkmm2ext/dndtreeview.h
@@ -73,6 +73,8 @@ class LIBGTKMM2EXT_API DnDTreeViewBase : public Gtk::TreeView
 		_drag_column = c;
 	}
 
+	void set_drag_button_mask(Gdk::ModifierType mask);
+
   protected:
 	std::list<Gtk::TargetEntry> draggable;
 	Gdk::DragAction             suggested_action;
@@ -82,6 +84,7 @@ class LIBGTKMM2EXT_API DnDTreeViewBase : public Gtk::TreeView
 	double press_start_x;
 	double press_start_y;
 	int _drag_column;
+	Gdk::ModifierType _drag_button_mask;
 
 	struct DragData {
 	    DragData () : source (0) {}


### PR DESCRIPTION
- Proposed fix for regions list drag and drop
After right-click on the regions list pop up menu appears in the middle of drag and drop operation and executing "remove unused" regions can't be accomplished with a mouse.

- Some whitespace corrections