### PR TITLE
Add missing `echo` in ardev_common.sh.in

### DIFF
--- a/gtk2_ardour/ardev_common.sh.in
+++ b/gtk2_ardour/ardev_common.sh.in
@@ -1,4 +1,4 @@
-[ -z $TOP ] && "ardev_common.sh: TOP var must be set" && exit 1
+[ -z $TOP ] && echo "ardev_common.sh: TOP var must be set" >&2 && exit 1
 
 #export G_DEBUG=fatal_criticals
 


### PR DESCRIPTION
The error message at the top of ardev_common.sh.in is missing a call to ``echo``, so Bash tries to run the error message text as a command.