### PR TITLE
ptformat: Make PT import more resilient to bad user choices and displ…

### DIFF
--- a/gtk2_ardour/editor_pt_import.cc
+++ b/gtk2_ardour/editor_pt_import.cc
@@ -121,6 +121,7 @@ Editor::do_ptimport (std::string ptpath,
 	vector<string> to_import;
 	string fullpath;
 	bool ok = false;
+	bool onefailed = false;
 	PTFFormat ptf;
 	framepos_t pos = -1;
 
@@ -165,7 +166,17 @@ Editor::do_ptimport (std::string ptpath,
 
 			ptfwavpair.push_back(p);
 			imported.push_back(import_status.sources.back());
+		} else {
+			onefailed = true;
 		}
+	}
+
+	if (onefailed) {
+		MessageDialog msg (_("Failed to load one or more of the audio files, but continuing to attempt import."));
+		msg.run ();
+	} else {
+		MessageDialog msg (_("Success! Import should complete soon."));
+		msg.run ();
 	}
 
 	for (vector<PTFFormat::region_t>::iterator a = ptf.regions.begin();

--- a/libs/ptformat/ptfformat.cc
+++ b/libs/ptformat/ptfformat.cc
@@ -113,6 +113,7 @@ PTFFormat::load(std::string path, int64_t targetsr) {
 	uint64_t i;
 	uint64_t j;
 	int inv;
+	int err;
 
 	if (! (fp = fopen(path.c_str(), "rb"))) {
 		return -1;
@@ -257,8 +258,12 @@ PTFFormat::load(std::string path, int64_t targetsr) {
 		}
 	}
 
+	if (version < 5 || version > 12)
+		return -1;
 	targetrate = targetsr;
-	parse();
+	err = parse();
+	if (err)
+		return -1;
 	return 0;
 }
 
@@ -298,36 +303,48 @@ PTFFormat::unxor10(void)
 	}
 }
 
-void
+int
 PTFFormat::parse(void) {
 	if (version == 5) {
 		parse5header();
 		setrates();
+		if (sessionrate < 44100 || sessionrate > 192000)
+		  return -1;
 		parseaudio5();
 		parserest5();
 	} else if (version == 7) {
 		parse7header();
 		setrates();
+		if (sessionrate < 44100 || sessionrate > 192000)
+		  return -1;
 		parseaudio();
 		parserest89();
 	} else if (version == 8) {
 		parse8header();
 		setrates();
+		if (sessionrate < 44100 || sessionrate > 192000)
+		  return -1;
 		parseaudio();
 		parserest89();
 	} else if (version == 9) {
 		parse9header();
 		setrates();
+		if (sessionrate < 44100 || sessionrate > 192000)
+		  return -1;
 		parseaudio();
 		parserest89();
 	} else if (version == 10 || version == 11 || version == 12) {
 		parse10header();
 		setrates();
+		if (sessionrate < 44100 || sessionrate > 192000)
+		  return -1;
 		parseaudio();
 		parserest10();
 	} else {
 		// Should not occur
+		return -1;
 	}
+	return 0;
 }
 
 void

--- a/libs/ptformat/ptfformat.h
+++ b/libs/ptformat/ptfformat.h
@@ -117,7 +117,7 @@ public:
 
 private:
 	bool foundin(std::string haystack, std::string needle);
-	void parse(void);
+	int parse(void);
 	void unxor10(void);
 	void setrates(void);
 	void parse5header(void);


### PR DESCRIPTION
…ay messages

Previously, libptformat would attempt to parse all kinds of files,
now the library stops parsing when the version number and session rate
is outside valid ranges, returning an error code to the caller.

If there is a valid PT file detected, but some audio files are missing,
Ardour now pops up an error message to inform the user that some files
may be missing from the import.  A success message is displayed otherwise.

Signed-off-by: Damien Zammit <damien@zamaudio.com>