### PR TITLE
Update clear_gray-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -460,7 +460,7 @@
     <ColorAlias name="transport marker bar" alias="color 25"/>
     <ColorAlias name="transport option button: fill active" alias="color 42"/>
     <ColorAlias name="transport option button: led active" alias="color 8"/>
-    <ColorAlias name="transport punch rect" alias="meter color9"/>
+    <ColorAlias name="transport punch rect" alias="color 91"/>
     <ColorAlias name="transport recenable button: fill" alias="color 20"/>
     <ColorAlias name="transport recenable button: fill active" alias="color 83"/>
     <ColorAlias name="transport recenable button: led active" alias="color 4"/>
@@ -484,7 +484,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.680625"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.92"/>
-    <Modifier name="editable region" modifier="= alpha:0"/>
+    <Modifier name="editable region" modifier="= alpha:0.14"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>


### PR DESCRIPTION
![clear_gray_corrections_291216](https://cloud.githubusercontent.com/assets/19673308/21556861/06777766-ce3e-11e6-9f05-a05726eb6208.png)
1. The punch rectangle is changed to lighter color. It was too much bright (transport punch rect - color 91)
2. The transparency of the midi region in “E”-mouse mode is little reduced. So we could slightly see the tracks colors. This parameter has the same value to all cooltehno’s themes now. (editable region – alpha:0.14)