### PR TITLE
Handle NetBSD behavior of handling of _POSIX_SOURCE or _XOPEN_SOURCE

### DIFF
--- a/libs/ardouralsautil/wscript
+++ b/libs/ardouralsautil/wscript
@@ -51,6 +51,7 @@ def build(bld):
             obj.defines = [
                     '_POSIX_SOURCE',
                     '_XOPEN_SOURCE=500',
+                    '_NETBSD_SOURCE',
                     'ARD_PROG_NAME="ardour-request-device"',
                     'ARD_APPL_NAME="Ardour ALSA Backend"',
             ]

--- a/libs/fst/wscript
+++ b/libs/fst/wscript
@@ -83,6 +83,7 @@ def build(bld):
     obj.includes  = [ '../pbd/', '../ardour/', '.' ]
     obj.defines = [
         '_POSIX_SOURCE',
+        '_NETBSD_SOURCE',
         'USE_WS_PREFIX',
         'VST_SCANNER_APP',
         'PACKAGE="' + I18N_PACKAGE + str(bld.env['MAJOR']) + '"',

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -97,7 +97,7 @@ def configure(conf):
     conf.check(header_name='execinfo.h', define_name='HAVE_EXECINFO',mandatory=False)
     conf.check(header_name='unistd.h', define_name='HAVE_UNISTD',mandatory=False)
     if not Options.options.ppc:
-        conf.check_cc(function_name='posix_memalign', header_name='stdlib.h', cflags='-D_XOPEN_SOURCE=600', define_name='HAVE_POSIX_MEMALIGN', mandatory=False)
+        conf.check_cc(function_name='posix_memalign', header_name='stdlib.h', cflags='-D_XOPEN_SOURCE=600 -D_NETBSD_SOURCE', define_name='HAVE_POSIX_MEMALIGN', mandatory=False)
     conf.check(function_name='localtime_r', header_name='time.h', define_name='HAVE_LOCALTIME_R',mandatory=False)
 
     conf.write_config_header('libpbd-config.h', remove=False)

--- a/libs/vfork/wscript
+++ b/libs/vfork/wscript
@@ -25,4 +25,5 @@ def build(bld):
     obj.defines = [
             '_POSIX_SOURCE',
             '_XOPEN_SOURCE=500',
+            '_NETBSD_SOURCE',
     ]


### PR DESCRIPTION
On NetBSD once these symbols are defined, we are disabling additional
features rather than enabling hidden ones like on Linux. To overcome it
define explicitly _NETBSD_SOURCE in waf files.