### PR TITLE
Fix the visibility of the patch changes after trimmed region start.

### DIFF
--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -1428,14 +1428,6 @@ MidiRegionView::reset_width_dependent_items (double pixel_width)
 		redisplay_model();
 	}
 
-	for (PatchChanges::iterator x = _patch_changes.begin(); x != _patch_changes.end(); ++x) {
-		if ((*x)->canvas_item()->width() >= _pixel_width) {
-			(*x)->hide();
-		} else {
-			(*x)->show();
-		}
-	}
-
 	move_step_edit_cursor (_step_edit_cursor_position);
 	set_step_edit_cursor_width (_step_edit_cursor_width);
 }


### PR DESCRIPTION
Updated for all the channels in display_patch_changes().

- add a midi track
- add a midi region and insert a patch change
- trim the start of the region after the patch change (flag out of the region)

Note: the follow test in add_canvas_patch_change() seems better:

```
-    if (patch_change->item().width() < _pixel_width) {
+    if (patch_change->item().width() < _pixel_width + region_frames) {
```

[ add_canvas_patch_change() is called during display_patch_changes() ]
