### PR TITLE
Update cubasish-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -55,7 +55,7 @@
     <Color name="color 52" value="0xbba34cff"/>
     <Color name="color 53" value="0xf2c37dff"/>
     <Color name="color 54" value="0xf48352ff"/>
-    <Color name="color 55" value="0xf85813ff"/>
+    <Color name="color 55" value="0xff0009ff"/>
     <Color name="color 56" value="0x8ec794ff"/>
     <Color name="color 57" value="0x7ea854ff"/>
     <Color name="color 58" value="0x3e3e3eff"/>
@@ -181,7 +181,7 @@
     <ColorAlias name="gtk_bg_tooltip" alias="color 52"/>
     <ColorAlias name="gtk_bright_color" alias="color 74"/>
     <ColorAlias name="gtk_bright_indicator" alias="color 9"/>
-    <ColorAlias name="gtk_clip_indicator" alias="color 9"/>
+    <ColorAlias name="gtk_clip_indicator" alias="color 55"/>
     <ColorAlias name="gtk_contrasting_indicator" alias="color 91"/>
     <ColorAlias name="gtk_control_master" alias="color 64"/>
     <ColorAlias name="gtk_control_text" alias="color 26"/>


### PR DESCRIPTION
This commit changes the clip indicator from white to red coloured (from "color 9" to "color 55"). Also the "color 55" is changing from orange (f85813) to maximum bright red color (ff0009)
![cor_131016](https://cloud.githubusercontent.com/assets/19673308/19329563/790b87ea-90ea-11e6-8b8a-c61c5777b750.jpg)
