### PR TITLE
Update cubasish-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -180,7 +180,7 @@
     <ColorAlias name="gtk_bg_selected" alias="color 99"/>
     <ColorAlias name="gtk_bg_tooltip" alias="color 52"/>
     <ColorAlias name="gtk_bright_color" alias="color 74"/>
-    <ColorAlias name="gtk_bright_indicator" alias="color 9"/>
+    <ColorAlias name="gtk_bright_indicator" alias="color 98"/>
     <ColorAlias name="gtk_contrasting_indicator" alias="color 91"/>
     <ColorAlias name="gtk_control_master" alias="color 64"/>
     <ColorAlias name="gtk_control_text" alias="color 26"/>


### PR DESCRIPTION

![cor_070916](https://cloud.githubusercontent.com/assets/19673308/18328050/39bdee0e-755e-11e6-94f0-8d2457857fd2.jpg)
 This commit changes the colour of the clip indicator in the meters (gtk_bright_indicator) from white (color9) to violet (color98). The reason is the small emphasis of the white clip indicator. Also the numerics in the clip indicator are not readable.

 P.S. I'd like to make the clip indicator red coloured, but I've faced with some problem about the general design of this theme. I reported here: http://tracker.ardour.org/view.php?id=7010