### PR TITLE
Formula fix for slider position (new gain math)

### DIFF
--- a/libs/ardour/ardour/utils.h
+++ b/libs/ardour/ardour/utils.h
@@ -144,9 +144,8 @@ slider_position_to_gain (double pos)
 
 	return g;
 #else
-	/* XXX Marcus writes: this doesn't seem right to me. but i don't have a better answer ... */
 	if (pos == 0.0) return 0;
-	return pow (2.0,(sqrt(sqrt(sqrt(pos)))*198.0-192.0)/6.0);
+	return exp(((pow(pos,1.0/8.0)*198.0)-192.0)/6.0*log(2.0));
 #endif
 }
 #undef OLD_GAIN_MATH


### PR DESCRIPTION
Was reading through the source code and looked into reusing slider_position_to_gain and gain_to_slider_position for another open source project. I noticed the comment "/* XXX Marcus writes: this doesn't seem right to me. but i don't have a better answer ... */" and wrote the proper inverse formula instead of the one that's in the sources. Maybe this helps.