### PR TITLE
Update caineville-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -464,7 +464,7 @@
     <ColorAlias name="transport marker bar" alias="color 25"/>
     <ColorAlias name="transport option button: fill active" alias="color 42"/>
     <ColorAlias name="transport option button: led active" alias="color 8"/>
-    <ColorAlias name="transport punch rect" alias="color 62"/>
+    <ColorAlias name="transport punch rect" alias="color 9"/>
     <ColorAlias name="transport recenable button: fill" alias="color 20"/>
     <ColorAlias name="transport recenable button: fill active" alias="color 83"/>
     <ColorAlias name="transport recenable button: led active" alias="color 4"/>
@@ -488,7 +488,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.680625"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.92"/>
-    <Modifier name="editable region" modifier="= alpha:0"/>
+    <Modifier name="editable region" modifier="= alpha:0.14"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>


### PR DESCRIPTION
![caineville_corrections_291216](https://cloud.githubusercontent.com/assets/19673308/21556794/4b75f74e-ce3d-11e6-948a-b8aad5f1b316.png)
1. The punch rectangle is changed from Yellow to Orange color. (transport punch rect - color 9)
2. The transparency of the midi region in “E”-mouse mode is little reduced. This parameter has the same value to all cooltehno’s themes now. (editable region – alpha:0.14)