### PR TITLE
Fix #5884, #4928, #5697: errors when using timestretch tool

### DIFF
--- a/libs/ardour/region.cc
+++ b/libs/ardour/region.cc
@@ -270,6 +270,7 @@ Region::Region (boost::shared_ptr<const Region> other)
 	_hidden = false;
 
 	use_sources (other->_sources);
+	set_master_sources (other->_master_sources);
 
 	_position_lock_style = other->_position_lock_style;
 	_first_edit = other->_first_edit;
@@ -329,6 +330,7 @@ Region::Region (boost::shared_ptr<const Region> other, frameoffset_t offset)
 	_hidden = false;
 
 	use_sources (other->_sources);
+	set_master_sources (other->_master_sources);
 
 	_start = other->_start + offset;
 


### PR DESCRIPTION
Details are in the bug tracker for #5884, particularly the last comment:
http://tracker.ardour.org/view.php?id=5884
The other two bugs that are also probably resolved:
http://tracker.ardour.org/view.php?id=4928
http://tracker.ardour.org/view.php?id=5697

As mentioned in #5884, I am not sure if this is the best way to fix the issue. Maybe it's better to change `Region::use_sources` to take an additional argument, master_sources? I am not, however, familiar enough with C++ & the codebase to do that.