### PR TITLE
Don't add audio outs to non-audio routes with strict I/O

### DIFF
--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -1636,8 +1636,9 @@ Route::try_configure_processors_unlocked (ChanCount in, ProcessorStreams* err)
 				 * Delivery::configure_io() will do the actual removal
 				 * by calling _output->ensure_io()
 				 */
-				if (!is_master() && _session.master_out ()) {
-					/* ..but at least as many as there are master-inputs */
+				if (!is_master() && _session.master_out () && in.n_audio() > 0) {
+					/* ..but at least as many as there are master-inputs, if
+					 * the delivery is dealing with audio */
 					// XXX this may need special-casing for mixbus (master-outputs)
 					// and should maybe be a preference anyway ?!
 					out = ChanCount::max (in, _session.master_out ()->n_inputs ());


### PR DESCRIPTION
If a route has strict I/O then the main delivery follows the output of
the last processor, but libardour ensures it has at least as many
outputs as inputs in the master strip. A good consequence is that mono
tracks get their expected panner.

An akward side-effect is that MIDI-only routes (e.g. midi tracks or busses
without a synth) get two audio channels that have no use (and indeed no
panner is added because there is nothing to pan).

Skip the completion of audio outs if there was no audio out to begin
with.