### PR TITLE
Make internal sends cope with non-audio data

### DIFF
--- a/libs/ardour/io.cc
+++ b/libs/ardour/io.cc
@@ -1721,11 +1721,13 @@ IO::collect_input (BufferSet& bufs, pframes_t nframes, ChanCount offset)
 void
 IO::copy_to_outputs (BufferSet& bufs, DataType type, pframes_t nframes, framecnt_t offset)
 {
-	// Copy any buffers 1:1 to outputs
-
 	PortSet::iterator o = _ports.begin(type);
 	BufferSet::iterator i = bufs.begin(type);
 	BufferSet::iterator prev = i;
+
+	assert(i != bufs.end(type)); // or second loop will crash
+
+	// Copy any buffers 1:1 to outputs
 
 	while (i != bufs.end(type) && o != _ports.end (type)) {
 		Buffer& port_buffer (o->get_buffer (nframes));

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -2580,6 +2580,7 @@ Session::new_midi_route (RouteGroup* route_group, uint32_t how_many, string name
 				route_group->add (bus);
 			}
 
+			bus->add_internal_return ();
 			ret.push_back (bus);
 		}
 


### PR DESCRIPTION
The first commit is just hardening. The second makes deliveries route all non-audio data instead of special-casing midi, so that they are future-proof. The third commit does the same thing with internal sends which didn't send midi data at all. The last commit adds returns to midi busses to take advantage of the previous commit.