### PR TITLE
Making one string translatable

### DIFF
--- a/gtk2_ardour/ardour_ui_dependents.cc
+++ b/gtk2_ardour/ardour_ui_dependents.cc
@@ -187,7 +187,7 @@ ARDOUR_UI::idle_ask_about_quit ()
 	} else {
 		/* no session or session not dirty, but still ask anyway */
 
-		Gtk::MessageDialog msg (string_compose ("Quit %1?", PROGRAM_NAME),
+		Gtk::MessageDialog msg (string_compose (_("Quit %1?"), PROGRAM_NAME),
 		                        false, /* no markup */
 		                        Gtk::MESSAGE_INFO,
 		                        Gtk::BUTTONS_YES_NO,


### PR DESCRIPTION
It should allow this dialog window to be translatable : 

![ardour-to_be_translatable](https://cloud.githubusercontent.com/assets/8705846/20846986/794a2b44-b8cc-11e6-9e0d-0c0370ef44ef.png)

I hope this is the correct way to do so. Please double-check what I've done before merging.