### PR TITLE
Fix #6280 ... no possiblity to select region aligned on 1st beat

### DIFF
--- a/libs/ardour/playlist.cc
+++ b/libs/ardour/playlist.cc
@@ -2066,7 +2066,7 @@ Playlist::find_next_region (framepos_t frame, RegionPoint point, int dir)
 		switch (dir) {
 		case 1: /* forwards */
 
-			if (pos > frame) {
+			if (pos > frame || (pos == 0 && frame == 0)) {
 				if ((distance = pos - frame) < closest) {
 					closest = distance;
 					ret = r;


### PR DESCRIPTION
Issue #6280 states that when selecting ranges using SnapToRegionBoundary it's
not possible to select regions with first_frame() == 0. This is because
Playlist::find_next_region() does not consider region boundaries == pos but
only > pos. Thus it never considers pos == 0 to be a region boundary.

The proposed solution is to treat (pos == 0 && frame == 0) as a special case
rather than generally consider (pos == frame) a region boundary in forward
direction, assuming that the latter would other calls of ::find_next_region().