### PR TITLE
Don't try to chop of the file name extension from a template dir

### DIFF
--- a/libs/ardour/template_utils.cc
+++ b/libs/ardour/template_utils.cc
@@ -22,7 +22,6 @@
 
 #include <glibmm.h>
 
-#include "pbd/basename.h"
 #include "pbd/file_utils.h"
 #include "pbd/stl_delete.h"
 #include "pbd/xml++.h"
@@ -104,7 +103,7 @@ find_session_templates (vector<TemplateInfo>& template_names, bool read_xml)
 
 		TemplateInfo rti;
 
-		rti.name = basename_nosuffix (*i);
+		rti.name = Glib::path_get_basename (*i);
 		rti.path = *i;
 
 		template_names.push_back (rti);


### PR DESCRIPTION
Template files reside in
`.config/ardour5/templates/$(template_name)/$(template_name).template`

We run through `.config/ardour5/templates/` and find there the names of the
directories the .template-files are located in. These directory names don't
have a .template extension. So we shouldn't try to chop the non existing
extension of, because then we only modify template names with a '.' in them.