### PR TITLE
Non single key keycodes

### DIFF
--- a/gtk2_ardour/ardour.keys.in
+++ b/gtk2_ardour/ardour.keys.in
@@ -313,7 +313,6 @@ This mode provides many different operations on both regions and control points,
 
 @-edit|Editor/edit-cursor-to-range-start|F1|some text
 @-edit|Editor/edit-cursor-to-range-end|F2|some text
-@-edit|Editor/pitch-shift-region|F5|some text
 
 @-edit|Editor/save-visual-state-1|<@PRIMARY@>F1|some text
 @-edit|Editor/save-visual-state-2|<@PRIMARY@>F2|some text

--- a/libs/gtkmm2ext/bindings.cc
+++ b/libs/gtkmm2ext/bindings.cc
@@ -264,19 +264,20 @@ KeyboardKey::make_key (const string& str, KeyboardKey& k)
 
 	string actual;
 
-	if (str.size() == 1) {
-		actual = PBD::downcase (str);
-	} else {
+	string::size_type lastmod = str.find_last_of ('-');
+
+	if (lastmod != string::npos) {
+		actual = str.substr (lastmod+1);
+	}
+	else {
 		actual = str;
 	}
 
-	string::size_type lastmod = actual.find_last_of ('-');
-	guint keyval;
-
-	if (lastmod != string::npos) {
-		actual = PBD::downcase (str.substr (lastmod+1));
+	if (actual.size() == 1) {
+		actual = PBD::downcase (actual);
 	}
 
+	guint keyval;
 	keyval = gdk_keyval_from_name (actual.c_str());
 
 	if (keyval == GDK_VoidSymbol || keyval == 0) {


### PR DESCRIPTION
Key combinations like Ctrl-F5, Alt-Insert were not loaded. They worked only for current session, but disappeared after reload  despite the fact there were correct entries in ardour.keys.