### PR TITLE
Refine Beats::operator== down to half a tick

### DIFF
--- a/libs/evoral/evoral/Beats.hpp
+++ b/libs/evoral/evoral/Beats.hpp
@@ -77,18 +77,18 @@ public:
 	}
 
 	inline bool operator==(const Beats& b) const {
-		/* Acceptable tolerance is 1 tick. */
-		return fabs(_time - b._time) <= (1.0 / PPQN);
+		/* Acceptable tolerance is 1/2 tick. */
+		return fabs(_time - b._time) <= (0.5 / PPQN);
 	}
 
 	inline bool operator==(double t) const {
-		/* Acceptable tolerance is 1 tick. */
-		return fabs(_time - t) <= (1.0 / PPQN);
+		/* Acceptable tolerance is 1/2 tick. */
+		return fabs(_time - t) <= (0.5 / PPQN);
 	}
 
 	inline bool operator==(int beats) const {
-		/* Acceptable tolerance is 1 tick. */
-		return fabs(_time - beats) <= (1.0 / PPQN);
+		/* Acceptable tolerance is 1/2 tick. */
+		return fabs(_time - beats) <= (0.5 / PPQN);
 	}
 
 	inline bool operator!=(const Beats& b) const {
@@ -96,8 +96,8 @@ public:
 	}
 
 	inline bool operator<(const Beats& b) const {
-		/* Acceptable tolerance is 1 tick. */
-		if (fabs(_time - b._time) <= (1.0 / PPQN)) {
+		/* Acceptable tolerance is 1/2 tick. */
+		if (fabs(_time - b._time) <= (0.5 / PPQN)) {
 			return false;  /* Effectively identical. */
 		} else {
 			return _time < b._time;
@@ -109,8 +109,8 @@ public:
 	}
 
 	inline bool operator>(const Beats& b) const {
-		/* Acceptable tolerance is 1 tick. */
-		if (fabs(_time - b._time) <= (1.0 / PPQN)) {
+		/* Acceptable tolerance is 1/2 tick. */
+		if (fabs(_time - b._time) <= (0.5 / PPQN)) {
 			return false;  /* Effectively identical. */
 		} else {
 			return _time > b._time;
@@ -122,8 +122,8 @@ public:
 	}
 
 	inline bool operator<(double b) const {
-		/* Acceptable tolerance is 1 tick. */
-		if (fabs(_time - b) <= (1.0 / PPQN)) {
+		/* Acceptable tolerance is 1/2 tick. */
+		if (fabs(_time - b) <= (0.5 / PPQN)) {
 			return false;  /* Effectively identical. */
 		} else {
 			return _time < b;
@@ -135,8 +135,8 @@ public:
 	}
 
 	inline bool operator>(double b) const {
-		/* Acceptable tolerance is 1 tick. */
-		if (fabs(_time - b) <= (1.0 / PPQN)) {
+		/* Acceptable tolerance is 1/2 tick. */
+		if (fabs(_time - b) <= (0.5 / PPQN)) {
 			return false;  /* Effectively identical. */
 		} else {
 			return _time > b;

--- a/libs/evoral/evoral/Beats.hpp
+++ b/libs/evoral/evoral/Beats.hpp
@@ -96,55 +96,35 @@ public:
 	}
 
 	inline bool operator<(const Beats& b) const {
-		/* Acceptable tolerance is 1/2 tick. */
-		if (fabs(_time - b._time) <= (0.5 / PPQN)) {
-			return false;  /* Effectively identical. */
-		} else {
-			return _time < b._time;
-		}
+		return operator==(b) ? false /* Effectively identical */ : _time < b._time;
 	}
 
 	inline bool operator<=(const Beats& b) const {
-		return operator==(b) || operator<(b);
+		return !operator>(b);
 	}
 
 	inline bool operator>(const Beats& b) const {
-		/* Acceptable tolerance is 1/2 tick. */
-		if (fabs(_time - b._time) <= (0.5 / PPQN)) {
-			return false;  /* Effectively identical. */
-		} else {
-			return _time > b._time;
-		}
+		return operator==(b) ? false /* Effectively identical */ : _time > b._time;
 	}
 
 	inline bool operator>=(const Beats& b) const {
-		return operator==(b) || operator>(b);
+		return !operator<(b);
 	}
 
 	inline bool operator<(double b) const {
-		/* Acceptable tolerance is 1/2 tick. */
-		if (fabs(_time - b) <= (0.5 / PPQN)) {
-			return false;  /* Effectively identical. */
-		} else {
-			return _time < b;
-		}
+		return operator==(b) ? false /* Effectively identical */ : _time < b;
 	}
 
 	inline bool operator<=(double b) const {
-		return operator==(b) || operator<(b);
+		return !operator>(b);
 	}
 
 	inline bool operator>(double b) const {
-		/* Acceptable tolerance is 1/2 tick. */
-		if (fabs(_time - b) <= (0.5 / PPQN)) {
-			return false;  /* Effectively identical. */
-		} else {
-			return _time > b;
-		}
+		return operator==(b) ? false /* Effectively identical */ : _time > b;
 	}
 
 	inline bool operator>=(double b) const {
-		return operator==(b) || operator>(b);
+		return !operator<(b);
 	}
 
 	Beats operator+(const Beats& b) const {

--- a/libs/evoral/test/BeatsTest.cpp
+++ b/libs/evoral/test/BeatsTest.cpp
@@ -1,0 +1,14 @@
+#include "BeatsTest.hpp"
+#include "evoral/Beats.hpp"
+#include <stdlib.h>
+
+CPPUNIT_TEST_SUITE_REGISTRATION (BeatsTest);
+
+using namespace Evoral;
+
+void
+BeatsTest::operator_eq ()
+{
+	for (int i = 1; i < 1000; i++)
+		CPPUNIT_ASSERT (Beats::ticks(i-1).operator!=(Beats::ticks(i)));
+}

--- a/libs/evoral/test/BeatsTest.hpp
+++ b/libs/evoral/test/BeatsTest.hpp
@@ -1,0 +1,12 @@
+#include <cppunit/TestFixture.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+class BeatsTest : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE (BeatsTest);
+	CPPUNIT_TEST (operator_eq);
+	CPPUNIT_TEST_SUITE_END ();
+
+public:
+	void operator_eq ();
+};

--- a/libs/evoral/wscript
+++ b/libs/evoral/wscript
@@ -146,6 +146,7 @@ def build(bld):
                 test/RangeTest.cpp
                 test/NoteTest.cpp
                 test/CurveTest.cpp
+                test/BeatsTest.cpp
                 test/testrunner.cpp
         '''
         obj.includes     = ['.', './src']


### PR DESCRIPTION
This addresses an issue that rises when changing a midi note start time or length to +/- one tick (I wanted to create an issue in the bug tracker but I'm still waiting for receiving the email to complete the process of creating my account).

To reproduce it: left-click on a midi note, open the note edit dialog and change the time or length by + or - one tick, then close, reopen on that same note, you'll notice that the tick hasn't changed. If it has changed, then you're lucky, try again one another time or length and you'll see no change.

I initially tried to fix that by replacing `<=` by `<`, so specifically
```
		return fabs(_time - b._time) <= (1.0 / PPQN);
```
by
```
		return fabs(_time - b._time) < (1.0 / PPQN);
```
on all methods concerned but it didn't work (probably due to floating point inaccuracies, still weird cause it's double, but I don't have another explanation). So instead I replaced `1.0` by `0.5` and it works. I'm pretty sure replacing by say `0.95` would work just as well, but `0.5` rounds to half a tick and is cooler in my own mind. Feel free to change the value to anything as long it fixes the issue. I see no reason why 0.5 wouldn't be fine though.

P.S: you may need to replace in file `gtk2_ardour/audio_clock.cc` the following by
```
	if (_mode == MinSec)
		tmp->set_text (" 88:88:88,888 ");
	else
		tmp->set_text (" 88:88:88,88 ");
```
by
```
	tmp->set_text (" 88:88:88,888 ");
```
in order to see what you're editing in the note edit dialog. I wanted to create a PR for that but @x42 told be the issue might be more subtle than I think so I prefer to let to someone else.

Oh, something else, the first commit fixes the problem. The second commit improves the code of the various operators by reusing others when possible. I think it's better that way but if you don't like it for any reason feel free to cherry pick only the first commit, as the second one is not essential for the fix.