### PR TITLE
Don't reset the audio tracks name when changing the number of channels.

### DIFF
--- a/gtk2_ardour/add_route_dialog.cc
+++ b/gtk2_ardour/add_route_dialog.cc
@@ -209,7 +209,6 @@ AddRouteDialog::~AddRouteDialog ()
 void
 AddRouteDialog::channel_combo_changed ()
 {
-	maybe_update_name_template_entry ();
 	refill_track_modes ();
 }
 


### PR DESCRIPTION
The audio track name appears above the channel configuration. The natural flow (top to bottom) is to type the track name in and then change the channel configuration.