### PR TITLE
Add note name parser to convert to midi note number

### DIFF
--- a/libs/ardour/ardour/parameter_descriptor.h
+++ b/libs/ardour/ardour/parameter_descriptor.h
@@ -43,7 +43,13 @@ struct LIBARDOUR_API ParameterDescriptor : public Evoral::ParameterDescriptor
 		HZ,         ///< Frequency in Hertz
 	};
 
-	static std::string midi_note_name (uint8_t);
+	static std::string midi_note_name (uint8_t, bool translate=true);
+
+	/** Dual of midi_note_name, convert a note name into its midi note number. */
+	typedef std::map<std::string, uint8_t> NameNumMap;
+	static std::string normalize_note_name(const std::string& name);
+	static NameNumMap build_midi_name2num();
+	static uint8_t midi_note_num (const std::string& name);
 
 	ParameterDescriptor(const Evoral::Parameter& parameter);
 


### PR DESCRIPTION
Supports i18n, is case and whitespace insensitive for more resilent parsing.