### PR TITLE
Playhead update

### DIFF
--- a/libs/ardour/session_time.cc
+++ b/libs/ardour/session_time.cc
@@ -183,19 +183,26 @@ int
 Session::backend_sync_callback (TransportState state, framepos_t pos)
 {
 	bool slave = synced_to_engine();
+	// cerr << "Session::backend_sync_callback() _transport_frame: " << _transport_frame << " pos: " << pos << " audible_frame: " << audible_frame() << endl;
+
+	if (slave) {
+		// cerr << "Session::backend_sync_callback() emitting Located()" << endl;
+		Located (); /* EMIT SIGNAL */
+	}
 
 	switch (state) {
 	case TransportStopped:
 		if (slave && _transport_frame != pos && post_transport_work() == 0) {
 			request_locate (pos, false);
-			// cerr << "SYNC: stopped, locate to " << pos->frame << " from " << _transport_frame << endl;
+			// cerr << "SYNC: stopped, locate to " << pos << " from " << _transport_frame << endl;
 			return false;
 		} else {
+			// cerr << "SYNC: stopped, nothing to do" << endl;
 			return true;
 		}
 
 	case TransportStarting:
-		// cerr << "SYNC: starting @ " << pos->frame << " a@ " << _transport_frame << " our work = " <<  post_transport_work() << " pos matches ? " << (_transport_frame == pos->frame) << endl;
+		// cerr << "SYNC: starting @ " << pos << " a@ " << _transport_frame << " our work = " <<  post_transport_work() << " pos matches ? " << (_transport_frame == pos) << endl;
 		if (slave) {
 			return _transport_frame == pos && post_transport_work() == 0;
 		} else {

--- a/libs/ardour/session_transport.cc
+++ b/libs/ardour/session_transport.cc
@@ -1367,7 +1367,9 @@ Session::locate (framepos_t target_frame, bool with_roll, bool with_flush, bool 
 	}
 
 	_last_roll_location = _last_roll_or_reversal_location =  _transport_frame;
-	Located (); /* EMIT SIGNAL */
+	if (!synced_to_engine () || _transport_frame == _engine.transport_frame ()) {
+		Located (); /* EMIT SIGNAL */
+	}
 }
 
 /** Set the transport speed.


### PR DESCRIPTION
This adresses the issue described in http://tracker.ardour.org/view.php?id=6887#c19765

Two things:
* `Session::Located` is emitted in `Session::backend_sync_callback()` to make sure there is a Located signal when `AudioEngine::transport_frame()` is up to date.
* Suppress emission of `Session::Located` in `Session::locate()` if `AudioEngine::transport_frame()` is not up to date, to prevent the playhead from jumping back and forth.

I debugged this together with @x42 on IRC and we ended up with the question, why `Session::backend_sync_callback()` is called with `TransportStopped`.

Since then I did some 16 hours of reallife recording and editing work using this branch. No problem occured, the playhead behaves as expected.