### PR TITLE
Formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,25 @@
+﻿---
+
+Language: Cpp
+AlignAfterOpenBracket: 'true'
+AlignTrailingComments: 'true'
+AlwaysBreakTemplateDeclarations: 'true'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: 'true'
+BasedOnStyle: LLVM
+BreakBeforeBraces: 'Linux'
+BreakConstructorInitializersBeforeComma: 'true'
+ColumnLimit: '100'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+IndentCaseLabels: 'false'
+NamespaceIndentation: 'None'
+PenaltyReturnTypeOnItsOwnLine: '1'
+PointerAlignment: Left
+SpaceBeforeParens: Always
+TabWidth: '2'
+UseTab: ForIndentation
+

--- a/libs/gtkmm2ext/bindings.cc
+++ b/libs/gtkmm2ext/bindings.cc
@@ -1,20 +1,19 @@
 /*
-    Copyright (C) 2012 Paul Davis
+  Copyright (C) 2012 Paul Davis
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation; either version 2 of the License, or
-    (at your option) any later version.
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 */
 
 #include <iostream>
@@ -42,267 +41,261 @@ using namespace Gtk;
 using namespace Gtkmm2ext;
 using namespace PBD;
 
-list<Bindings*> Bindings::bindings; /* global. Gulp */
+list<Bindings*> Bindings::bindings;      /* global. Gulp */
 list<ActionMap*> ActionMap::action_maps; /* global. Gulp */
-PBD::Signal1<void,Bindings*> Bindings::BindingsChanged;
-
+PBD::Signal1<void, Bindings*> Bindings::BindingsChanged;
 
 /*============================ ActionNameRegistered ===========================*/
 template <typename IteratorValueType>
-struct ActionNameRegistered
-{
-	ActionNameRegistered(std::string const& name)
-	: action_name(name)
-	{}
+struct ActionNameRegistered {
+	ActionNameRegistered (std::string const& name) : action_name (name) {}
 
-	bool operator()(IteratorValueType elem) const {
-		return elem.second.action_name == action_name;
-	}
+	bool operator() (IteratorValueType elem) const { return elem.second.action_name == action_name; }
 	std::string const& action_name;
 };
 
 /*================================ MouseButton ================================*/
 MouseButton::MouseButton (uint32_t state, uint32_t keycode)
 {
-        uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
+	uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
 
-        /* this is a slightly wierd test that relies on
-         * gdk_keyval_is_{upper,lower}() returning true for keys that have no
-         * case-sensitivity. This covers mostly non-alphanumeric keys.
-         */
+	/* this is a slightly wierd test that relies on
+	 * gdk_keyval_is_{upper,lower}() returning true for keys that have no
+	 * case-sensitivity. This covers mostly non-alphanumeric keys.
+	 */
 
-        if (gdk_keyval_is_upper (keycode) && gdk_keyval_is_lower (keycode)) {
-                /* key is not subject to case, so ignore SHIFT
-                 */
-                ignore |= GDK_SHIFT_MASK;
-        }
+	if (gdk_keyval_is_upper (keycode) && gdk_keyval_is_lower (keycode)) {
+		/* key is not subject to case, so ignore SHIFT */
+		ignore |= GDK_SHIFT_MASK;
+	}
 
-        _val = (state & ~ignore);
-        _val <<= 32;
-        _val |= keycode;
+	_val = (state & ~ignore);
+	_val <<= 32;
+	_val |= keycode;
 };
 
 bool
 MouseButton::make_button (const string& str, MouseButton& b)
 {
-        int s = 0;
+	int s = 0;
 
-        if (str.find ("Primary") != string::npos) {
-                s |= Keyboard::PrimaryModifier;
-        }
+	if (str.find ("Primary") != string::npos) {
+		s |= Keyboard::PrimaryModifier;
+	}
 
-        if (str.find ("Secondary") != string::npos) {
-                s |= Keyboard::SecondaryModifier;
-        }
+	if (str.find ("Secondary") != string::npos) {
+		s |= Keyboard::SecondaryModifier;
+	}
 
-        if (str.find ("Tertiary") != string::npos) {
-                s |= Keyboard::TertiaryModifier;
-        }
+	if (str.find ("Tertiary") != string::npos) {
+		s |= Keyboard::TertiaryModifier;
+	}
 
-        if (str.find ("Level4") != string::npos) {
-                s |= Keyboard::Level4Modifier;
-        }
+	if (str.find ("Level4") != string::npos) {
+		s |= Keyboard::Level4Modifier;
+	}
 
-        string::size_type lastmod = str.find_last_of ('-');
-        uint32_t button_number;
+	string::size_type lastmod = str.find_last_of ('-');
+	uint32_t button_number;
 
-        if (lastmod == string::npos) {
-                button_number = PBD::atoi (str);
-        } else {
-                button_number = PBD::atoi (str.substr (lastmod+1));
-        }
+	if (lastmod == string::npos) {
+		button_number = PBD::atoi (str);
+	} else {
+		button_number = PBD::atoi (str.substr (lastmod + 1));
+	}
 
-        b = MouseButton (s, button_number);
-        return true;
+	b = MouseButton (s, button_number);
+	return true;
 }
 
 string
 MouseButton::name () const
 {
-        int s = state();
+	int s = state ();
 
-        string str;
+	string str;
 
-        if (s & Keyboard::PrimaryModifier) {
-                str += "Primary";
-        }
-        if (s & Keyboard::SecondaryModifier) {
-                if (!str.empty()) {
-                        str += '-';
-                }
-                str += "Secondary";
-        }
-        if (s & Keyboard::TertiaryModifier) {
-                if (!str.empty()) {
-                        str += '-';
-                }
-                str += "Tertiary";
-        }
-        if (s & Keyboard::Level4Modifier) {
-                if (!str.empty()) {
-                        str += '-';
-                }
-                str += "Level4";
-        }
+	if (s & Keyboard::PrimaryModifier) {
+		str += "Primary";
+	}
 
-        if (!str.empty()) {
-                str += '-';
-        }
+	if (s & Keyboard::SecondaryModifier) {
+		if (!str.empty ()) {
+			str += '-';
+		}
+		str += "Secondary";
+	}
 
-        char buf[16];
-        snprintf (buf, sizeof (buf), "%u", button());
-        str += buf;
+	if (s & Keyboard::TertiaryModifier) {
+		if (!str.empty ()) {
+			str += '-';
+		}
+		str += "Tertiary";
+	}
 
-        return str;
+	if (s & Keyboard::Level4Modifier) {
+		if (!str.empty ()) {
+			str += '-';
+		}
+		str += "Level4";
+	}
+
+	if (!str.empty ()) {
+		str += '-';
+	}
+
+	char buf[16];
+	snprintf (buf, sizeof (buf), "%u", button ());
+	str += buf;
+
+	return str;
 }
 
 /*================================ KeyboardKey ================================*/
 KeyboardKey::KeyboardKey (uint32_t state, uint32_t keycode)
 {
-        uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
+	uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
 
-        _val = (state & ~ignore);
-        _val <<= 32;
-        _val |= keycode;
+	_val = (state & ~ignore);
+	_val <<= 32;
+	_val |= keycode;
 }
 
 string
 KeyboardKey::display_label () const
 {
-	if (key() == 0) {
-		return string();
+	if (key () == 0) {
+		return string ();
 	}
 
 	/* This magically returns a string that will display the right thing
 	 *  on all platforms, notably the command key on OS X.
 	 */
 
-        uint32_t mod = state();
+	uint32_t mod = state ();
 
 #ifdef __APPLE__
-                /* We use both bits (MOD2|META) for Primary on OS X,
-                 * but we don't want MOD2 showing up in listings.
-                 */
+	/* We use both bits (MOD2|META) for Primary on OS X,
+	 * but we don't want MOD2 showing up in listings.
+	 */
 
-                if (mod & GDK_MOD2_MASK) {
-                        mod &= ~GDK_MOD2_MASK;
-                }
+	if (mod & GDK_MOD2_MASK) {
+		mod &= ~GDK_MOD2_MASK;
+	}
 #endif
 
-	return gtk_accelerator_get_label (key(), (GdkModifierType) mod);
+	return gtk_accelerator_get_label (key (), (GdkModifierType)mod);
 }
 
 string
 KeyboardKey::name () const
 {
-        int s = state();
+	int s = state ();
 
-        string str;
+	string str;
 
-        if (s & Keyboard::PrimaryModifier) {
-                str += "Primary";
-        }
-        if (s & Keyboard::SecondaryModifier) {
-                if (!str.empty()) {
-                        str += '-';
-                }
-                str += "Secondary";
-        }
-        if (s & Keyboard::TertiaryModifier) {
-                if (!str.empty()) {
-                        str += '-';
-                }
-                str += "Tertiary";
-        }
-        if (s & Keyboard::Level4Modifier) {
-                if (!str.empty()) {
-                        str += '-';
-                }
-                str += "Level4";
-        }
+	if (s & Keyboard::PrimaryModifier) {
+		str += "Primary";
+	}
 
-        if (!str.empty()) {
-                str += '-';
-        }
+	if (s & Keyboard::SecondaryModifier) {
+		if (!str.empty ()) {
+			str += '-';
+		}
+		str += "Secondary";
+	}
 
-        char const *gdk_name = gdk_keyval_name (key());
+	if (s & Keyboard::TertiaryModifier) {
+		if (!str.empty ()) {
+			str += '-';
+		}
+		str += "Tertiary";
+	}
 
-        if (gdk_name) {
-	        str += gdk_name;
-        } else {
-	        /* fail! */
-	        return string();
-        }
+	if (s & Keyboard::Level4Modifier) {
+		if (!str.empty ()) {
+			str += '-';
+		}
+		str += "Level4";
+	}
 
-        return str;
+	if (!str.empty ()) {
+		str += '-';
+	}
+
+	char const* gdk_name = gdk_keyval_name (key ());
+
+	if (gdk_name) {
+		str += gdk_name;
+	} else {
+		/* fail! */
+		return string ();
+	}
+
+	return str;
 }
 
 bool
 KeyboardKey::make_key (const string& str, KeyboardKey& k)
 {
-        int s = 0;
+	int s = 0;
 
-        if (str.find ("Primary") != string::npos) {
-                s |= Keyboard::PrimaryModifier;
-        }
+	if (str.find ("Primary") != string::npos) {
+		s |= Keyboard::PrimaryModifier;
+	}
 
-        if (str.find ("Secondary") != string::npos) {
-                s |= Keyboard::SecondaryModifier;
-        }
+	if (str.find ("Secondary") != string::npos) {
+		s |= Keyboard::SecondaryModifier;
+	}
 
-        if (str.find ("Tertiary") != string::npos) {
-                s |= Keyboard::TertiaryModifier;
-        }
+	if (str.find ("Tertiary") != string::npos) {
+		s |= Keyboard::TertiaryModifier;
+	}
 
-        if (str.find ("Level4") != string::npos) {
-                s |= Keyboard::Level4Modifier;
-        }
+	if (str.find ("Level4") != string::npos) {
+		s |= Keyboard::Level4Modifier;
+	}
 
-        /* since all SINGLE key events keycodes are changed to lower case
-         * before looking them up, make sure we only store lower case here. The
-         * Shift part will be stored in the modifier part of the KeyboardKey.
-         *
-         * And yes Mildred, this doesn't cover CapsLock cases. Oh well.
-         */
+	/* since all SINGLE key events keycodes are changed to lower case
+	 * before looking them up, make sure we only store lower case here. The
+	 * Shift part will be stored in the modifier part of the KeyboardKey.
+	 *
+	 * And yes Mildred, this doesn't cover CapsLock cases. Oh well.
+	 */
 
-        string actual;
+	string actual;
 
-        if (str.size() == 1) {
-	        actual = PBD::downcase (str);
-        } else {
-	        actual = str;
-        }
+	if (str.size () == 1) {
+		actual = PBD::downcase (str);
+	} else {
+		actual = str;
+	}
 
-        string::size_type lastmod = actual.find_last_of ('-');
-        guint keyval;
+	string::size_type lastmod = actual.find_last_of ('-');
+	guint keyval;
 
-        if (lastmod != string::npos) {
-	        actual = PBD::downcase (str.substr (lastmod+1));
-        }
+	if (lastmod != string::npos) {
+		actual = PBD::downcase (str.substr (lastmod + 1));
+	}
 
-        keyval = gdk_keyval_from_name (actual.c_str());
+	keyval = gdk_keyval_from_name (actual.c_str ());
 
-        if (keyval == GDK_VoidSymbol || keyval == 0) {
-	        return false;
-        }
+	if (keyval == GDK_VoidSymbol || keyval == 0) {
+		return false;
+	}
 
-        k = KeyboardKey (s, keyval);
+	k = KeyboardKey (s, keyval);
 
-        return true;
+	return true;
 }
 
 /*================================= Bindings =================================*/
-Bindings::Bindings (std::string const& name)
-	: _name (name)
-	, _action_map (0)
+Bindings::Bindings (std::string const& name) : _name (name), _action_map (0)
 {
 	bindings.push_back (this);
 }
 
-Bindings::~Bindings()
-{
-	bindings.remove (this);
-}
+Bindings::~Bindings () { bindings.remove (this); }
 
 string
 Bindings::ardour_action_name (RefPtr<Action> action)
@@ -316,49 +309,47 @@ Bindings::get_binding_for_action (RefPtr<Action> action, Operation& op)
 {
 	const string action_name = ardour_action_name (action);
 
-        for (KeybindingMap::iterator k = press_bindings.begin(); k != press_bindings.end(); ++k) {
+	for (KeybindingMap::iterator k = press_bindings.begin (); k != press_bindings.end (); ++k) {
 
-	        /* option one: action has already been associated with the
-	         * binding
-	         */
+		/* option one: action has already been associated with the
+		 * binding
+		 */
 
-	        if (k->second.action == action) {
-		        return k->first;
-	        }
+		if (k->second.action == action) {
+			return k->first;
+		}
 
-	        /* option two: action name matches, so lookup the action,
-	         * setup the association while we're here, and return the binding.
-	         */
+		/* option two: action name matches, so lookup the action,
+		 * setup the association while we're here, and return the binding.
+		 */
 
-	        if (_action_map && k->second.action_name == action_name) {
-		        k->second.action = _action_map->find_action (action_name);
-		        return k->first;
-	        }
+		if (_action_map && k->second.action_name == action_name) {
+			k->second.action = _action_map->find_action (action_name);
+			return k->first;
+		}
+	}
 
-        }
+	for (KeybindingMap::iterator k = release_bindings.begin (); k != release_bindings.end (); ++k) {
 
-        for (KeybindingMap::iterator k = release_bindings.begin(); k != release_bindings.end(); ++k) {
+		/* option one: action has already been associated with the
+		 * binding
+		 */
 
-	        /* option one: action has already been associated with the
-	         * binding
-	         */
+		if (k->second.action == action) {
+			return k->first;
+		}
 
-	        if (k->second.action == action) {
-		        return k->first;
-	        }
+		/* option two: action name matches, so lookup the action,
+		 * setup the association while we're here, and return the binding.
+		 */
 
-	        /* option two: action name matches, so lookup the action,
-	         * setup the association while we're here, and return the binding.
-	         */
+		if (_action_map && k->second.action_name == action_name) {
+			k->second.action = _action_map->find_action (action_name);
+			return k->first;
+		}
+	}
 
-	        if (_action_map && k->second.action_name == action_name) {
-		         k->second.action = _action_map->find_action (action_name);
-		         return k->first;
-	         }
-
-        }
-
-        return KeyboardKey::null_key();
+	return KeyboardKey::null_key ();
 }
 
 void
@@ -376,21 +367,21 @@ Bindings::set_action_map (ActionMap& actions)
 }
 
 bool
-Bindings::empty_keys() const
+Bindings::empty_keys () const
 {
-	return press_bindings.empty() && release_bindings.empty();
+	return press_bindings.empty () && release_bindings.empty ();
 }
 
 bool
 Bindings::empty_mouse () const
 {
-	return button_press_bindings.empty() && button_release_bindings.empty();
+	return button_press_bindings.empty () && button_release_bindings.empty ();
 }
 
 bool
-Bindings::empty() const
+Bindings::empty () const
 {
-	return empty_keys() && empty_mouse ();
+	return empty_keys () && empty_mouse ();
 }
 
 bool
@@ -398,40 +389,41 @@ Bindings::activate (KeyboardKey kb, Operation op)
 {
 	KeybindingMap& kbm = get_keymap (op);
 
-        /* if shift was pressed, GDK will send us (e.g) 'E' rather than 'e'.
-           Our bindings all use the lower case character/keyname, so switch
-           to the lower case before doing the lookup.
-        */
+	/* if shift was pressed, GDK will send us (e.g) 'E' rather than 'e'.
+	   Our bindings all use the lower case character/keyname, so switch
+	   to the lower case before doing the lookup.
+	*/
 
-        KeyboardKey unshifted (kb.state(), gdk_keyval_to_lower (kb.key()));
+	KeyboardKey unshifted (kb.state (), gdk_keyval_to_lower (kb.key ()));
 
-        KeybindingMap::iterator k = kbm.find (unshifted);
+	KeybindingMap::iterator k = kbm.find (unshifted);
 
-        if (k == kbm.end()) {
-                /* no entry for this key in the state map */
-	        DEBUG_TRACE (DEBUG::Bindings, string_compose ("no binding for %1\n", unshifted));
-	        return false;
-        }
+	if (k == kbm.end ()) {
+		/* no entry for this key in the state map */
+		DEBUG_TRACE (DEBUG::Bindings, string_compose ("no binding for %1\n", unshifted));
+		return false;
+	}
 
-        RefPtr<Action> action;
+	RefPtr<Action> action;
 
-        if (k->second.action) {
-	        action = k->second.action;
-        } else {
-	        if (_action_map) {
-		        action = _action_map->find_action (k->second.action_name);
-	        }
-        }
+	if (k->second.action) {
+		action = k->second.action;
+	} else {
+		if (_action_map) {
+			action = _action_map->find_action (k->second.action_name);
+		}
+	}
 
-        if (action) {
-	        /* lets do it ... */
-	        DEBUG_TRACE (DEBUG::Bindings, string_compose ("binding for %1: %2\n", unshifted, k->second.action_name));
-	        action->activate ();
-        }
+	if (action) {
+		/* lets do it ... */
+		DEBUG_TRACE (DEBUG::Bindings,
+		             string_compose ("binding for %1: %2\n", unshifted, k->second.action_name));
+		action->activate ();
+	}
 
-        /* return true even if the action could not be found */
+	/* return true even if the action could not be found */
 
-        return true;
+	return true;
 }
 
 void
@@ -443,27 +435,28 @@ Bindings::associate ()
 		return;
 	}
 
-	for (k = press_bindings.begin(); k != press_bindings.end(); ++k) {
+	for (k = press_bindings.begin (); k != press_bindings.end (); ++k) {
 		k->second.action = _action_map->find_action (k->second.action_name);
 		if (k->second.action) {
 			push_to_gtk (k->first, k->second.action);
 		} else {
-			cerr << _name << " didn't find " << k->second.action_name << " in " << _action_map->name() << endl;
+			cerr << _name << " didn't find " << k->second.action_name << " in " << _action_map->name ()
+			     << endl;
 		}
 	}
 
-	for (k = release_bindings.begin(); k != release_bindings.end(); ++k) {
+	for (k = release_bindings.begin (); k != release_bindings.end (); ++k) {
 		k->second.action = _action_map->find_action (k->second.action_name);
 		/* no working support in GTK for release bindings */
 	}
 
 	MouseButtonBindingMap::iterator b;
 
-	for (b = button_press_bindings.begin(); b != button_press_bindings.end(); ++b) {
+	for (b = button_press_bindings.begin (); b != button_press_bindings.end (); ++b) {
 		b->second.action = _action_map->find_action (b->second.action_name);
 	}
 
-	for (b = button_release_bindings.begin(); b != button_release_bindings.end(); ++b) {
+	for (b = button_release_bindings.begin (); b != button_release_bindings.end (); ++b) {
 		b->second.action = _action_map->find_action (b->second.action_name);
 	}
 }
@@ -473,10 +466,10 @@ Bindings::dissociate ()
 {
 	KeybindingMap::iterator k;
 
-	for (k = press_bindings.begin(); k != press_bindings.end(); ++k) {
+	for (k = press_bindings.begin (); k != press_bindings.end (); ++k) {
 		k->second.action.clear ();
 	}
-	for (k = release_bindings.begin(); k != release_bindings.end(); ++k) {
+	for (k = release_bindings.begin (); k != release_bindings.end (); ++k) {
 		k->second.action.clear ();
 	}
 }
@@ -484,43 +477,43 @@ Bindings::dissociate ()
 void
 Bindings::push_to_gtk (KeyboardKey kb, RefPtr<Action> what)
 {
-        /* GTK has the useful feature of showing key bindings for actions in
-         * menus. As of August 2015, we have no interest in trying to
-         * reimplement this functionality, so we will use it even though we no
-         * longer use GTK accelerators for handling key events. To do this, we
-         * need to make sure that there is a fully populated GTK AccelMap set
-         * up with all bindings/actions.
-         */
+	/* GTK has the useful feature of showing key bindings for actions in
+	 * menus. As of August 2015, we have no interest in trying to
+	 * reimplement this functionality, so we will use it even though we no
+	 * longer use GTK accelerators for handling key events. To do this, we
+	 * need to make sure that there is a fully populated GTK AccelMap set
+	 * up with all bindings/actions.
+	 */
 
 	Gtk::AccelKey gtk_key;
-	bool entry_exists = Gtk::AccelMap::lookup_entry (what->get_accel_path(), gtk_key);
+	bool entry_exists = Gtk::AccelMap::lookup_entry (what->get_accel_path (), gtk_key);
 
-        if (!entry_exists) {
+	if (!entry_exists) {
 
-	        /* there is a trick happening here. It turns out that
-	         * gtk_accel_map_add_entry() performs no validation checks on
-	         * the accelerator keyval. This means we can use it to define
-	         * ANY accelerator, even if they violate GTK's rules
-	         * (e.g. about not using navigation keys). This works ONLY when
-	         * the entry in the GTK accelerator map has not already been
-	         * added. The entries will be added by the GTK UIManager when
-	         * building menus, so this code must be called before that
-	         * happens.
-	         */
+		/* there is a trick happening here. It turns out that
+		 * gtk_accel_map_add_entry() performs no validation checks on
+		 * the accelerator keyval. This means we can use it to define
+		 * ANY accelerator, even if they violate GTK's rules
+		 * (e.g. about not using navigation keys). This works ONLY when
+		 * the entry in the GTK accelerator map has not already been
+		 * added. The entries will be added by the GTK UIManager when
+		 * building menus, so this code must be called before that
+		 * happens.
+		 */
 
-	        Gtk::AccelMap::add_entry (what->get_accel_path(), kb.key(), (Gdk::ModifierType) kb.state());
-        }
+		Gtk::AccelMap::add_entry (what->get_accel_path (), kb.key (), (Gdk::ModifierType)kb.state ());
+	}
 }
 
 bool
-Bindings::replace (KeyboardKey kb, Operation op, string const & action_name, bool can_save)
+Bindings::replace (KeyboardKey kb, Operation op, string const& action_name, bool can_save)
 {
 	if (!_action_map) {
 		return false;
 	}
 
-	if (is_registered(op, action_name)) {
-		remove(op, action_name, can_save);
+	if (is_registered (op, action_name)) {
+		remove (op, action_name, can_save);
 	}
 	add (kb, op, action_name, can_save);
 	return true;
@@ -529,7 +522,7 @@ Bindings::replace (KeyboardKey kb, Operation op, string const & action_name, boo
 bool
 Bindings::add (KeyboardKey kb, Operation op, string const& action_name, bool can_save)
 {
-	if (is_registered(op, action_name)) {
+	if (is_registered (op, action_name)) {
 		return false;
 	}
 
@@ -551,7 +544,7 @@ Bindings::remove (Operation op, std::string const& action_name, bool can_save)
 {
 	bool erased_action = false;
 	KeybindingMap& kbm = get_keymap (op);
-	for (KeybindingMap::iterator k = kbm.begin(); k != kbm.end(); ++k) {
+	for (KeybindingMap::iterator k = kbm.begin (); k != kbm.end (); ++k) {
 		if (k->second.action_name == action_name) {
 			kbm.erase (k);
 			erased_action = true;
@@ -571,181 +564,181 @@ Bindings::remove (Operation op, std::string const& action_name, bool can_save)
 	return erased_action;
 }
 
-
 bool
 Bindings::activate (MouseButton bb, Operation op)
 {
-	MouseButtonBindingMap& bbm = get_mousemap(op);
+	MouseButtonBindingMap& bbm = get_mousemap (op);
 
-        MouseButtonBindingMap::iterator b = bbm.find (bb);
+	MouseButtonBindingMap::iterator b = bbm.find (bb);
 
-        if (b == bbm.end()) {
-                /* no entry for this key in the state map */
-                return false;
-        }
+	if (b == bbm.end ()) {
+		/* no entry for this key in the state map */
+		return false;
+	}
 
-        RefPtr<Action> action;
+	RefPtr<Action> action;
 
-        if (b->second.action) {
-	        action = b->second.action;
-        } else {
-	        if (_action_map) {
-		        action = _action_map->find_action (b->second.action_name);
-	        }
-        }
+	if (b->second.action) {
+		action = b->second.action;
+	} else {
+		if (_action_map) {
+			action = _action_map->find_action (b->second.action_name);
+		}
+	}
 
-        if (action) {
-	        /* lets do it ... */
-	        DEBUG_TRACE (DEBUG::Bindings, string_compose ("activating action %1\n", ardour_action_name (action)));
-	        action->activate ();
-        }
+	if (action) {
+		/* lets do it ... */
+		DEBUG_TRACE (DEBUG::Bindings,
+		             string_compose ("activating action %1\n", ardour_action_name (action)));
+		action->activate ();
+	}
 
-        /* return true even if the action could not be found */
+	/* return true even if the action could not be found */
 
-        return true;
+	return true;
 }
 
 void
 Bindings::add (MouseButton bb, Operation op, string const& action_name)
 {
-	MouseButtonBindingMap& bbm = get_mousemap(op);
+	MouseButtonBindingMap& bbm = get_mousemap (op);
 
-        MouseButtonBindingMap::value_type newpair (bb, ActionInfo (action_name));
-        bbm.insert (newpair);
+	MouseButtonBindingMap::value_type newpair (bb, ActionInfo (action_name));
+	bbm.insert (newpair);
 }
 
 void
 Bindings::remove (MouseButton bb, Operation op)
 {
-	MouseButtonBindingMap& bbm = get_mousemap(op);
-        MouseButtonBindingMap::iterator b = bbm.find (bb);
+	MouseButtonBindingMap& bbm = get_mousemap (op);
+	MouseButtonBindingMap::iterator b = bbm.find (bb);
 
-        if (b != bbm.end()) {
-                bbm.erase (b);
-        }
+	if (b != bbm.end ()) {
+		bbm.erase (b);
+	}
 }
 
 void
 Bindings::save (XMLNode& root)
 {
-        XMLNode* presses = new XMLNode (X_("Press"));
+	XMLNode* presses = new XMLNode (X_ ("Press"));
 
-        for (KeybindingMap::iterator k = press_bindings.begin(); k != press_bindings.end(); ++k) {
-                XMLNode* child;
+	for (KeybindingMap::iterator k = press_bindings.begin (); k != press_bindings.end (); ++k) {
+		XMLNode* child;
 
-                if (k->first.name().empty()) {
-	                continue;
-                }
+		if (k->first.name ().empty ()) {
+			continue;
+		}
 
-                child = new XMLNode (X_("Binding"));
-                child->add_property (X_("key"), k->first.name());
-                child->add_property (X_("action"), k->second.action_name);
-                presses->add_child_nocopy (*child);
-        }
+		child = new XMLNode (X_ ("Binding"));
+		child->add_property (X_ ("key"), k->first.name ());
+		child->add_property (X_ ("action"), k->second.action_name);
+		presses->add_child_nocopy (*child);
+	}
 
-        for (MouseButtonBindingMap::iterator k = button_press_bindings.begin(); k != button_press_bindings.end(); ++k) {
-                XMLNode* child;
-                child = new XMLNode (X_("Binding"));
-                child->add_property (X_("button"), k->first.name());
-                child->add_property (X_("action"), k->second.action_name);
-                presses->add_child_nocopy (*child);
-        }
+	for (MouseButtonBindingMap::iterator k = button_press_bindings.begin ();
+	     k != button_press_bindings.end (); ++k) {
+		XMLNode* child;
+		child = new XMLNode (X_ ("Binding"));
+		child->add_property (X_ ("button"), k->first.name ());
+		child->add_property (X_ ("action"), k->second.action_name);
+		presses->add_child_nocopy (*child);
+	}
 
-        XMLNode* releases = new XMLNode (X_("Release"));
+	XMLNode* releases = new XMLNode (X_ ("Release"));
 
-        for (KeybindingMap::iterator k = release_bindings.begin(); k != release_bindings.end(); ++k) {
-                XMLNode* child;
+	for (KeybindingMap::iterator k = release_bindings.begin (); k != release_bindings.end (); ++k) {
+		XMLNode* child;
 
-                if (k->first.name().empty()) {
-	                continue;
-                }
+		if (k->first.name ().empty ()) {
+			continue;
+		}
 
-                child = new XMLNode (X_("Binding"));
-                child->add_property (X_("key"), k->first.name());
-                child->add_property (X_("action"), k->second.action_name);
-                releases->add_child_nocopy (*child);
-        }
+		child = new XMLNode (X_ ("Binding"));
+		child->add_property (X_ ("key"), k->first.name ());
+		child->add_property (X_ ("action"), k->second.action_name);
+		releases->add_child_nocopy (*child);
+	}
 
-        for (MouseButtonBindingMap::iterator k = button_release_bindings.begin(); k != button_release_bindings.end(); ++k) {
-                XMLNode* child;
-                child = new XMLNode (X_("Binding"));
-                child->add_property (X_("button"), k->first.name());
-                child->add_property (X_("action"), k->second.action_name);
-                releases->add_child_nocopy (*child);
-        }
+	for (MouseButtonBindingMap::iterator k = button_release_bindings.begin ();
+	     k != button_release_bindings.end (); ++k) {
+		XMLNode* child;
+		child = new XMLNode (X_ ("Binding"));
+		child->add_property (X_ ("button"), k->first.name ());
+		child->add_property (X_ ("action"), k->second.action_name);
+		releases->add_child_nocopy (*child);
+	}
 
-        root.add_child_nocopy (*presses);
-        root.add_child_nocopy (*releases);
+	root.add_child_nocopy (*presses);
+	root.add_child_nocopy (*releases);
 }
 
 bool
 Bindings::load (XMLNode const& node)
 {
-        const XMLNodeList& children (node.children());
+	const XMLNodeList& children (node.children ());
 
-        press_bindings.clear ();
-        release_bindings.clear ();
+	press_bindings.clear ();
+	release_bindings.clear ();
 
-        for (XMLNodeList::const_iterator i = children.begin(); i != children.end(); ++i) {
-	        /* each node could be Press or Release */
-	        load_operation (**i);
-        }
+	for (XMLNodeList::const_iterator i = children.begin (); i != children.end (); ++i) {
+		/* each node could be Press or Release */
+		load_operation (**i);
+	}
 
-        return true;
+	return true;
 }
 
 void
 Bindings::load_operation (XMLNode const& node)
 {
-        if (node.name() == X_("Press") || node.name() == X_("Release")) {
+	if (node.name () == X_ ("Press") || node.name () == X_ ("Release")) {
 
-                Operation op;
+		Operation op;
 
-                if (node.name() == X_("Press")) {
-                        op = Press;
-                } else {
-                        op = Release;
-                }
+		if (node.name () == X_ ("Press")) {
+			op = Press;
+		} else {
+			op = Release;
+		}
 
-                const XMLNodeList& children (node.children());
+		const XMLNodeList& children (node.children ());
 
-                for (XMLNodeList::const_iterator p = children.begin(); p != children.end(); ++p) {
+		for (XMLNodeList::const_iterator p = children.begin (); p != children.end (); ++p) {
 
-                        XMLProperty* ap;
-                        XMLProperty* kp;
-                        XMLProperty* bp;
+			XMLProperty* ap;
+			XMLProperty* kp;
+			XMLProperty* bp;
 
-                        ap = (*p)->property ("action");
-                        kp = (*p)->property ("key");
-                        bp = (*p)->property ("button");
+			ap = (*p)->property ("action");
+			kp = (*p)->property ("key");
+			bp = (*p)->property ("button");
 
-                        if (!ap || (!kp && !bp)) {
-                                continue;
-                        }
+			if (!ap || (!kp && !bp)) {
+				continue;
+			}
 
-                        if (kp) {
-                                KeyboardKey k;
-                                if (!KeyboardKey::make_key (kp->value(), k)) {
-                                        continue;
-                                }
-                                add (k, op, ap->value());
-                        } else {
-                                MouseButton b;
-                                if (!MouseButton::make_button (bp->value(), b)) {
-                                        continue;
-                                }
-                                add (b, op, ap->value());
-                        }
-                }
-        }
+			if (kp) {
+				KeyboardKey k;
+				if (!KeyboardKey::make_key (kp->value (), k)) {
+					continue;
+				}
+				add (k, op, ap->value ());
+			} else {
+				MouseButton b;
+				if (!MouseButton::make_button (bp->value (), b)) {
+					continue;
+				}
+				add (b, op, ap->value ());
+			}
+		}
+	}
 }
 
 void
-Bindings::get_all_actions (std::vector<std::string>& paths,
-                           std::vector<std::string>& labels,
-                           std::vector<std::string>& tooltips,
-                           std::vector<std::string>& keys,
-                           std::vector<RefPtr<Action> >& actions)
+Bindings::get_all_actions (std::vector<std::string>& paths, std::vector<std::string>& labels,
+                           std::vector<std::string>& tooltips, std::vector<std::string>& keys,
+                           std::vector<RefPtr<Action>>& actions)
 {
 	if (!_action_map) {
 		return;
@@ -753,10 +746,10 @@ Bindings::get_all_actions (std::vector<std::string>& paths,
 
 	/* build a reverse map from actions to bindings */
 
-	typedef map<Glib::RefPtr<Gtk::Action>,KeyboardKey> ReverseMap;
+	typedef map<Glib::RefPtr<Gtk::Action>, KeyboardKey> ReverseMap;
 	ReverseMap rmap;
 
-	for (KeybindingMap::const_iterator k = press_bindings.begin(); k != press_bindings.end(); ++k) {
+	for (KeybindingMap::const_iterator k = press_bindings.begin (); k != press_bindings.end (); ++k) {
 		rmap.insert (make_pair (k->second.action, k->first));
 	}
 
@@ -765,18 +758,19 @@ Bindings::get_all_actions (std::vector<std::string>& paths,
 	ActionMap::Actions all_actions;
 	_action_map->get_actions (all_actions);
 
-	for (ActionMap::Actions::const_iterator act = all_actions.begin(); act != all_actions.end(); ++act) {
+	for (ActionMap::Actions::const_iterator act = all_actions.begin (); act != all_actions.end ();
+	     ++act) {
 
-		paths.push_back ((*act)->get_accel_path());
-		labels.push_back ((*act)->get_label());
-		tooltips.push_back ((*act)->get_tooltip());
+		paths.push_back ((*act)->get_accel_path ());
+		labels.push_back ((*act)->get_label ());
+		tooltips.push_back ((*act)->get_tooltip ());
 
 		ReverseMap::iterator r = rmap.find (*act);
 
-		if (r != rmap.end()) {
-			keys.push_back (r->second.display_label());
+		if (r != rmap.end ()) {
+			keys.push_back (r->second.display_label ());
 		} else {
-			keys.push_back (string());
+			keys.push_back (string ());
 		}
 
 		actions.push_back (*act);
@@ -786,8 +780,8 @@ Bindings::get_all_actions (std::vector<std::string>& paths,
 Bindings*
 Bindings::get_bindings (string const& name, ActionMap& map)
 {
-	for (list<Bindings*>::iterator b = bindings.begin(); b != bindings.end(); b++) {
-		if ((*b)->name() == name) {
+	for (list<Bindings*>::iterator b = bindings.begin (); b != bindings.end (); b++) {
+		if ((*b)->name () == name) {
 			(*b)->set_action_map (map);
 			return *b;
 		}
@@ -799,7 +793,7 @@ Bindings::get_bindings (string const& name, ActionMap& map)
 void
 Bindings::associate_all ()
 {
-	for (list<Bindings*>::iterator b = bindings.begin(); b != bindings.end(); b++) {
+	for (list<Bindings*>::iterator b = bindings.begin (); b != bindings.end (); b++) {
 		(*b)->associate ();
 	}
 }
@@ -807,26 +801,28 @@ Bindings::associate_all ()
 bool
 Bindings::is_bound (KeyboardKey const& kb, Operation op) const
 {
-	const KeybindingMap& km = get_keymap(op);
-	return km.find(kb) != km.end();
+	const KeybindingMap& km = get_keymap (op);
+	return km.find (kb) != km.end ();
 }
 
 bool
 Bindings::is_registered (Operation op, std::string const& action_name) const
 {
-	const KeybindingMap& km = get_keymap(op);
-	return std::find_if(km.begin(),  km.end(),  ActionNameRegistered<KeybindingMap::const_iterator::value_type>(action_name)) != km.end();
+	const KeybindingMap& km = get_keymap (op);
+	return std::find_if (km.begin (), km.end (),
+	                     ActionNameRegistered<KeybindingMap::const_iterator::value_type> (
+	                         action_name)) != km.end ();
 }
 
 Bindings::KeybindingMap&
 Bindings::get_keymap (Operation op)
 {
 	switch (op) {
-		case Press:
-			return press_bindings;
-		case Release:
-		default:
-			return release_bindings;
+	case Press:
+		return press_bindings;
+	case Release:
+	default:
+		return release_bindings;
 	}
 }
 
@@ -834,11 +830,11 @@ const Bindings::KeybindingMap&
 Bindings::get_keymap (Operation op) const
 {
 	switch (op) {
-		case Press:
-			return press_bindings;
-		case Release:
-		default:
-			return release_bindings;
+	case Press:
+		return press_bindings;
+	case Release:
+	default:
+		return release_bindings;
 	}
 }
 
@@ -846,27 +842,22 @@ Bindings::MouseButtonBindingMap&
 Bindings::get_mousemap (Operation op)
 {
 	switch (op) {
-		case Press:
-			return button_press_bindings;
-		case Release:
-		default:
-			return button_release_bindings;
+	case Press:
+		return button_press_bindings;
+	case Release:
+	default:
+		return button_release_bindings;
 	}
 }
 
 /*==========================================ACTION MAP =========================================*/
 
-ActionMap::ActionMap (string const & name)
-	: _name (name)
-	, _bindings (0)
+ActionMap::ActionMap (string const& name) : _name (name), _bindings (0)
 {
 	action_maps.push_back (this);
 }
 
-ActionMap::~ActionMap ()
-{
-	action_maps.remove (this);
-}
+ActionMap::~ActionMap () { action_maps.remove (this); }
 
 void
 ActionMap::set_bindings (Bindings* b)
@@ -877,7 +868,7 @@ ActionMap::set_bindings (Bindings* b)
 void
 ActionMap::get_actions (ActionMap::Actions& acts)
 {
-	for (_ActionMap::iterator a = _actions.begin(); a != _actions.end(); ++a) {
+	for (_ActionMap::iterator a = _actions.begin (); a != _actions.end (); ++a) {
 		acts.push_back (a->second);
 	}
 }
@@ -885,13 +876,13 @@ ActionMap::get_actions (ActionMap::Actions& acts)
 RefPtr<Action>
 ActionMap::find_action (const string& name)
 {
-        _ActionMap::iterator a = _actions.find (name);
+	_ActionMap::iterator a = _actions.find (name);
 
-        if (a != _actions.end()) {
-                return a->second;
-        }
+	if (a != _actions.end ()) {
+		return a->second;
+	}
 
-        return RefPtr<Action>();
+	return RefPtr<Action> ();
 }
 
 RefPtr<ActionGroup>
@@ -916,136 +907,132 @@ ActionMap::create_action_group (const string& name)
 RefPtr<Action>
 ActionMap::register_action (RefPtr<ActionGroup> group, const char* name, const char* label)
 {
-        string fullpath;
+	string fullpath;
 
-        RefPtr<Action> act = Action::create (name, label);
+	RefPtr<Action> act = Action::create (name, label);
 
-        fullpath = group->get_name();
-        fullpath += '/';
-        fullpath += name;
+	fullpath = group->get_name ();
+	fullpath += '/';
+	fullpath += name;
 
-        if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
-	        group->add (act);
-	        return act;
-        }
+	if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
+		group->add (act);
+		return act;
+	}
 
-        /* already registered */
-        return RefPtr<Action> ();
+	/* already registered */
+	return RefPtr<Action> ();
 }
 
 RefPtr<Action>
-ActionMap::register_action (RefPtr<ActionGroup> group,
-                            const char* name, const char* label, sigc::slot<void> sl)
+ActionMap::register_action (RefPtr<ActionGroup> group, const char* name, const char* label,
+                            sigc::slot<void> sl)
 {
-        string fullpath;
+	string fullpath;
 
-        RefPtr<Action> act = Action::create (name, label);
+	RefPtr<Action> act = Action::create (name, label);
 
-        fullpath = group->get_name();
-        fullpath += '/';
-        fullpath += name;
+	fullpath = group->get_name ();
+	fullpath += '/';
+	fullpath += name;
 
-        if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
-	        group->add (act, sl);
-	        return act;
-        }
+	if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
+		group->add (act, sl);
+		return act;
+	}
 
-        /* already registered */
-        return RefPtr<Action>();
+	/* already registered */
+	return RefPtr<Action> ();
 }
 
 RefPtr<Action>
-ActionMap::register_radio_action (RefPtr<ActionGroup> group,
-                                  Gtk::RadioAction::Group& rgroup,
+ActionMap::register_radio_action (RefPtr<ActionGroup> group, Gtk::RadioAction::Group& rgroup,
+                                  const char* name, const char* label, sigc::slot<void> sl)
+{
+	string fullpath;
+
+	RefPtr<Action> act = RadioAction::create (rgroup, name, label);
+	RefPtr<RadioAction> ract = RefPtr<RadioAction>::cast_dynamic (act);
+
+	fullpath = group->get_name ();
+	fullpath += '/';
+	fullpath += name;
+
+	if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
+		group->add (act, sl);
+		return act;
+	}
+
+	/* already registered */
+	return RefPtr<Action> ();
+}
+
+RefPtr<Action>
+ActionMap::register_radio_action (RefPtr<ActionGroup> group, Gtk::RadioAction::Group& rgroup,
                                   const char* name, const char* label,
-                                  sigc::slot<void> sl)
+                                  sigc::slot<void, GtkAction*> sl, int value)
 {
-        string fullpath;
+	string fullpath;
 
-        RefPtr<Action> act = RadioAction::create (rgroup, name, label);
-        RefPtr<RadioAction> ract = RefPtr<RadioAction>::cast_dynamic(act);
+	RefPtr<Action> act = RadioAction::create (rgroup, name, label);
+	RefPtr<RadioAction> ract = RefPtr<RadioAction>::cast_dynamic (act);
+	ract->property_value () = value;
 
-        fullpath = group->get_name();
-        fullpath += '/';
-        fullpath += name;
+	fullpath = group->get_name ();
+	fullpath += '/';
+	fullpath += name;
 
-        if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
-	        group->add (act, sl);
-	        return act;
-        }
+	if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
+		group->add (act, sigc::bind (sl, act->gobj ()));
+		return act;
+	}
 
-        /* already registered */
-        return RefPtr<Action>();
+	/* already registered */
+
+	return RefPtr<Action> ();
 }
 
 RefPtr<Action>
-ActionMap::register_radio_action (RefPtr<ActionGroup> group,
-                                  Gtk::RadioAction::Group& rgroup,
-                                  const char* name, const char* label,
-                                  sigc::slot<void,GtkAction*> sl,
-                                  int value)
+ActionMap::register_toggle_action (RefPtr<ActionGroup> group, const char* name, const char* label,
+                                   sigc::slot<void> sl)
 {
-        string fullpath;
+	string fullpath;
 
-        RefPtr<Action> act = RadioAction::create (rgroup, name, label);
-        RefPtr<RadioAction> ract = RefPtr<RadioAction>::cast_dynamic(act);
-        ract->property_value() = value;
+	fullpath = group->get_name ();
+	fullpath += '/';
+	fullpath += name;
 
-        fullpath = group->get_name();
-        fullpath += '/';
-        fullpath += name;
+	RefPtr<Action> act = ToggleAction::create (name, label);
 
-        if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
-	        group->add (act, sigc::bind (sl, act->gobj()));
-	        return act;
-        }
+	if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
+		group->add (act, sl);
+		return act;
+	}
 
-        /* already registered */
-
-        return RefPtr<Action>();
-}
-
-RefPtr<Action>
-ActionMap::register_toggle_action (RefPtr<ActionGroup> group,
-                                   const char* name, const char* label, sigc::slot<void> sl)
-{
-        string fullpath;
-
-        fullpath = group->get_name();
-        fullpath += '/';
-        fullpath += name;
-
-        RefPtr<Action> act = ToggleAction::create (name, label);
-
-        if (_actions.insert (_ActionMap::value_type (fullpath, act)).second) {
-	        group->add (act, sl);
-	        return act;
-        }
-
-        /* already registered */
-        return RefPtr<Action>();
+	/* already registered */
+	return RefPtr<Action> ();
 }
 
 void
-ActionMap::get_all_actions (std::vector<std::string>& paths,
-                           std::vector<std::string>& labels,
-                           std::vector<std::string>& tooltips,
-                           std::vector<std::string>& keys,
-                           std::vector<RefPtr<Action> >& actions)
+ActionMap::get_all_actions (std::vector<std::string>& paths, std::vector<std::string>& labels,
+                            std::vector<std::string>& tooltips, std::vector<std::string>& keys,
+                            std::vector<RefPtr<Action>>& actions)
 {
-	for (list<ActionMap*>::const_iterator map = action_maps.begin(); map != action_maps.end(); ++map) {
+	for (list<ActionMap*>::const_iterator map = action_maps.begin (); map != action_maps.end ();
+	     ++map) {
 
 		ActionMap::Actions these_actions;
 		(*map)->get_actions (these_actions);
 
-		for (ActionMap::Actions::const_iterator act = these_actions.begin(); act != these_actions.end(); ++act) {
+		for (ActionMap::Actions::const_iterator act = these_actions.begin ();
+		     act != these_actions.end (); ++act) {
 
-			paths.push_back ((*act)->get_accel_path());
-			labels.push_back ((*act)->get_label());
-			tooltips.push_back ((*act)->get_tooltip());
+			paths.push_back ((*act)->get_accel_path ());
+			labels.push_back ((*act)->get_label ());
+			tooltips.push_back ((*act)->get_tooltip ());
 			actions.push_back (*act);
 
-			Bindings* bindings = (*map)->bindings();
+			Bindings* bindings = (*map)->bindings ();
 
 			if (bindings) {
 
@@ -1054,13 +1041,13 @@ ActionMap::get_all_actions (std::vector<std::string>& paths,
 
 				key = bindings->get_binding_for_action (*act, op);
 
-				if (key == KeyboardKey::null_key()) {
-					keys.push_back (string());
+				if (key == KeyboardKey::null_key ()) {
+					keys.push_back (string ());
 				} else {
-					keys.push_back (key.display_label());
+					keys.push_back (key.display_label ());
 				}
 			} else {
-				keys.push_back (string());
+				keys.push_back (string ());
 			}
 		}
 
@@ -1068,7 +1055,9 @@ ActionMap::get_all_actions (std::vector<std::string>& paths,
 	}
 }
 
-std::ostream& operator<<(std::ostream& out, Gtkmm2ext::KeyboardKey const & k) {
-	char const *gdk_name = gdk_keyval_name (k.key());
-	return out << "Key " << k.key() << " (" << (gdk_name ? gdk_name : "no-key") << ") state " << hex << k.state() << dec;
+std::ostream& operator<<(std::ostream& out, Gtkmm2ext::KeyboardKey const& k)
+{
+	char const* gdk_name = gdk_keyval_name (k.key ());
+	return out << "Key " << k.key () << " (" << (gdk_name ? gdk_name : "no-key") << ") state " << hex
+	           << k.state () << dec;
 }

--- a/libs/gtkmm2ext/bindings.cc
+++ b/libs/gtkmm2ext/bindings.cc
@@ -45,7 +45,6 @@ list<Bindings*> Bindings::bindings;      /* global. Gulp */
 list<ActionMap*> ActionMap::action_maps; /* global. Gulp */
 PBD::Signal1<void, Bindings*> Bindings::BindingsChanged;
 
-/*============================ ActionNameRegistered ===========================*/
 template <typename IteratorValueType>
 struct ActionNameRegistered {
 	ActionNameRegistered (std::string const& name) : action_name (name) {}
@@ -54,7 +53,6 @@ struct ActionNameRegistered {
 	std::string const& action_name;
 };
 
-/*================================ MouseButton ================================*/
 MouseButton::MouseButton (uint32_t state, uint32_t keycode)
 {
 	uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
@@ -151,7 +149,6 @@ MouseButton::name () const
 	return str;
 }
 
-/*================================ KeyboardKey ================================*/
 KeyboardKey::KeyboardKey (uint32_t state, uint32_t keycode)
 {
 	uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
@@ -289,7 +286,6 @@ KeyboardKey::make_key (const string& str, KeyboardKey& k)
 	return true;
 }
 
-/*================================= Bindings =================================*/
 Bindings::Bindings (std::string const& name) : _name (name), _action_map (0)
 {
 	bindings.push_back (this);
@@ -849,8 +845,6 @@ Bindings::get_mousemap (Operation op)
 		return button_release_bindings;
 	}
 }
-
-/*==========================================ACTION MAP =========================================*/
 
 ActionMap::ActionMap (string const& name) : _name (name), _bindings (0)
 {

--- a/libs/gtkmm2ext/gtkmm2ext/bindings.h
+++ b/libs/gtkmm2ext/gtkmm2ext/bindings.h
@@ -18,219 +18,235 @@
 
 class XMLNode;
 
-namespace Gtkmm2ext {
+namespace Gtkmm2ext
+{
 
 class LIBGTKMM2EXT_API KeyboardKey
 {
-  public:
-        KeyboardKey () {
-                _val = GDK_VoidSymbol;
-        }
+public:
+	KeyboardKey () { _val = GDK_VoidSymbol; }
 
-        KeyboardKey (uint32_t state, uint32_t keycode);
+	KeyboardKey (uint32_t state, uint32_t keycode);
 
-        static KeyboardKey null_key() { return KeyboardKey (0, 0); }
+	static KeyboardKey
+	null_key ()
+	{
+		return KeyboardKey (0, 0);
+	}
 
-        uint32_t state() const { return _val >> 32; }
-        uint32_t key() const { return _val & 0xffff; }
+	uint32_t
+	state () const
+	{
+		return _val >> 32;
+	}
+	uint32_t
+	key () const
+	{
+		return _val & 0xffff;
+	}
 
-        bool operator<(const KeyboardKey& other) const {
-                return _val < other._val;
-        }
+	bool operator<(const KeyboardKey& other) const { return _val < other._val; }
 
-        bool operator==(const KeyboardKey& other) const {
-                return _val == other._val;
-        }
+	bool operator==(const KeyboardKey& other) const { return _val == other._val; }
 
-        std::string name() const;
-        static bool make_key (const std::string&, KeyboardKey&);
+	std::string name () const;
+	static bool make_key (const std::string&, KeyboardKey&);
 
-        std::string display_label() const;
+	std::string display_label () const;
 
-  private:
-        uint64_t _val;
+private:
+	uint64_t _val;
 };
 
-class LIBGTKMM2EXT_API MouseButton {
-  public:
-        MouseButton () {
-                _val = ~0ULL;
-        }
+class LIBGTKMM2EXT_API MouseButton
+{
+public:
+	MouseButton () { _val = ~0ULL; }
 
-        MouseButton (uint32_t state, uint32_t button_number);
-        uint32_t state() const { return _val >> 32; }
-        uint32_t button() const { return _val & 0xffff; }
+	MouseButton (uint32_t state, uint32_t button_number);
+	uint32_t
+	state () const
+	{
+		return _val >> 32;
+	}
+	uint32_t
+	button () const
+	{
+		return _val & 0xffff;
+	}
 
-        bool operator<(const MouseButton& other) const {
-                return _val < other._val;
-        }
+	bool operator<(const MouseButton& other) const { return _val < other._val; }
 
-        bool operator==(const MouseButton& other) const {
-                return _val == other._val;
-        }
+	bool operator==(const MouseButton& other) const { return _val == other._val; }
 
-        std::string name() const;
-        static bool make_button (const std::string&, MouseButton&);
+	std::string name () const;
+	static bool make_button (const std::string&, MouseButton&);
 
-  private:
-        uint64_t _val;
+private:
+	uint64_t _val;
 };
 
 class LIBGTKMM2EXT_API Bindings;
 
-class LIBGTKMM2EXT_API ActionMap {
-  public:
+class LIBGTKMM2EXT_API ActionMap
+{
+public:
 	ActionMap (std::string const& name);
-	~ActionMap();
+	~ActionMap ();
 
-	std::string name() const { return _name; }
+	std::string
+	name () const
+	{
+		return _name;
+	}
 
-        Glib::RefPtr<Gtk::ActionGroup> create_action_group (const std::string& group_name);
+	Glib::RefPtr<Gtk::ActionGroup> create_action_group (const std::string& group_name);
 
-        Glib::RefPtr<Gtk::Action> register_action (Glib::RefPtr<Gtk::ActionGroup> group, const char* name, const char* label);
-        Glib::RefPtr<Gtk::Action> register_action (Glib::RefPtr<Gtk::ActionGroup> group,
-						   const char* name, const char* label, sigc::slot<void> sl);
-        Glib::RefPtr<Gtk::Action> register_radio_action (Glib::RefPtr<Gtk::ActionGroup> group,
-							 Gtk::RadioAction::Group&,
-							 const char* name, const char* label,
-                                                         sigc::slot<void,GtkAction*> sl,
-                                                         int value);
-        Glib::RefPtr<Gtk::Action> register_radio_action (Glib::RefPtr<Gtk::ActionGroup> group,
-							 Gtk::RadioAction::Group&,
-							 const char* name, const char* label,
-                                                         sigc::slot<void> sl);
-	Glib::RefPtr<Gtk::Action> register_toggle_action (Glib::RefPtr<Gtk::ActionGroup> group,
-							  const char* name, const char* label, sigc::slot<void> sl);
+	Glib::RefPtr<Gtk::Action>
+	register_action (Glib::RefPtr<Gtk::ActionGroup> group, const char* name, const char* label);
+	Glib::RefPtr<Gtk::Action> register_action (Glib::RefPtr<Gtk::ActionGroup> group, const char* name,
+	                                           const char* label, sigc::slot<void> sl);
+	Glib::RefPtr<Gtk::Action>
+	register_radio_action (Glib::RefPtr<Gtk::ActionGroup> group, Gtk::RadioAction::Group&,
+	                       const char* name, const char* label, sigc::slot<void, GtkAction*> sl,
+	                       int value);
+	Glib::RefPtr<Gtk::Action>
+	register_radio_action (Glib::RefPtr<Gtk::ActionGroup> group, Gtk::RadioAction::Group&,
+	                       const char* name, const char* label, sigc::slot<void> sl);
+	Glib::RefPtr<Gtk::Action>
+	register_toggle_action (Glib::RefPtr<Gtk::ActionGroup> group, const char* name, const char* label,
+	                        sigc::slot<void> sl);
 
-        Glib::RefPtr<Gtk::Action> find_action (const std::string& name);
+	Glib::RefPtr<Gtk::Action> find_action (const std::string& name);
 
 	void set_bindings (Bindings*);
-	Bindings* bindings() const { return _bindings; }
+	Bindings*
+	bindings () const
+	{
+		return _bindings;
+	}
 
-	typedef std::vector<Glib::RefPtr<Gtk::Action> > Actions;
+	typedef std::vector<Glib::RefPtr<Gtk::Action>> Actions;
 	void get_actions (Actions&);
 
 	static std::list<ActionMap*> action_maps;
 
-        /* used by control surface protocols and other UIs */
-	static void get_all_actions (std::vector<std::string>& paths,
-	                             std::vector<std::string>& labels,
-	                             std::vector<std::string>& tooltips,
-	                             std::vector<std::string>& keys,
-	                             std::vector<Glib::RefPtr<Gtk::Action> >& actions);
+	/* used by control surface protocols and other UIs */
+	static void get_all_actions (std::vector<std::string>& paths, std::vector<std::string>& labels,
+	                             std::vector<std::string>& tooltips, std::vector<std::string>& keys,
+	                             std::vector<Glib::RefPtr<Gtk::Action>>& actions);
 
-  private:
+private:
 	std::string _name;
 
 	/* hash for faster lookup of actions by name */
 
-	typedef std::map<std::string, Glib::RefPtr<Gtk::Action> > _ActionMap;
-        _ActionMap _actions;
+	typedef std::map<std::string, Glib::RefPtr<Gtk::Action>> _ActionMap;
+	_ActionMap _actions;
 
-        /* initialized to null; set after a Bindings object has ::associated()
-         * itself with this action map.
-         */
+	/* initialized to null; set after a Bindings object has ::associated()
+	 * itself with this action map.
+	 */
 
-        Bindings* _bindings;
-
+	Bindings* _bindings;
 };
 
-class LIBGTKMM2EXT_API Bindings {
-	public:
-        enum Operation {
-                Press,
-                Release
-        };
+class LIBGTKMM2EXT_API Bindings
+{
+public:
+	enum Operation { Press, Release };
 
-        struct ActionInfo {
-	        ActionInfo (std::string const& name) : action_name (name) {}
+	struct ActionInfo {
+		ActionInfo (std::string const& name) : action_name (name) {}
 
-	        std::string action_name;
-	        Glib::RefPtr<Gtk::Action> action;
-        };
-		typedef std::map<KeyboardKey,ActionInfo> KeybindingMap;
+		std::string action_name;
+		Glib::RefPtr<Gtk::Action> action;
+	};
+	typedef std::map<KeyboardKey, ActionInfo> KeybindingMap;
 
-        Bindings (std::string const& name);
-        ~Bindings ();
+	Bindings (std::string const& name);
+	~Bindings ();
 
-        std::string const& name() const { return _name; }
+	std::string const&
+	name () const
+	{
+		return _name;
+	}
 
-        void associate ();
-        void dissociate ();
+	void associate ();
+	void dissociate ();
 
-        bool empty() const;
-        bool empty_keys () const;
-        bool empty_mouse () const;
+	bool empty () const;
+	bool empty_keys () const;
+	bool empty_mouse () const;
 
-        bool add (KeyboardKey, Operation, std::string const&, bool can_save = false);
-        bool replace (KeyboardKey, Operation, std::string const& action_name, bool can_save = true);
-        bool remove (Operation, std::string const& action_name, bool can_save = false);
+	bool add (KeyboardKey, Operation, std::string const&, bool can_save = false);
+	bool replace (KeyboardKey, Operation, std::string const& action_name, bool can_save = true);
+	bool remove (Operation, std::string const& action_name, bool can_save = false);
 
-        bool activate (KeyboardKey, Operation);
+	bool activate (KeyboardKey, Operation);
 
-        void add (MouseButton, Operation, std::string const&);
-        void remove (MouseButton, Operation);
-        bool activate (MouseButton, Operation);
+	void add (MouseButton, Operation, std::string const&);
+	void remove (MouseButton, Operation);
+	bool activate (MouseButton, Operation);
 
-		bool is_bound (KeyboardKey const&, Operation) const;
-		bool is_registered (Operation op, std::string const& action_name) const;
+	bool is_bound (KeyboardKey const&, Operation) const;
+	bool is_registered (Operation op, std::string const& action_name) const;
 
-        KeyboardKey get_binding_for_action (Glib::RefPtr<Gtk::Action>, Operation& op);
+	KeyboardKey get_binding_for_action (Glib::RefPtr<Gtk::Action>, Operation& op);
 
-        bool load (XMLNode const& node);
-        void load_operation (XMLNode const& node);
-        void save (XMLNode& root);
+	bool load (XMLNode const& node);
+	void load_operation (XMLNode const& node);
+	void save (XMLNode& root);
 
-        /* GTK has the following position a Gtk::Action:
-         *
-         *  accel_path: <Actions>/GroupName/ActionName
-         *  name: ActionName
-         *
-         * We want proper namespacing and we're not interested in
-         * the silly <Actions> "extra" namespace. So in Ardour:
-         *
-         * accel_path: <Actions>/GroupName/ActionName
-         * name: GroupName/ActionName
-         *
-         * This (static) method returns the "ardour" name for the action.
-         */
-        static std::string ardour_action_name (Glib::RefPtr<Gtk::Action>);
+	/* GTK has the following position a Gtk::Action:
+	 *
+	 *  accel_path: <Actions>/GroupName/ActionName
+	 *  name: ActionName
+	 *
+	 * We want proper namespacing and we're not interested in
+	 * the silly <Actions> "extra" namespace. So in Ardour:
+	 *
+	 * accel_path: <Actions>/GroupName/ActionName
+	 * name: GroupName/ActionName
+	 *
+	 * This (static) method returns the "ardour" name for the action.
+	 */
+	static std::string ardour_action_name (Glib::RefPtr<Gtk::Action>);
 
-        void set_action_map (ActionMap&);
+	void set_action_map (ActionMap&);
 
-        /* used for editing bindings */
-        void get_all_actions (std::vector<std::string>& paths,
-                              std::vector<std::string>& labels,
-                              std::vector<std::string>& tooltips,
-                              std::vector<std::string>& keys,
-                              std::vector<Glib::RefPtr<Gtk::Action> >& actions);
+	/* used for editing bindings */
+	void get_all_actions (std::vector<std::string>& paths, std::vector<std::string>& labels,
+	                      std::vector<std::string>& tooltips, std::vector<std::string>& keys,
+	                      std::vector<Glib::RefPtr<Gtk::Action>>& actions);
 
 	/* all bindings currently in existence, as grouped into Bindings */
 	static std::list<Bindings*> bindings;
 	static Bindings* get_bindings (std::string const& name, ActionMap&);
 	static void associate_all ();
 
-	static PBD::Signal1<void,Bindings*> BindingsChanged;
+	static PBD::Signal1<void, Bindings*> BindingsChanged;
 
-	private:
-        std::string  _name;
-        ActionMap*   _action_map;
-        KeybindingMap press_bindings;
-        KeybindingMap release_bindings;
+private:
+	std::string _name;
+	ActionMap* _action_map;
+	KeybindingMap press_bindings;
+	KeybindingMap release_bindings;
 
-        typedef std::map<MouseButton,ActionInfo> MouseButtonBindingMap;
-        MouseButtonBindingMap button_press_bindings;
-        MouseButtonBindingMap button_release_bindings;
+	typedef std::map<MouseButton, ActionInfo> MouseButtonBindingMap;
+	MouseButtonBindingMap button_press_bindings;
+	MouseButtonBindingMap button_release_bindings;
 
-        void push_to_gtk (KeyboardKey, Glib::RefPtr<Gtk::Action>);
+	void push_to_gtk (KeyboardKey, Glib::RefPtr<Gtk::Action>);
 
-		KeybindingMap& get_keymap (Operation op);
-		const KeybindingMap& get_keymap (Operation op) const;
-		MouseButtonBindingMap& get_mousemap (Operation op);
+	KeybindingMap& get_keymap (Operation op);
+	const KeybindingMap& get_keymap (Operation op) const;
+	MouseButtonBindingMap& get_mousemap (Operation op);
 };
 
 } // namespace
 
-std::ostream& operator<<(std::ostream& out, Gtkmm2ext::KeyboardKey const & k);
+std::ostream& operator<<(std::ostream& out, Gtkmm2ext::KeyboardKey const& k);
 
 #endif /* __libgtkmm2ext_bindings_h__ */


### PR DESCRIPTION
Hi,

The indentation in bindings.* was pretty messy. In order to solve this automatically I created a clang-format style configuration which should be pretty close to the current coding style in the code base. Nevertheless, there are some minor differences:
- Putting the return type on separate lines for function definitions also puts all return types on inline definition on separate lines. This is in contrast to the current style but clang-format can't handle it better. 

This PR:
- creates a clang-format style definition (usable with clang-format version >= 3.6)
- reformats bindings.* using this definition
- removes some uncharacteristic comments 
- changes no code functionality
