### PR TITLE
Match new[] with delete[]

### DIFF
--- a/libs/ardour/rb_effect.cc
+++ b/libs/ardour/rb_effect.cc
@@ -372,7 +372,7 @@ RBEffect::run (boost::shared_ptr<Region> r, Progress* progress)
 
 	if (buffers) {
 		for (uint32_t i = 0; i < channels; ++i) {
-			delete buffers[i];
+			delete [] buffers[i];
 		}
 		delete [] buffers;
 	}


### PR DESCRIPTION
Found with address sanitizer while investigating bug 0007043.