### PR TITLE
Append channel number as in Automatable::describe_parameter

### DIFF
--- a/libs/ardour/instrument_info.cc
+++ b/libs/ardour/instrument_info.cc
@@ -151,7 +151,8 @@ InstrumentInfo::get_controller_name (Evoral::Parameter param) const
 		return "";
 	}
 
-	return control_names->control(param.id())->name();
+	std::string name(control_names->control(param.id())->name());
+	return string_compose(name + " [%1]", int(param.channel()) + 1);
 }
 
 boost::shared_ptr<MIDI::Name::ChannelNameSet>


### PR DESCRIPTION
Fixing the fact that midi controller names coming from patch files don't have channel num appended to them.

I'm not totally sure it is the right way to do it but it works for me.
