### PR TITLE
workaround changes in glibmm 2.49.x

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -5397,16 +5397,16 @@ ARDOUR_UI::setup_toplevel_window (Gtk::Window& window, const string& name, void*
 
 	if (window_icons.empty()) {
 		Glib::RefPtr<Gdk::Pixbuf> icon;
-		if ((icon = ::get_icon (PROGRAM_NAME "-icon_16px")) != 0) {
+		if ((icon = ::get_icon (PROGRAM_NAME "-icon_16px"))) {
 			window_icons.push_back (icon);
 		}
-		if ((icon = ::get_icon (PROGRAM_NAME "-icon_22px")) != 0) {
+		if ((icon = ::get_icon (PROGRAM_NAME "-icon_22px"))) {
 			window_icons.push_back (icon);
 		}
-		if ((icon = ::get_icon (PROGRAM_NAME "-icon_32px")) != 0) {
+		if ((icon = ::get_icon (PROGRAM_NAME "-icon_32px"))) {
 			window_icons.push_back (icon);
 		}
-		if ((icon = ::get_icon (PROGRAM_NAME "-icon_48px")) != 0) {
+		if ((icon = ::get_icon (PROGRAM_NAME "-icon_48px"))) {
 			window_icons.push_back (icon);
 		}
 	}

--- a/gtk2_ardour/fft_graph.cc
+++ b/gtk2_ardour/fft_graph.cc
@@ -312,7 +312,7 @@ FFTGraph::draw_scales (cairo_t* cr)
 	cairo_line_to (cr, width - 3              , .5 + v_margin); // 5
 	cairo_stroke (cr);
 
-	if (layout == 0) {
+	if (! layout) {
 		layout = create_pango_layout ("");
 		layout->set_font_description (get_style ()->get_font ());
 	}

--- a/gtk2_ardour/startup.cc
+++ b/gtk2_ardour/startup.cc
@@ -80,23 +80,23 @@ ArdourStartup::ArdourStartup ()
 	set_position (WIN_POS_CENTER);
 	set_border_width (12);
 
-	if ((icon_pixbuf = ::get_icon (PROGRAM_NAME "-icon_48px")) == 0) {
+	if (! (icon_pixbuf = ::get_icon (PROGRAM_NAME "-icon_48px"))) {
 		throw failed_constructor();
 	}
 
 	list<Glib::RefPtr<Gdk::Pixbuf> > window_icons;
 	Glib::RefPtr<Gdk::Pixbuf> icon;
 
-	if ((icon = ::get_icon (PROGRAM_NAME "-icon_16px")) != 0) {
+	if ((icon = ::get_icon (PROGRAM_NAME "-icon_16px"))) {
 		window_icons.push_back (icon);
 	}
-	if ((icon = ::get_icon (PROGRAM_NAME "-icon_22px")) != 0) {
+	if ((icon = ::get_icon (PROGRAM_NAME "-icon_22px"))) {
 		window_icons.push_back (icon);
 	}
-	if ((icon = ::get_icon (PROGRAM_NAME "-icon_32px")) != 0) {
+	if ((icon = ::get_icon (PROGRAM_NAME "-icon_32px"))) {
 		window_icons.push_back (icon);
 	}
-	if ((icon = ::get_icon (PROGRAM_NAME "-icon_48px")) != 0) {
+	if ((icon = ::get_icon (PROGRAM_NAME "-icon_48px"))) {
 		window_icons.push_back (icon);
 	}
 	if (!window_icons.empty ()) {

--- a/libs/gtkmm2ext/actions.cc
+++ b/libs/gtkmm2ext/actions.cc
@@ -167,7 +167,7 @@ ActionManager::get_action (const char* group_name, const char* action_name)
 	   gtkmm2.6, so we fall back to the C level.
 	*/
 
-	if (ui_manager == 0) {
+	if (! ui_manager) {
 		return RefPtr<Action> ();
 	}
 

--- a/libs/gtkmm2ext/fastmeter.cc
+++ b/libs/gtkmm2ext/fastmeter.cc
@@ -731,7 +731,7 @@ FastMeter::set (float lvl, float peak)
 
 	Glib::RefPtr<Gdk::Window> win;
 
-	if ((win = get_window()) == 0) {
+	if (! (win = get_window())) {
 		queue_draw ();
 		return;
 	}


### PR DESCRIPTION
Glib::RefPtr defines the operator bool() as explicit which breaks
comparisons like "some_ref_ptr == 0" or "... != 0".

https://bugzilla.gnome.org/show_bug.cgi?id=769502