### PR TITLE
Support to set gain automation by OSC

### DIFF
--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -487,6 +487,8 @@ OSC::register_callbacks()
 		REGISTER_CALLBACK (serv, "/ardour/routes/send/gainabs", "iif", route_set_send_gain_abs);
 		REGISTER_CALLBACK (serv, "/ardour/routes/send/gaindB", "iif", route_set_send_gain_dB);
 
+                REGISTER_CALLBACK (serv, "/ardour/routes/gain_automation", "is", route_set_gain_automation);
+
 		/* still not-really-standardized query interface */
 		//REGISTER_CALLBACK (serv, "/ardour/*/#current_value", "", current_value);
 		//REGISTER_CALLBACK (serv, "/ardour/set", "", set);
@@ -1346,6 +1348,42 @@ OSC::route_plugin_parameter_print (int rid, int piid, int par)
 	}
 
 	return 0;
+}
+
+
+static void set_automation_state (boost::shared_ptr<AutomationControl> c, char state)
+{
+        switch (state) {
+		case 'p':
+			c->set_automation_state (Play);
+			break;
+		case 'm':
+			c->set_automation_state (Off);
+			break;
+		case 'w':
+			c->set_automation_state (Write);
+			break;
+		case 't':
+			c->set_automation_state (Touch);
+			break;
+		default:
+			break;
+        }
+}
+
+int OSC::route_set_gain_automation (int rid, char state)
+{
+        if (!session) {
+                return -1;
+        }
+
+        boost::shared_ptr<Route> r = session->route_by_remote_id (rid);
+        if (!r || !r->gain_control ()) {
+                return -1;
+        }
+
+        set_automation_state (r->gain_control (), state);
+        return 0;
 }
 
 XMLNode&

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -291,6 +291,7 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 	PATH_CALLBACK2(route_set_gain_abs,i,f);
 	PATH_CALLBACK2(route_set_gain_dB,i,f);
 	PATH_CALLBACK2(route_set_gain_fader,i,f);
+	PATH_CALLBACK2(route_set_gain_automation,i,s);
 	PATH_CALLBACK2(route_set_trim_abs,i,f);
 	PATH_CALLBACK2(route_set_trim_dB,i,f);
 	PATH_CALLBACK2(route_set_pan_stereo_position,i,f);
@@ -306,6 +307,7 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 	int route_set_gain_abs (int rid, float level);
 	int route_set_gain_dB (int rid, float dB);
 	int route_set_gain_fader (int rid, float pos);
+	int route_set_gain_automation (int rid, char state);
 	int route_set_trim_abs (int rid, float level);
 	int route_set_trim_dB (int rid, float dB);
 	int route_set_pan_stereo_position (int rid, float left_right_fraction);


### PR DESCRIPTION
This is a retry of #170. I felt like hacking on miniLAC and reimplemented it according to the ideas of @x42.

So greetings from miniLAC :)
  

Added support for OSC message

"/ardour/routes/gain_automation" rid state

where rid is the remote route id and state is a character representing
the desired gain automation state:

'm': Manual (Off)
'p': Play
'w': Write
't': Touch