### PR TITLE
bounced region name issue

### DIFF
--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -5723,14 +5723,12 @@ Session::write_one_track (Track& track, framepos_t start, framepos_t end,
 		goto out;
 	}
 
-	legal_playlist_name = legalize_for_path (playlist->name());
-
 	for (uint32_t chan_n = 0; chan_n < diskstream_channels.n(track.data_type()); ++chan_n) {
 
-		string base_name = string_compose ("%1-%2-bounce", playlist->name(), chan_n);
+		string base_name = string_compose ("%1-bounce", playlist->name());
 		string path = ((track.data_type() == DataType::AUDIO)
-		               ? new_audio_source_path (legal_playlist_name, diskstream_channels.n_audio(), chan_n, false, true)
-		               : new_midi_source_path (legal_playlist_name));
+		               ? new_audio_source_path (base_name, diskstream_channels.n_audio(), chan_n, false, true)
+		               : new_midi_source_path (base_name));
 
 		if (path.empty()) {
 			goto out;


### PR DESCRIPTION
Bounced regions were named after track. Previous version of Ardour added "bounce" to the name. It seems that it was overlooked. Sometimes it is difficult to find bounced region when there are tens or hundred of regions on the list. Methods new_audio_source_path and new_midi_source_path correctly enumerate and "legalize" files paths. Probably this suffix could be added a region name only.
