### PR TITLE
Better choice for ports on external send creation

### DIFF
--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -2496,7 +2496,7 @@ ProcessorBox::choose_send ()
 	boost::shared_ptr<Send> send (new Send (*_session, _route->pannable (), _route->mute_master()));
 
 	/* make an educated guess at the initial number of outputs for the send */
-	ChanCount outs = (_session->master_out())
+	ChanCount outs = (_route->n_outputs().n_audio() && _session->master_out())
 			? _session->master_out()->n_outputs()
 			: _route->n_outputs();
 


### PR DESCRIPTION
Ardour tried to make an educated guess at the initial number of outputs
for a new send. It used the channel configuration of the master bus, if
it existed, else the channel configuration of the route itself.

That guess is good in most cases, but in the case of a track/bus without
audio channels, creating a send with audio doesn't make sense. In that
case, also use the route outputs as a base for the send configuration.