### PR TITLE
Update cubasish-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -247,7 +247,7 @@
     <ColorAlias name="meterbridge label: led" alias="color 9"/>
     <ColorAlias name="meterbridge label: led active" alias="color 9"/>
     <ColorAlias name="meterbridge peakindicator: fill" alias="color 34"/>
-    <ColorAlias name="meterbridge peakindicator: fill active" alias="color 9"/>
+    <ColorAlias name="meterbridge peakindicator: fill active" alias="meter color9"/>
     <ColorAlias name="meterbridge peakindicator: led" alias="color 9"/>
     <ColorAlias name="meterbridge peakindicator: led active" alias="color 9"/>
     <ColorAlias name="meterbridge peaklabel" alias="color 9"/>
@@ -488,7 +488,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.700615"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.423606"/>
     <Modifier name="dragging region" modifier="= alpha:0.99"/>
-    <Modifier name="editable region" modifier="= alpha:0"/>
+    <Modifier name="editable region" modifier="= alpha:0.14"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.182769"/>


### PR DESCRIPTION
![cubasish_corrections_291216](https://cloud.githubusercontent.com/assets/19673308/21556966/1b9df52e-ce3f-11e6-8937-9004a1b39846.png)
1. The peak indicator of the transport panel is changed from White to Red color. It was missed to change in the past commit (meterbridge peakindicator>fill active - meter color 9)
2. The transparency of the midi region in “E”-mouse mode is little reduced. So we could slightly see the tracks colors. This parameter has the same value to all cooltehno’s themes now. (editable region – alpha:0.14)