### PR TITLE
Fix double "Tape" in Record Mode drop down when adding new track.

### DIFF
--- a/gtk2_ardour/add_route_dialog.cc
+++ b/gtk2_ardour/add_route_dialog.cc
@@ -373,7 +373,6 @@ AddRouteDialog::refill_track_modes ()
 #ifdef XXX_OLD_DESTRUCTIVE_API_XXX
 	s.push_back (_("Non Layered"));
 #endif
-	s.push_back (_("Tape"));
 	if (!ARDOUR::Profile->get_mixbus ()) {
 		s.push_back (_("Tape"));
 	}


### PR DESCRIPTION
This bug probably also lead to "Tape" being shown in mixbus even
though it should not.
