### PR TITLE
Add region position to note start in the midi list editor

### DIFF
--- a/gtk2_ardour/midi_list_editor.cc
+++ b/gtk2_ardour/midi_list_editor.cc
@@ -764,7 +764,7 @@ MidiListEditor::redisplay_model ()
 			row[columns.note] = (*i)->note();
 			row[columns.velocity] = (*i)->velocity();
 
-			Timecode::BBT_Time bbt (_session->tempo_map().bbt_at_frame (conv.to ((*i)->time())));
+			Timecode::BBT_Time bbt (_session->tempo_map().bbt_at_frame (region->position() + conv.to ((*i)->time())));
 
 			ss.str ("");
 			ss << bbt;


### PR DESCRIPTION
This PR fixes a small bug in the midi list editor when the region is not at the origin of the timeline. Start notes were not properly calculated taking into account the region position.