### PR TITLE
Fix a-EQ when parameter changes are very slow

### DIFF
--- a/libs/plugins/a-eq.lv2/a-eq.c
+++ b/libs/plugins/a-eq.lv2/a-eq.c
@@ -393,23 +393,17 @@ run(LV2_Handle instance, uint32_t n_samples)
 			if (!is_eq(aeq->v_f0[i], *aeq->f0[i], 0.1)) {
 				aeq->v_f0[i] += tau * (*aeq->f0[i] - aeq->v_f0[i]);
 				changed = true;
-			} else {
-				aeq->v_f0[i] = *aeq->f0[i];
 			}
 
 			if (*aeq->filtog[i] <= 0 || *aeq->enable <= 0) {
 				if (!is_eq(aeq->v_g[i], 0.f, 0.05)) {
 					aeq->v_g[i] += tau * (0.0 - aeq->v_g[i]);
 					changed = true;
-				} else {
-					aeq->v_g[i] = 0.0;
 				}
 			} else {
 				if (!is_eq(aeq->v_g[i], *aeq->g[i], 0.05)) {
 					aeq->v_g[i] += tau * (*aeq->g[i] - aeq->v_g[i]);
 					changed = true;
-				} else {
-					aeq->v_g[i] = *aeq->g[i];
 				}
 			}
 
@@ -417,8 +411,6 @@ run(LV2_Handle instance, uint32_t n_samples)
 				if (!is_eq(aeq->v_bw[i], *aeq->bw[i], 0.001)) {
 					aeq->v_bw[i] += tau * (*aeq->bw[i] - aeq->v_bw[i]);
 					changed = true;
-				} else {
-					aeq->v_bw[i] = *aeq->bw[i];
 				}
 			}
 


### PR DESCRIPTION


If the parameters change too slowly the filter may never get updated. Indeed,
in spite of v_f0, v_g or v_bw being updated, set_params may never be called,
thus v_filter never updated.

Find attached a project showing the problem. You'll see the frequency response graph doesn't get updated for the first 2 lines, cause the rate of change is too low. Of course it's not just the graph, the filter itself isn't updated as well.

[automation-debug.zip](https://github.com/Ardour/ardour/files/1050667/automation-debug.zip)
