### PR TITLE
allow linking unbundled version of qm-dsp

### DIFF
--- a/libs/qm-dsp/wscript
+++ b/libs/qm-dsp/wscript
@@ -23,10 +23,17 @@ def options(opt):
     autowaf.set_options(opt)
 
 def configure(conf):
-    conf.load('compiler_cxx')
-    autowaf.configure(conf)
+    if conf.is_defined('USE_EXTERNAL_LIBS'):
+        conf.check_cxx(header_name="base/Pitch.h", mandatory=True)
+        conf.check_cxx(lib="qm-dsp", uselib_store="QMDSP", mandatory=True)
+    else:
+        conf.load('compiler_cxx')
+        autowaf.configure(conf)
 
 def build(bld):
+    if bld.is_defined('USE_EXTERNAL_LIBS'):
+        return
+
     # Host Library
     obj = bld(features = 'cxx cxxshlib')
     obj.source = '''
@@ -50,8 +57,8 @@ def build(bld):
     autowaf.ensure_visible_symbols (obj, True)
     obj.export_includes = ['.']
     obj.includes     = ['.']
-    obj.name         = 'libqmdsp'
-    obj.target       = 'qmdsp'
+    obj.name         = 'libqm-dsp'
+    obj.target       = 'qm-dsp'
     obj.vnum         = QM_DSP_VERSION
     obj.install_path = bld.env['LIBDIR']
 

--- a/libs/vamp-plugins/wscript
+++ b/libs/vamp-plugins/wscript
@@ -50,8 +50,8 @@ def build(bld):
     obj.includes     = ['.']
     obj.name         = 'libardourvampplugins'
     obj.target       = 'ardourvampplugins'
-    obj.uselib       = 'FFTW3F VAMPSDK'
-    obj.use          = 'libvampplugin libqmdsp'
+    obj.uselib       = 'FFTW3F VAMPSDK QMDSP'
+    obj.use          = 'libvampplugin libqm-dsp'
     autowaf.ensure_visible_symbols (obj, True)
     if bld.is_defined('HAVE_AUBIO4'):
         obj.source += ' Onset.cpp '

--- a/wscript
+++ b/wscript
@@ -773,6 +773,10 @@ def options(opt):
                     help='Turn on PT session import option')
     opt.add_option('--no-threaded-waveviews', action='store_true', default=False, dest='no_threaded_waveviews',
                     help='Disable threaded waveview rendering')
+    opt.add_option(
+        '--qm-dsp-include', type='string', action='store',
+        dest='qm_dsp_include', default='/usr/include/qm-dsp',
+        help='directory where the header files of qm-dsp can be found')
 
     for i in children:
         opt.recurse(i)
@@ -933,6 +937,8 @@ def configure(conf):
 
     if Options.options.use_external_libs:
         conf.define('USE_EXTERNAL_LIBS', 1)
+        conf.env.append_value(
+            'CXXFLAGS', '-I' + Options.options.qm_dsp_include)
 
     if Options.options.boost_include != '':
         conf.env.append_value('CXXFLAGS', '-I' + Options.options.boost_include)


### PR DESCRIPTION
In the course, rename the bundled, built version libqm-dsp so it matches
packaged versions.