### PR TITLE
Update blueberry_milk-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -97,7 +97,7 @@
     <Color name="color 90" value="0x222020ff"/>
     <Color name="color 91" value="0x8ef823ff"/>
     <Color name="color 92" value="0xcfdee4ff"/>
-    <Color name="color 93" value="0x51578aff"/>
+    <Color name="color 93" value="0x2F3880ff"/>
     <Color name="color 94" value="0x636363ff"/>
     <Color name="color 95" value="0xe4f4d3ff"/>
     <Color name="color 96" value="0x85e524ff"/>
@@ -172,7 +172,7 @@
     <ColorAlias name="ghost track wave fill" alias="color 29"/>
     <ColorAlias name="ghost track zero line" alias="color 30"/>
     <ColorAlias name="gtk_arm" alias="color 9"/>
-    <ColorAlias name="gtk_audio_bus" alias="color 2"/>
+    <ColorAlias name="gtk_audio_bus" alias="color 4"/>
     <ColorAlias name="gtk_audio_track" alias="color 16"/>
     <ColorAlias name="gtk_automation_track_header" alias="color 13"/>
     <ColorAlias name="gtk_background" alias="color 22"/>
@@ -180,7 +180,7 @@
     <ColorAlias name="gtk_bg_selected" alias="color 99"/>
     <ColorAlias name="gtk_bg_tooltip" alias="color 52"/>
     <ColorAlias name="gtk_bright_color" alias="color 74"/>
-    <ColorAlias name="gtk_bright_indicator" alias="color 9"/>
+    <ColorAlias name="gtk_bright_indicator" alias="color 23"/>
     <ColorAlias name="gtk_clip_indicator" alias="color 9"/>
     <ColorAlias name="gtk_contrasting_indicator" alias="color 91"/>
     <ColorAlias name="gtk_control_master" alias="color 64"/>
@@ -210,9 +210,9 @@
     <ColorAlias name="gtk_send_fg" alias="color 24"/>
     <ColorAlias name="gtk_solo" alias="color 91"/>
     <ColorAlias name="gtk_somewhat_bright_indicator" alias="color 89"/>
-    <ColorAlias name="gtk_texts" alias="color 7"/>
+    <ColorAlias name="gtk_texts" alias="color 27"/>
     <ColorAlias name="gtk_track_header_inactive" alias="color 34"/>
-    <ColorAlias name="gtk_track_header_selected" alias="color 59"/>
+    <ColorAlias name="gtk_track_header_selected" alias="color 23"/>
     <ColorAlias name="image track" alias="color 31"/>
     <ColorAlias name="inactive crossfade" alias="color 32"/>
     <ColorAlias name="inactive fade handle" alias="color 33"/>
@@ -397,7 +397,7 @@
     <ColorAlias name="secondary delta clock: text" alias="color 92"/>
     <ColorAlias name="selected midi note frame" alias="color 63"/>
     <ColorAlias name="selected region base" alias="color 22"/>
-    <ColorAlias name="selected time axis frame" alias="color 86"/>
+    <ColorAlias name="selected time axis frame" alias="color 85"/>
     <ColorAlias name="selected waveform fill" alias="color 21"/>
     <ColorAlias name="selected waveform outline" alias="color 67"/>
     <ColorAlias name="selection" alias="color 94"/>
@@ -493,7 +493,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.7"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.9"/>
-    <Modifier name="editable region" modifier="= alpha:0.0752019"/>
+    <Modifier name="editable region" modifier="= alpha:0.14"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>


### PR DESCRIPTION

![blue_b_m_corrections_291216](https://cloud.githubusercontent.com/assets/19673308/21556652/c697d5f2-ce3b-11e6-8205-a54ba28e79ed.png)
1. The frame of the selected track header is changed from Red to Violet color. It's more  harmoniously with general design. (gtk_bright_indicator - color 23)
2. The fill of the selected track header is changed to Violet color. It was very similar to an unselected midi track header. Also more  harmoniously with general design. (gtk_track_header_selected - color 23)
3. The frame of the selected midi region is changed from Brown to Blue color. This is more noticeable & harmoniously with a general design. (selected time axis frame - color 85)
4. The GTK text is changed to darker – more readable. (gtk_texts – color 27)
5. The text of the general menu, names of tracks is changed to darker – more readable. (gtk_foreground: color 93: from #51578A to #2F3880)
6. The fill of the selected BUS-track header is changed to lighter. It’s more close to “light-theme-conception” and makes more readable the name track text. (gtk_audio_bus – color 4)
7. The transparency of the midi region in “E”-mouse mode is little reduced. This parameter has the same value to all cooltehno’s themes now. (editable region – alpha:0.14)