### PR TITLE
Use correct action in map for Korg nanoKontrol2

### DIFF
--- a/midi_maps/Korg_nanoKONTROL2_With_Master.map
+++ b/midi_maps/Korg_nanoKONTROL2_With_Master.map
@@ -81,7 +81,7 @@
   
   
   <Binding channel="1" ctl="23" uri="/bus/panwidth master"/>
-  <Binding channel="1" ctl="39" action="Common/toggle-mixer-on-top"/>
+  <Binding channel="1" ctl="39" action="Common/toggle-editor-and-mixer"/>
   <Binding channel="1" ctl="55" uri="/bus/mute master"/>
   <Binding channel="1" ctl="7"  uri="/bus/gain master"/>
 


### PR DESCRIPTION
According to the comment in line 79, this button should toggle between mixer and 
editor windows - but it didn't (for me). Apparently that action named has changed 
in Ardour 5.x - anyway, using this command, it works for me.