### PR TITLE
Update blueberry_milk-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -275,11 +275,11 @@
     <ColorAlias name="midi meter color8" alias="color 56"/>
     <ColorAlias name="midi meter color9" alias="color 17"/>
     <ColorAlias name="midi note inactive channel" alias="color 4"/>
-    <ColorAlias name="midi note max" alias="color 17"/>
-    <ColorAlias name="midi note mid" alias="color 62"/>
-    <ColorAlias name="midi note min" alias="color 93"/>
-    <ColorAlias name="midi note selected" alias="color 25"/>
-    <ColorAlias name="midi note selected outline" alias="color 85"/>
+    <ColorAlias name="midi note max" alias="color 67"/>
+    <ColorAlias name="midi note mid" alias="color 93"/>
+    <ColorAlias name="midi note min" alias="color 13"/>
+    <ColorAlias name="midi note selected" alias="color 91"/>
+    <ColorAlias name="midi note selected outline" alias="color 67"/>
     <ColorAlias name="midi note velocity text" alias="color 32"/>
     <ColorAlias name="midi patch change fill" alias="color 60"/>
     <ColorAlias name="midi patch change outline" alias="color 26"/>
@@ -478,7 +478,7 @@
     <ColorAlias name="trim knob" alias="color 60"/>
     <ColorAlias name="trim knob: arc end" alias="color 81"/>
     <ColorAlias name="trim knob: arc start" alias="color 82"/>
-    <ColorAlias name="verbose canvas cursor" alias="color 32"/>
+    <ColorAlias name="verbose canvas cursor" alias="color 13"/>
     <ColorAlias name="video timeline bar" alias="color 46"/>
     <ColorAlias name="waveform fill" alias="color 13"/>
     <ColorAlias name="waveform outline" alias="color 4"/>


### PR DESCRIPTION
![blue_b_m_correction_040417](https://cloud.githubusercontent.com/assets/19673308/24647057/49acd80a-192f-11e7-9641-abca1e0a8997.png)

1. The colour of selected notes is changed from grey to bright green (midi note selected - color 91), the colour of min velocity notes is changed to white (midi note min - color 13) - there was no visible difference between selected and min velocity notes. Also the outline of selected notes is changed to black (midi note selected outline - color 67) - it adds more visibility.
2. The colour of:
- min velocity notes is changed to white (midi note min - color 13);
- mid velocity notes is changed to dark blue (midi note mid - color 93);
- max velocity notes is changed to black (midi note mid - color 67).
It adds some more contrast and intuitive difference between min and max velocity notes.
3. The fill of the velocity information text is changed (verbose canvas cursor - color13).