### PR TITLE
Update caineville-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -142,8 +142,8 @@
     <ColorAlias name="comment button: fill" alias="color 20"/>
     <ColorAlias name="control point fill" alias="color 97"/>
     <ColorAlias name="control point outline" alias="meter color8"/>
-    <ColorAlias name="control point selected fill" alias="color 13"/>
-    <ColorAlias name="control point selected outline" alias="color 91"/>
+    <ColorAlias name="control point selected fill" alias="color 80"/>
+    <ColorAlias name="control point selected outline" alias="color 29"/>
     <ColorAlias name="covered region" alias="color 87"/>
     <ColorAlias name="crossfade editor base" alias="color 15"/>
     <ColorAlias name="crossfade editor line" alias="color 4"/>


### PR DESCRIPTION
![caineville_correction_180617](https://user-images.githubusercontent.com/19673308/27269324-a9097522-54be-11e7-9aad-24cb93dbebf2.png)
1. The selected control points are changed from light to dark colors to provide more difference between selected and non-selected points (control point selected fill – color 80; control point selected outline – color 29).