### PR TITLE
Addressing #7371: don't trigger session->undo() from non-GUI-thread

### DIFF
--- a/libs/surfaces/control_protocol/basic_ui.cc
+++ b/libs/surfaces/control_protocol/basic_ui.cc
@@ -334,7 +334,7 @@ BasicUI::undo ()
 void
 BasicUI::redo ()
 {
-	access_action ("Editor/redor");
+	access_action ("Editor/redo");
 }
 
 void

--- a/libs/surfaces/control_protocol/basic_ui.cc
+++ b/libs/surfaces/control_protocol/basic_ui.cc
@@ -328,13 +328,13 @@ BasicUI::get_transport_speed ()
 void
 BasicUI::undo ()
 {
-	session->undo (1);
+	access_action ("Editor/undo");
 }
 
 void
 BasicUI::redo ()
 {
-	session->redo (1);
+	access_action ("Editor/redor");
 }
 
 void


### PR DESCRIPTION
When triggering Session::undo() or Session::redo() from a
non-GUI-thread (e.g. from a surface protocol) Ardour crashes if setting a
CairoWidget dirty due to a ENSURE_GUI_THREAD assertion. (see #7371)

By triggering undo by BasicUI::access_action() rather than by Session::undo()
we ensure that the GUI thread will finally call Session::undo().

So more like a workaround ... but better than crashing :)