### PR TITLE
Fix LD_LIBRARY_PATH in GNU/Linux startup script

### DIFF
--- a/tools/linux_packaging/ardour.sh.in
+++ b/tools/linux_packaging/ardour.sh.in
@@ -17,7 +17,7 @@ checkdebug "$@"
 
 # LD_LIBRARY_PATH needs to be set here so that epa can swap between the original and the bundled version
 # (the original one will be stored in PREBUNDLE_ENV)
-export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 export PREBUNDLE_ENV="$(env)"
 
 BIN_DIR=$(dirname $(readlink -f $0))


### PR DESCRIPTION
This PR fixes the same issue as Ardour/ardour#342, but keeps the script's behavior of setting LD_LIBRARY_PATH to an empty string when it's unset.

Currently, the startup script for GNU/Linux adds the current working directory to LD_LIBRARY_PATH if LD_LIBRARY_PATH is not empty or unset, due to the insertion of an extra colon.

This PR changes the line
```
export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
```

to this line:
```
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH
```

which is functionally identical to this line (note the removed colon), but easier to read:
```
export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH}
```