### PR TITLE
Don't crash when keyeditor is empty

### DIFF
--- a/gtk2_ardour/keyeditor.cc
+++ b/gtk2_ardour/keyeditor.cc
@@ -496,5 +496,8 @@ void
 KeyEditor::search_string_updated (const std::string& filter)
 {
 	filter_string = boost::to_lower_copy(filter);
-	current_tab ()->filter->refilter ();
+	KeyEditor::Tab* tab = current_tab ();
+	if (tab) {
+		tab->filter->refilter ();
+	}
 }


### PR DESCRIPTION
The recent changes to the bindings capitalization caused a crash in the keyeditor when an outdated ardour.keys file rendered the editor empty. 