### PR TITLE
ifdef out uri_map when lv2_support is disabled

### DIFF
--- a/libs/ardour/automatable.cc
+++ b/libs/ardour/automatable.cc
@@ -37,7 +37,9 @@
 #include "ardour/plugin_insert.h"
 #include "ardour/record_enable_control.h"
 #include "ardour/session.h"
+#ifdef LV2_SUPPORT
 #include "ardour/uri_map.h"
+#endif
 #include "ardour/value_as_string.h"
 
 #include "pbd/i18n.h"

--- a/libs/ardour/buffer_set.cc
+++ b/libs/ardour/buffer_set.cc
@@ -34,10 +34,10 @@
 #include "ardour/midi_buffer.h"
 #include "ardour/port.h"
 #include "ardour/port_set.h"
-#include "ardour/uri_map.h"
 #ifdef LV2_SUPPORT
 #include "ardour/lv2_plugin.h"
 #include "lv2_evbuf.h"
+#include "ardour/uri_map.h"
 #endif
 #if defined WINDOWS_VST_SUPPORT || defined LXVST_SUPPORT || defined MACVST_SUPPORT
 #include "ardour/vestige/aeffectx.h"

--- a/libs/ardour/event_type_map.cc
+++ b/libs/ardour/event_type_map.cc
@@ -24,7 +24,9 @@
 #include "ardour/event_type_map.h"
 #include "ardour/parameter_descriptor.h"
 #include "ardour/parameter_types.h"
+#ifdef LV2_Support
 #include "ardour/uri_map.h"
+#endif
 #include "evoral/Parameter.hpp"
 #include "evoral/ParameterDescriptor.hpp"
 #include "evoral/midi_events.h"

--- a/libs/ardour/globals.cc
+++ b/libs/ardour/globals.cc
@@ -111,8 +111,9 @@
 #include "ardour/runtime_functions.h"
 #include "ardour/session_event.h"
 #include "ardour/source_factory.h"
+#ifdef LV2_SUPPORT
 #include "ardour/uri_map.h"
-
+#endif
 #include "audiographer/routines.h"
 
 #if defined (__APPLE__)

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -92,7 +92,9 @@
 #include "ardour/filename_extensions.h"
 #include "ardour/graph.h"
 #include "ardour/location.h"
+#ifdef LV2_SUPPORT
 #include "ardour/lv2_plugin.h"
+#endif
 #include "ardour/midi_model.h"
 #include "ardour/midi_patch_manager.h"
 #include "ardour/midi_region.h"
@@ -5226,8 +5228,9 @@ Session::archive_session (const std::string& dest,
 	/* write session file */
 	_path = to_dir;
 	g_mkdir_with_parents (externals_dir ().c_str (), 0755);
-
+#ifdef LV2_SUPPORT
 	PBD::Unwinder<bool> uw (LV2Plugin::force_state_save, true);
+#endif
 	save_state (name);
 	save_default_options ();
 

--- a/libs/pbd/pbd/configuration_variable.h
+++ b/libs/pbd/pbd/configuration_variable.h
@@ -90,7 +90,7 @@ class /*LIBPBD_API*/ ConfigVariable : public ConfigVariableBase
 };
 
 /** Specialisation of ConfigVariable to deal with float (-inf etc) */
-template<> void
+template<> LIBPBD_API void
 ConfigVariable<float>::set_from_string (std::string const & s);
 
 /** Specialisation of ConfigVariable for std::string to cope with whitespace properly */


### PR DESCRIPTION
Currently when compiling Ardour on FreeBSD11 with the option --no-lv2, ardour will still attempt to use uri_map.h and lv2_plugin.h in a few places, even though in theory the option should disable it. This is a fix for this issue. 