### PR TITLE
Fix LD_LIBRARY_PATH in GNU/Linux startup script

### DIFF
--- a/tools/linux_packaging/ardour.sh.in
+++ b/tools/linux_packaging/ardour.sh.in
@@ -15,9 +15,8 @@ checkdebug(){
 checkdebug "$@"
 
 
-# LD_LIBRARY_PATH needs to be set here so that epa can swap between the original and the bundled version
-# (the original one will be stored in PREBUNDLE_ENV)
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+# this needs to be set so that we can restore the environment when we want to
+# find JACK (or similar)
 export PREBUNDLE_ENV="$(env)"
 
 BIN_DIR=$(dirname $(readlink -f $0))


### PR DESCRIPTION
Currently, the startup script for GNU/Linux adds the current working directory to ``LD_LIBRARY_PATH`` if ``LD_LIBRARY_PATH`` is not empty or unset.

For example, if ``LD_LIBRARY_PATH`` is set to ``/lib`` when the current script is run, it will be set to ``<install-dir>/lib::/lib``, which includes the current working directory as one of the paths.

This pull request removes the extra colon added to ``LD_LIBRARY_PATH``.