### PR TITLE
Fix/route template names

### DIFF
--- a/gtk2_ardour/template_dialog.cc
+++ b/gtk2_ardour/template_dialog.cc
@@ -568,9 +568,11 @@ RouteTemplateManager::rename_template (TreeModel::iterator& item, const Glib::us
 	const string new_state_dir = Glib::build_filename (user_route_template_directory(), new_name);
 
 	if (adjusted) {
-		if (g_rename (old_state_dir.c_str(), new_state_dir.c_str()) != 0) {
-			error << string_compose (_("Could not rename state dir \"%1\" to \"%22\": %3"), old_state_dir, new_state_dir, strerror (errno)) << endmsg;
-			return;
+		if (g_file_test (old_state_dir.c_str(), G_FILE_TEST_EXISTS)) {
+			if (g_rename (old_state_dir.c_str(), new_state_dir.c_str()) != 0) {
+				error << string_compose (_("Could not rename state dir \"%1\" to \"%22\": %3"), old_state_dir, new_state_dir, strerror (errno)) << endmsg;
+				return;
+			}
 		}
 	}
 

--- a/gtk2_ardour/template_dialog.cc
+++ b/gtk2_ardour/template_dialog.cc
@@ -560,6 +560,7 @@ RouteTemplateManager::rename_template (TreeModel::iterator& item, const Glib::us
 		error << string_compose (_("Could not parse template file \"%1\"."), old_filepath) << endmsg;
 		return;
 	}
+	tree.root()->set_property (X_("name"), new_name);
 	tree.root()->children().front()->set_property (X_("name"), new_name);
 
 	const bool adjusted = adjust_plugin_paths (tree.root(), old_name, string (new_name));

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -4022,6 +4022,7 @@ Route::save_as_template (const string& path, const string& name)
 	PBD::Unwinder<std::string> uw (_session._template_state_dir, state_dir);
 
 	XMLNode& node (state (false));
+	node.set_property (X_("name"), name);
 
 	XMLTree tree;
 


### PR DESCRIPTION
Fix of a bug reported by a beta tester:

> BUG: let's say I save a template of the first Channel, Mondo Bass and rename it Mondo Round Bass, two
> things happen to my surprise, when I go to add track Mondo Round Bass appears as a template but
> when I add it to the session it comes up as Mondo Bass 1, reverting to the original name of the source
> channel and adding a 1 as if to denote a duplicate, as if it forgot the new name it's confusing it makes
> you wonder if it's the right template.

Therefore the name of the route in the route in the template is already set to the template name when the template is saved. So if we save the channel "Mondo Bass" a template that we name "Great Bass", newly created routes from the template will be named "Great Bass 1" rather than "Mondo Bass 1".

Finally when we rename a template we also rename the route in the template to the new template name.

This PR is intentionally split into three tiny commits to make them cherry-pickable. Feel free to squash them together.
