### PR TITLE
Try to fix #7429

### DIFF
--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -903,6 +903,11 @@ Mixer_UI::strip_button_release_event (GdkEventButton *ev, MixerStrip *strip)
 				/* de-select others */
 				_selection.set (strip);
 			}
+			PublicEditor& pe = PublicEditor::instance();
+			TimeAxisView* tav = pe.time_axis_view_from_stripable (strip->stripable());
+			if (tav) {
+				pe.set_selected_mixer_strip (*tav);
+			}
 		} else {
 			if (Keyboard::modifier_state_equals (ev->state, Keyboard::PrimaryModifier)) {
 				_selection.add (strip, true);

--- a/gtk2_ardour/route_time_axis.cc
+++ b/gtk2_ardour/route_time_axis.cc
@@ -1340,6 +1340,8 @@ RouteTimeAxisView::selection_click (GdkEventButton* ev)
 	}
 
 	_editor.commit_reversible_selection_op ();
+
+	_editor.set_selected_mixer_strip (*this);
 }
 
 void


### PR DESCRIPTION
#7429 states that the editor mixer strip is not updated when clicking on a route which is member of an already selected group.

This PR tries to fix it by calling `Editor::set_selected_mixer_strip()` after the click events on the TimeAxisView as well as on the MixerStrip of the Route.