### PR TITLE
Update clear-gray-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/clear-gray-ardour.colors
+++ b/gtk2_ardour/themes/clear-gray-ardour.colors
@@ -175,7 +175,7 @@
     <ColorAlias name="gtk_audio_track" alias="color 25"/>
     <ColorAlias name="gtk_automation_track_header" alias="color 48"/>
     <ColorAlias name="gtk_background" alias="color 87"/>
-    <ColorAlias name="gtk_bases" alias="color 22"/>
+    <ColorAlias name="gtk_bases" alias="color 88"/>
     <ColorAlias name="gtk_bg_selected" alias="color 81"/>
     <ColorAlias name="gtk_bg_tooltip" alias="color 74"/>
     <ColorAlias name="gtk_bright_color" alias="color 74"/>


### PR DESCRIPTION

![correction_060916](https://cloud.githubusercontent.com/assets/19673308/18288003/906e4b4c-748a-11e6-911a-59e630a2dae5.jpg)
This commit changes item "gtk_bases" from light (color22) to darker (color88). The knob of "Enable/Disable MIDI input" in Edit List had the same colour and was not visible. This commit makes it clear visible, and it has no much influence on a general design.