### PR TITLE
LuaBridge: Use correct type of std::map::count (fix build with GCC6)

### DIFF
--- a/libs/lua/LuaBridge/detail/Namespace.h
+++ b/libs/lua/LuaBridge/detail/Namespace.h
@@ -1658,12 +1658,14 @@ public:
     typedef std::map<K, V> LT;
     typedef std::pair<const K, V> T;
 
+    typedef typename std::map<K, V>::size_type T_SIZE;
+
     return beginClass<LT> (name)
       .addVoidConstructor ()
       .addFunction ("empty", &LT::empty)
       .addFunction ("size", &LT::size)
       .addFunction ("clear", (void (LT::*)())&LT::clear)
-      .addFunction ("count", (void (LT::*)())&LT::count)
+      .addFunction ("count", (T_SIZE (LT::*)(const K&) const)&LT::count)
       .addExtCFunction ("add", &CFunc::tableToMap<K, V>)
       .addExtCFunction ("iter", &CFunc::mapIter<K, V>)
       .addExtCFunction ("table", &CFunc::mapToTable<K, V>);


### PR DESCRIPTION
Compiling Ardour commit ec8a4de01596c162c1529f3021dfc432bf66dfe8 with GCC
6.1.1 (on Fedora 24) gave this build failure:

    In file included from /home/sam/ardour/libs/lua/LuaBridge/LuaBridge.h:154:0,
                     from ../tools/luadevel/devel.cc:16:
    /home/sam/ardour/libs/lua/LuaBridge/detail/Namespace.h: In instantiation of ‘luabridge::Namespace::Class<std::map<K, V> > luabridge::Namespace::beginStdMap(const char*) [with K = std::__cxx11::basic_string<char>; V = std::__cxx11::basic_string<char>]’:
    ../tools/luadevel/devel.cc:89:60:   required from here
    /home/sam/ardour/libs/lua/LuaBridge/detail/Namespace.h:1666:30: error: no matches converting function ‘count’ to type ‘void (class std::map<std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char>, std::less<std::__cxx11::basic_string<char> >, std::allocator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > > >::*)()’
           .addFunction ("count", (void (LT::*)())&LT::count)
                                  ^~~~~~~~~~~~~~~~~~~
    In file included from /usr/include/c++/6.1.1/map:61:0,
                     from /home/sam/ardour/libs/lua/LuaBridge/LuaBridge.h:45,
                     from ../tools/luadevel/devel.cc:16:
    /usr/include/c++/6.1.1/bits/stl_map.h:1131:2: note: candidates are: template<class _Kt> decltype (((const std::map<_Key, _Tp, _Compare, _Alloc>*)this)->std::map<_Key, _Tp, _Compare, _Alloc>::_M_t._M_count_tr(__x)) std::map<_Key, _Tp, _Compare, _Alloc>::count(const _Kt&) const [with _Kt = _Kt; _Key = std::__cxx11::basic_string<char>; _Tp = std::__cxx11::basic_string<char>; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >]
      count(const _Kt& __x) const -> decltype(_M_t._M_count_tr(__x))
      ^~~~~
    /usr/include/c++/6.1.1/bits/stl_map.h:1125:7: note:                 std::map<_Key, _Tp, _Compare, _Alloc>::size_type std::map<_Key, _Tp, _Compare, _Alloc>::count(const key_type&) const [with _Key = std::__cxx11::basic_string<char>; _Tp = std::__cxx11::basic_string<char>; _Compare = std::less<std::__cxx11::basic_string<char> >; _Alloc = std::allocator<std::pair<const std::__cxx11::basic_string<char>, std::__cxx11::basic_string<char> > >; std::map<_Key, _Tp, _Compare, _Alloc>::size_type = long unsigned int; std::map<_Key, _Tp, _Compare, _Alloc>::key_type = std::__cxx11::basic_string<char>]
           count(const key_type& __x) const
           ^~~~~

Casting std::map::count to the correct type instead of a fake void()
type fixes the compile failure.