### PR TITLE
Call flush_buffers() more pervasively

### DIFF
--- a/libs/ardour/ardour/port_insert.h
+++ b/libs/ardour/ardour/port_insert.h
@@ -26,6 +26,7 @@
 
 #include "ardour/ardour.h"
 #include "ardour/io_processor.h"
+#include "ardour/delivery.h"
 #include "ardour/libardour_visibility.h"
 #include "ardour/types.h"
 
@@ -53,6 +54,10 @@ class LIBARDOUR_API PortInsert : public IOProcessor
 	int set_state (const XMLNode&, int version);
 
 	void run (BufferSet& bufs, framepos_t start_frame, framepos_t end_frame, double speed, pframes_t nframes, bool);
+
+	void flush_buffers (framecnt_t nframes) {
+		_out->flush_buffers (nframes);
+	}
 
 	framecnt_t signal_latency () const;
 

--- a/libs/ardour/ardour/route.h
+++ b/libs/ardour/ardour/route.h
@@ -588,6 +588,8 @@ public:
 	                                     pframes_t nframes, int declick,
 	                                     bool gain_automation_ok);
 
+	void flush_processor_buffers_locked (framecnt_t nframes);
+
 	virtual void bounce_process (BufferSet& bufs,
 	                             framepos_t start_frame, framecnt_t nframes,
 															 boost::shared_ptr<Processor> endpoint, bool include_endpoint,

--- a/libs/ardour/audio_track.cc
+++ b/libs/ardour/audio_track.cc
@@ -394,12 +394,7 @@ AudioTrack::roll (pframes_t nframes, framepos_t start_frame, framepos_t end_fram
 
 	process_output_buffers (bufs, start_frame, end_frame, nframes, declick, (!diskstream->record_enabled() && _session.transport_rolling()));
 
-	for (ProcessorList::iterator i = _processors.begin(); i != _processors.end(); ++i) {
-		boost::shared_ptr<Delivery> d = boost::dynamic_pointer_cast<Delivery> (*i);
-		if (d) {
-			d->flush_buffers (nframes);
-		}
-	}
+	flush_processor_buffers_locked (nframes);
 
 	need_butler = diskstream->commit (playback_distance);
 

--- a/libs/ardour/midi_track.cc
+++ b/libs/ardour/midi_track.cc
@@ -444,12 +444,7 @@ MidiTrack::roll (pframes_t nframes, framepos_t start_frame, framepos_t end_frame
 	process_output_buffers (bufs, start_frame, end_frame, nframes,
 				declick, (!diskstream->record_enabled() && !_session.transport_stopped()));
 
-	for (ProcessorList::iterator i = _processors.begin(); i != _processors.end(); ++i) {
-		boost::shared_ptr<Delivery> d = boost::dynamic_pointer_cast<Delivery> (*i);
-		if (d) {
-			d->flush_buffers (nframes);
-		}
-	}
+	flush_processor_buffers_locked (nframes);
 
 	need_butler = diskstream->commit (playback_distance);
 

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -3398,6 +3398,11 @@ Route::flush_processor_buffers_locked (framecnt_t nframes)
 		boost::shared_ptr<Delivery> d = boost::dynamic_pointer_cast<Delivery> (*i);
 		if (d) {
 			d->flush_buffers (nframes);
+		} else {
+			boost::shared_ptr<PortInsert> p = boost::dynamic_pointer_cast<PortInsert> (*i);
+			if (p) {
+				p->flush_buffers (nframes);
+			}
 		}
 	}
 }

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -3501,6 +3501,7 @@ int
 Route::silent_roll (pframes_t nframes, framepos_t /*start_frame*/, framepos_t /*end_frame*/, bool& /* need_butler */)
 {
 	silence (nframes);
+	flush_processor_buffers_locked (nframes);
 	return 0;
 }
 

--- a/libs/ardour/track.cc
+++ b/libs/ardour/track.cc
@@ -496,6 +496,7 @@ Track::silent_roll (pframes_t nframes, framepos_t /*start_frame*/, framepos_t /*
 	_amp->apply_gain_automation(false);
 
 	silence (nframes);
+	flush_processor_buffers_locked (nframes);
 
 	framecnt_t playback_distance;
 

--- a/libs/ardour/track.cc
+++ b/libs/ardour/track.cc
@@ -466,12 +466,7 @@ Track::no_roll (pframes_t nframes, framepos_t start_frame, framepos_t end_frame,
 		passthru (bufs, start_frame, end_frame, nframes, false);
 	}
 
-	for (ProcessorList::iterator i = _processors.begin(); i != _processors.end(); ++i) {
-		boost::shared_ptr<Delivery> d = boost::dynamic_pointer_cast<Delivery> (*i);
-		if (d) {
-			d->flush_buffers (nframes);
-		}
-	}
+	flush_processor_buffers_locked (nframes);
 
 	return 0;
 }


### PR DESCRIPTION
In particular this fixes sending MIDI data with inserts when the destination is another Ardour track.