### PR TITLE
Select newly created region after separate

### DIFF
--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -4069,6 +4069,16 @@ Editor::bounce_range_selection (bool replace, bool enable_processing)
 
 	if (in_command) {
 		commit_reversible_command ();
+
+		if(replace)
+		{
+			select_all_selectables_using_time_selection();
+			if(!Config->get_automation_follows_regions())
+			{
+				selection->clear_points ();
+			}
+		        selection->clear_time ();
+		}
 	}
 }
 

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -3190,6 +3190,10 @@ Editor::separate_region_from_selection ()
 
 		separate_regions_between (selection->time);
 		select_all_selectables_using_time_selection();
+		if(!Config->get_automation_follows_regions())
+		{
+			selection->clear_points ();
+		}
 		selection->clear_time ();
 
 	} else {

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -3189,6 +3189,8 @@ Editor::separate_region_from_selection ()
 	if (!selection->time.empty()) {
 
 		separate_regions_between (selection->time);
+		select_all_selectables_using_time_selection();
+		selection->clear_time ();
 
 	} else {
 


### PR DESCRIPTION
current behaviour:
using a time selection on a region: from context menu "Separate":
-this will leave a time selection over the new region
-> there is no way to move or grab the region since its covered by the ts
-> user must click anywhere to unselect
-> there is no obvious case where keeping the initial selection makes sense as is after the op

new behaviour:
-the newly created region is selected after the op (ts cleared)