### PR TITLE
Experimental: Plugin inline display in generic GUI (renewal)

### DIFF
--- a/gtk2_ardour/generic_pluginui.cc
+++ b/gtk2_ardour/generic_pluginui.cc
@@ -49,6 +49,7 @@
 #include "widgets/tooltips.h"
 
 #include "plugin_ui.h"
+#include "plugin_display.h"
 #include "gui_thread.h"
 #include "automation_controller.h"
 #include "gain_meter.h"
@@ -526,6 +527,12 @@ GenericPluginUI::automatic_layout (const std::vector<ControlUI*>& control_uis)
 		output_table->show_all ();
 	} else {
 		delete output_table;
+	}
+
+	if (plugin->has_inline_display ()) {
+		PluginDisplay* pd = manage (new PluginDisplay (plugin, 300));
+		pd->set_name("inside gui");
+		hpacker.pack_end (*pd, true, true);
 	}
 	show_all();
 

--- a/gtk2_ardour/generic_pluginui.cc
+++ b/gtk2_ardour/generic_pluginui.cc
@@ -529,9 +529,8 @@ GenericPluginUI::automatic_layout (const std::vector<ControlUI*>& control_uis)
 		delete output_table;
 	}
 
-	if (plugin->has_inline_display ()) {
+	if (plugin->has_inline_display () && plugin->inline_display_in_gui ()) {
 		PluginDisplay* pd = manage (new PluginDisplay (plugin, 300));
-		pd->set_name("inside gui");
 		hpacker.pack_end (*pd, true, true);
 	}
 	show_all();
@@ -551,6 +550,11 @@ GenericPluginUI::custom_layout (const std::vector<ControlUI*>& control_uis)
 		layout->attach (*cui, cui->x0, cui->x1, cui->y0, cui->y1, FILL, SHRINK, 2, 2);
 	}
 	hpacker.pack_start (*layout, true, true);
+
+	if (plugin->has_inline_display () && plugin->inline_display_in_gui ()) {
+		PluginDisplay* pd = manage (new PluginDisplay (plugin, 300));
+		hpacker.pack_end (*pd, true, true);
+	}
 }
 
 GenericPluginUI::ControlUI::ControlUI (const Evoral::Parameter& p)

--- a/gtk2_ardour/plugin_display.cc
+++ b/gtk2_ardour/plugin_display.cc
@@ -1,0 +1,187 @@
+/*
+    Copyright (C) 2017 Paul Davis
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#include <gtkmm/container.h>
+
+#include "gtkmm2ext/colors.h"
+#include "gtkmm2ext/gtk_ui.h"
+#include "gtkmm2ext/gui_thread.h"
+#include "gtkmm2ext/utils.h"
+
+#include "ui_config.h"
+
+#include "plugin_display.h"
+
+
+
+PluginDisplay::PluginDisplay (boost::shared_ptr<ARDOUR::Plugin> p, uint32_t max_height)
+	: _plug (p)
+	, _surf (0)
+	, _max_height (max_height)
+	, _cur_height (1)
+	, _scroll (false)
+{
+	add_events (Gdk::BUTTON_PRESS_MASK|Gdk::BUTTON_RELEASE_MASK);
+	_plug->DropReferences.connect (_death_connection, invalidator (*this), boost::bind (&PluginDisplay::plugin_going_away, this), gui_context());
+	_plug->QueueDraw.connect (_qdraw_connection, invalidator (*this),
+			boost::bind (&Gtk::Widget::queue_draw, this), gui_context ());
+}
+
+PluginDisplay::~PluginDisplay ()
+{
+	if (_surf) {
+		cairo_surface_destroy (_surf);
+	}
+}
+
+bool
+PluginDisplay::on_button_press_event (GdkEventButton *ev)
+{
+	return false;
+}
+
+bool
+PluginDisplay::on_button_release_event (GdkEventButton *ev)
+{
+	return false;
+}
+
+void
+PluginDisplay::on_size_request (Gtk::Requisition* req)
+{
+	req->width = 56;
+	req->height = _cur_height;
+}
+
+
+void
+PluginDisplay::update_height_alloc (uint32_t height)
+{
+	uint32_t shm = std::min (_max_height, height);
+
+	Gtk::Container* pr = get_parent();
+	for (uint32_t i = 0; i < 4 && pr; ++i) {
+		// VBox, EventBox, ViewPort, ScrolledWindow
+		pr = pr->get_parent();
+	}
+
+	if (shm != _cur_height) {
+		if (_cur_height < shm) {
+			queue_resize ();
+		}
+		_cur_height = shm;
+	}
+}
+
+uint32_t
+PluginDisplay::render_inline (cairo_t* cr, uint32_t width)
+{
+	ARDOUR::Plugin::Display_Image_Surface* dis = _plug->render_inline_display (width, _max_height);
+	if (!dis) {
+		return 0;
+	}
+
+	/* allocate a local image-surface,
+	 * We cannot re-use the data via cairo_image_surface_create_for_data(),
+	 * since pixman keeps a reference to it.
+	 * we'd need to hand over the data and ha cairo_surface_destroy to free it.
+	 * it might be possible to work around via cairo_surface_set_user_data().
+	 */
+	if (!_surf
+			|| dis->width !=  cairo_image_surface_get_width (_surf)
+			|| dis->height !=  cairo_image_surface_get_height (_surf)
+		 ) {
+		if (_surf) {
+			cairo_surface_destroy (_surf);
+		}
+		_surf = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, dis->width, dis->height);
+	}
+
+	if (cairo_image_surface_get_stride (_surf) == dis->stride) {
+		memcpy (cairo_image_surface_get_data (_surf), dis->data, dis->stride * dis->height);
+	} else {
+		unsigned char *src = dis->data;
+		unsigned char *dst = cairo_image_surface_get_data (_surf);
+		const int dst_stride =  cairo_image_surface_get_stride (_surf);
+		for (int y = 0; y < dis->height; ++y) {
+			memcpy (dst, src, dis->width * 4 /*ARGB32*/);
+			src += dis->stride;
+			dst += dst_stride;
+		}
+	}
+
+	cairo_surface_flush(_surf);
+	cairo_surface_mark_dirty(_surf);
+	const double xc = floor ((width - dis->width) * .5);
+	cairo_set_source_surface(cr, _surf, xc, 0);
+	cairo_paint (cr);
+
+	return dis->height;
+}
+
+bool
+PluginDisplay::on_expose_event (GdkEventExpose* ev)
+{
+	Gtk::Allocation a = get_allocation();
+	double const width = a.get_width();
+	double const height = a.get_height();
+
+	cairo_t* cr = gdk_cairo_create (get_window()->gobj());
+	cairo_rectangle (cr, ev->area.x, ev->area.y, ev->area.width, ev->area.height);
+	cairo_clip (cr);
+
+	Gdk::Color const bg = get_style()->get_bg (Gtk::STATE_NORMAL);
+	cairo_set_source_rgb (cr, bg.get_red_p (), bg.get_green_p (), bg.get_blue_p ());
+	cairo_rectangle (cr, 0, 0, width, height);
+	cairo_fill (cr);
+
+	cairo_save (cr);
+	cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
+	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, width - 1, height + 1, 7);
+	cairo_clip (cr);
+	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
+
+	uint32_t ht = render_inline (cr, width);
+	cairo_restore (cr);
+
+	if (ht == 0) {
+		hide ();
+		if (_cur_height != 1) {
+			_cur_height = 1;
+			queue_resize ();
+		}
+		cairo_destroy (cr);
+		return true;
+	} else {
+		update_height_alloc (ht);
+	}
+
+	bool failed = false;
+	std::string name = get_name();
+	Gtkmm2ext::Color fill_color = UIConfiguration::instance().color (string_compose ("%1: fill active", name), &failed);
+
+	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, width - 1, height + 1, 7);
+	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
+	cairo_set_line_width(cr, 1.0);
+	Gtkmm2ext::set_source_rgb_a (cr, fill_color, 1.0);
+	cairo_stroke (cr);
+
+	cairo_destroy(cr);
+	return true;
+}

--- a/gtk2_ardour/plugin_display.cc
+++ b/gtk2_ardour/plugin_display.cc
@@ -65,7 +65,7 @@ PluginDisplay::on_button_release_event (GdkEventButton *ev)
 void
 PluginDisplay::on_size_request (Gtk::Requisition* req)
 {
-	req->width = 56;
+	req->width = 300;
 	req->height = _cur_height;
 }
 

--- a/gtk2_ardour/plugin_display.cc
+++ b/gtk2_ardour/plugin_display.cc
@@ -153,7 +153,7 @@ PluginDisplay::on_expose_event (GdkEventExpose* ev)
 
 	cairo_save (cr);
 	cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
-	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, width - 1, height + 1, 7);
+	display_frame(cr, width, height);
 	cairo_clip (cr);
 	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
 
@@ -176,12 +176,22 @@ PluginDisplay::on_expose_event (GdkEventExpose* ev)
 	std::string name = get_name();
 	Gtkmm2ext::Color fill_color = UIConfiguration::instance().color (string_compose ("%1: fill active", name), &failed);
 
-	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, width - 1, height + 1, 7);
+	display_frame(cr, width, height);
 	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
 	cairo_set_line_width(cr, 1.0);
-	Gtkmm2ext::set_source_rgb_a (cr, fill_color, 1.0);
+	if (failed) {
+		cairo_set_source_rgba (cr, .75, .75, .75, 1.0);
+	} else {
+		Gtkmm2ext::set_source_rgb_a (cr, fill_color, 1.0);
+	}
 	cairo_stroke (cr);
 
 	cairo_destroy(cr);
 	return true;
+}
+
+void
+PluginDisplay::display_frame (cairo_t* cr, double w, double h)
+{
+	cairo_rectangle (cr, 0.0, 0.0, w, h);
 }

--- a/gtk2_ardour/plugin_display.h
+++ b/gtk2_ardour/plugin_display.h
@@ -43,6 +43,8 @@ protected:
 	void update_height_alloc (uint32_t inline_height);
 	virtual uint32_t render_inline (cairo_t *, uint32_t width);
 
+	virtual void display_frame (cairo_t* cr, double w, double h);
+
 	boost::shared_ptr<ARDOUR::Plugin> _plug;
 	PBD::ScopedConnection _qdraw_connection;
 	PBD::ScopedConnection _death_connection;

--- a/gtk2_ardour/plugin_display.h
+++ b/gtk2_ardour/plugin_display.h
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2017 Paul Davis
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#ifndef __ardour_plugin_display__
+#define __ardour_plugin_display__
+
+#include <gtkmm/drawingarea.h>
+
+#include "ardour/plugin.h"
+
+class PluginDisplay : public Gtk::DrawingArea
+{
+public:
+	PluginDisplay(boost::shared_ptr<ARDOUR::Plugin>, uint32_t max_height = 80);
+	virtual ~PluginDisplay();
+
+protected:
+	bool on_expose_event (GdkEventExpose *);
+	void on_size_request (Gtk::Requisition* req);
+	bool on_button_press_event (GdkEventButton *ev);
+	bool on_button_release_event (GdkEventButton *ev);
+
+	void plugin_going_away () {
+		_qdraw_connection.disconnect ();
+	}
+
+	void update_height_alloc (uint32_t inline_height);
+	virtual uint32_t render_inline (cairo_t *, uint32_t width);
+
+	boost::shared_ptr<ARDOUR::Plugin> _plug;
+	PBD::ScopedConnection _qdraw_connection;
+	PBD::ScopedConnection _death_connection;
+	cairo_surface_t* _surf;
+	uint32_t _max_height;
+	uint32_t _cur_height;
+	bool _scroll;
+};
+
+#endif

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -1623,6 +1623,12 @@ ProcessorEntry::PluginInlineDisplay::update_height_alloc (uint32_t inline_height
 	_scroll = sc;
 }
 
+void
+ProcessorEntry::PluginInlineDisplay::display_frame (cairo_t* cr, double w, double h)
+{
+	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, w - 1, h + 1, 7);
+}
+
 ProcessorEntry::LuaPluginDisplay::LuaPluginDisplay (ProcessorEntry& e, boost::shared_ptr<ARDOUR::LuaProc> p, uint32_t max_height)
 	: PluginInlineDisplay (e, p, max_height)
 	, _luaproc (p)

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -184,7 +184,7 @@ ProcessorEntry::ProcessorEntry (ProcessorBox* parent, boost::shared_ptr<Processo
 		boost::shared_ptr<PluginInsert> pi = boost::dynamic_pointer_cast<PluginInsert> (_processor);
 		if (pi && pi->plugin() && pi->plugin()->has_inline_display()) {
 			if (pi->plugin()->get_info()->type != ARDOUR::Lua) {
-				_plugin_display = new PluginDisplay (*this, pi->plugin(),
+				_plugin_display = new PluginInlineDisplay (*this, pi->plugin(),
 						std::max (60.f, rintf(112.f * UIConfiguration::instance().get_ui_scale())));
 			} else {
 				assert (boost::dynamic_pointer_cast<LuaProc>(pi->plugin()));
@@ -1540,20 +1540,11 @@ ProcessorEntry::RoutingIcon::expose_output_map (cairo_t* cr, const double width,
 	}
 }
 
-ProcessorEntry::PluginDisplay::PluginDisplay (ProcessorEntry& e, boost::shared_ptr<ARDOUR::Plugin> p, uint32_t max_height)
-	: _entry (e)
-	, _plug (p)
-	, _surf (0)
-	, _max_height (max_height)
-	, _cur_height (1)
+ProcessorEntry::PluginInlineDisplay::PluginInlineDisplay (ProcessorEntry& e, boost::shared_ptr<ARDOUR::Plugin> p, uint32_t max_height)
+	: PluginDisplay (p, max_height)
+	, _entry (e)
 	, _scroll (false)
 {
-	set_name ("processor prefader");
-	add_events (Gdk::BUTTON_PRESS_MASK|Gdk::BUTTON_RELEASE_MASK);
-	_plug->DropReferences.connect (_death_connection, invalidator (*this), boost::bind (&PluginDisplay::plugin_going_away, this), gui_context());
-	_plug->QueueDraw.connect (_qdraw_connection, invalidator (*this),
-			boost::bind (&Gtk::Widget::queue_draw, this), gui_context ());
-
 	std::string postfix = string_compose(_("\n%1+double-click to toggle inline-display"), Keyboard::tertiary_modifier_name ());
 
 	if (_plug->has_editor()) {
@@ -1565,15 +1556,9 @@ ProcessorEntry::PluginDisplay::PluginDisplay (ProcessorEntry& e, boost::shared_p
 	}
 }
 
-ProcessorEntry::PluginDisplay::~PluginDisplay ()
-{
-	if (_surf) {
-		cairo_surface_destroy (_surf);
-	}
-}
 
 bool
-ProcessorEntry::PluginDisplay::on_button_press_event (GdkEventButton *ev)
+ProcessorEntry::PluginInlineDisplay::on_button_press_event (GdkEventButton *ev)
 {
 	assert (_entry.processor ());
 
@@ -1600,14 +1585,8 @@ ProcessorEntry::PluginDisplay::on_button_press_event (GdkEventButton *ev)
 	return false;
 }
 
-bool
-ProcessorEntry::PluginDisplay::on_button_release_event (GdkEventButton *ev)
-{
-	return false;
-}
-
 void
-ProcessorEntry::PluginDisplay::on_size_request (Requisition* req)
+ProcessorEntry::PluginInlineDisplay::on_size_request (Requisition* req)
 {
 	req->width = 56;
 	req->height = _cur_height;
@@ -1615,7 +1594,7 @@ ProcessorEntry::PluginDisplay::on_size_request (Requisition* req)
 
 
 void
-ProcessorEntry::PluginDisplay::update_height_alloc (uint32_t inline_height)
+ProcessorEntry::PluginInlineDisplay::update_height_alloc (uint32_t inline_height)
 {
 	/* work-around scroll-bar + aspect ratio
 	 * show inline-view -> height changes -> scrollbar gets added
@@ -1644,105 +1623,8 @@ ProcessorEntry::PluginDisplay::update_height_alloc (uint32_t inline_height)
 	_scroll = sc;
 }
 
-uint32_t
-ProcessorEntry::PluginDisplay::render_inline (cairo_t* cr, uint32_t width)
-{
-	Plugin::Display_Image_Surface* dis = _plug->render_inline_display (width, _max_height);
-	if (!dis) {
-		return 0;
-	}
-
-	/* allocate a local image-surface,
-	 * We cannot re-use the data via cairo_image_surface_create_for_data(),
-	 * since pixman keeps a reference to it.
-	 * we'd need to hand over the data and ha cairo_surface_destroy to free it.
-	 * it might be possible to work around via cairo_surface_set_user_data().
-	 */
-	if (!_surf
-			|| dis->width !=  cairo_image_surface_get_width (_surf)
-			|| dis->height !=  cairo_image_surface_get_height (_surf)
-		 ) {
-		if (_surf) {
-			cairo_surface_destroy (_surf);
-		}
-		_surf = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, dis->width, dis->height);
-	}
-
-	if (cairo_image_surface_get_stride (_surf) == dis->stride) {
-		memcpy (cairo_image_surface_get_data (_surf), dis->data, dis->stride * dis->height);
-	} else {
-		unsigned char *src = dis->data;
-		unsigned char *dst = cairo_image_surface_get_data (_surf);
-		const int dst_stride =  cairo_image_surface_get_stride (_surf);
-		for (int y = 0; y < dis->height; ++y) {
-			memcpy (dst, src, dis->width * 4 /*ARGB32*/);
-			src += dis->stride;
-			dst += dst_stride;
-		}
-	}
-
-	cairo_surface_flush(_surf);
-	cairo_surface_mark_dirty(_surf);
-	const double xc = floor ((width - dis->width) * .5);
-	cairo_set_source_surface(cr, _surf, xc, 0);
-	cairo_paint (cr);
-
-	return dis->height;
-}
-
-bool
-ProcessorEntry::PluginDisplay::on_expose_event (GdkEventExpose* ev)
-{
-	Gtk::Allocation a = get_allocation();
-	double const width = a.get_width();
-	double const height = a.get_height();
-
-	cairo_t* cr = gdk_cairo_create (get_window()->gobj());
-	cairo_rectangle (cr, ev->area.x, ev->area.y, ev->area.width, ev->area.height);
-	cairo_clip (cr);
-
-	Gdk::Color const bg = get_style()->get_bg (STATE_NORMAL);
-	cairo_set_source_rgb (cr, bg.get_red_p (), bg.get_green_p (), bg.get_blue_p ());
-	cairo_rectangle (cr, 0, 0, width, height);
-	cairo_fill (cr);
-
-	cairo_save (cr);
-	cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
-	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, width - 1, height + 1, 7);
-	cairo_clip (cr);
-	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
-
-	uint32_t ht = render_inline (cr, width);
-	cairo_restore (cr);
-
-	if (ht == 0) {
-		hide ();
-		if (_cur_height != 1) {
-			_cur_height = 1;
-			queue_resize ();
-		}
-		cairo_destroy (cr);
-		return true;
-	} else {
-		update_height_alloc (ht);
-	}
-
-	bool failed = false;
-	std::string name = get_name();
-	Gtkmm2ext::Color fill_color = UIConfiguration::instance().color (string_compose ("%1: fill active", name), &failed);
-
-	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, width - 1, height + 1, 7);
-	cairo_set_operator (cr, CAIRO_OPERATOR_OVER);
-	cairo_set_line_width(cr, 1.0);
-	Gtkmm2ext::set_source_rgb_a (cr, fill_color, 1.0);
-	cairo_stroke (cr);
-
-	cairo_destroy(cr);
-	return true;
-}
-
 ProcessorEntry::LuaPluginDisplay::LuaPluginDisplay (ProcessorEntry& e, boost::shared_ptr<ARDOUR::LuaProc> p, uint32_t max_height)
-	: PluginDisplay (e, p, max_height)
+	: PluginInlineDisplay (e, p, max_height)
 	, _luaproc (p)
 	, _lua_render_inline (0)
 {

--- a/gtk2_ardour/processor_box.h
+++ b/gtk2_ardour/processor_box.h
@@ -54,6 +54,7 @@
 #include "widgets/slider_controller.h"
 
 #include "plugin_interest.h"
+#include "plugin_display.h"
 #include "io_selector.h"
 #include "send_ui.h"
 #include "enums.h"
@@ -242,34 +243,20 @@ private:
 	void toggle_panner_link ();
 	void toggle_allow_feedback ();
 
-	class PluginDisplay : public Gtk::DrawingArea {
+	class PluginInlineDisplay : public PluginDisplay {
 	public:
-		PluginDisplay(ProcessorEntry&, boost::shared_ptr<ARDOUR::Plugin>, uint32_t max_height = 80);
-		virtual ~PluginDisplay();
+		PluginInlineDisplay(ProcessorEntry&, boost::shared_ptr<ARDOUR::Plugin>, uint32_t max_height = 80);
+		~PluginInlineDisplay() {}
 	protected:
-		bool on_expose_event (GdkEventExpose *);
 		void on_size_request (Gtk::Requisition* req);
 		bool on_button_press_event (GdkEventButton *ev);
-		bool on_button_release_event (GdkEventButton *ev);
-
-		void plugin_going_away () {
-			_qdraw_connection.disconnect ();
-		}
-
 		void update_height_alloc (uint32_t inline_height);
-		virtual uint32_t render_inline (cairo_t *, uint32_t width);
 
 		ProcessorEntry& _entry;
-		boost::shared_ptr<ARDOUR::Plugin> _plug;
-		PBD::ScopedConnection _qdraw_connection;
-		PBD::ScopedConnection _death_connection;
-		cairo_surface_t* _surf;
-		uint32_t _max_height;
-		uint32_t _cur_height;
 		bool _scroll;
 	};
 
-	class LuaPluginDisplay : public PluginDisplay {
+	class LuaPluginDisplay : public PluginInlineDisplay {
 	public:
 		LuaPluginDisplay(ProcessorEntry&, boost::shared_ptr<ARDOUR::LuaProc>, uint32_t max_height = 80);
 		~LuaPluginDisplay();

--- a/gtk2_ardour/processor_box.h
+++ b/gtk2_ardour/processor_box.h
@@ -252,6 +252,8 @@ private:
 		bool on_button_press_event (GdkEventButton *ev);
 		void update_height_alloc (uint32_t inline_height);
 
+		void display_frame (cairo_t* cr, double w, double h);
+
 		ProcessorEntry& _entry;
 		bool _scroll;
 	};

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -181,6 +181,7 @@ gtk2_ardour_sources = [
         'piano_roll_header.cc',
         'pingback.cc',
         'playlist_selector.cc',
+        'plugin_display.cc',
         'plugin_eq_gui.cc',
         'plugin_pin_dialog.cc',
         'plugin_setup_dialog.cc',

--- a/libs/ardour/ardour/lv2_extensions.h
+++ b/libs/ardour/ardour/lv2_extensions.h
@@ -32,6 +32,7 @@
 #define LV2_INLINEDISPLAY_PREFIX LV2_INLINEDISPLAY_URI "#"
 #define LV2_INLINEDISPLAY__interface LV2_INLINEDISPLAY_PREFIX "interface"
 #define LV2_INLINEDISPLAY__queue_draw LV2_INLINEDISPLAY_PREFIX "queue_draw"
+#define LV2_INLINEDISPLAY__in_gui LV2_INLINEDISPLAY_PREFIX "in_gui"
 
 /** Opaque handle for LV2_Inline_Display::queue_draw() */
 typedef void* LV2_Inline_Display_Handle;

--- a/libs/ardour/ardour/lv2_plugin.h
+++ b/libs/ardour/ardour/lv2_plugin.h
@@ -278,7 +278,7 @@ class LIBARDOUR_API LV2Plugin : public ARDOUR::Plugin, public ARDOUR::Workee
 
 #ifdef LV2_EXTENDED
 	const LV2_Inline_Display_Interface* _display_interface;
-	bool _show_display_in_generic_gui;
+	bool _inline_display_in_gui;
 	const LV2_Midnam_Interface* _midname_interface;
 #endif
 

--- a/libs/ardour/ardour/lv2_plugin.h
+++ b/libs/ardour/ardour/lv2_plugin.h
@@ -278,6 +278,7 @@ class LIBARDOUR_API LV2Plugin : public ARDOUR::Plugin, public ARDOUR::Workee
 
 #ifdef LV2_EXTENDED
 	const LV2_Inline_Display_Interface* _display_interface;
+	bool _show_display_in_generic_gui;
 	const LV2_Midnam_Interface* _midname_interface;
 #endif
 
@@ -322,6 +323,7 @@ class LIBARDOUR_API LV2Plugin : public ARDOUR::Plugin, public ARDOUR::Workee
 
 #ifdef LV2_EXTENDED
 	bool has_inline_display ();
+	bool inline_display_in_gui ();
 	Plugin::Display_Image_Surface* render_inline_display (uint32_t, uint32_t);
 
 	bool has_midnam ();

--- a/libs/ardour/ardour/plugin.h
+++ b/libs/ardour/ardour/plugin.h
@@ -171,6 +171,7 @@ class LIBARDOUR_API Plugin : public PBD::StatefulDestructible, public Latent
 	} Display_Image_Surface;
 
 	virtual bool has_inline_display () { return false; }
+	virtual bool inline_display_in_gui () { return false; }
 	virtual Display_Image_Surface* render_inline_display (uint32_t, uint32_t) { return NULL; }
 	PBD::Signal0<void> QueueDraw;
 

--- a/libs/ardour/lv2_plugin.cc
+++ b/libs/ardour/lv2_plugin.cc
@@ -190,6 +190,7 @@ public:
 	LilvNode* auto_automation_control; // atom:supports
 	LilvNode* auto_automation_controlled; // lv2:portProperty
 	LilvNode* auto_automation_controller; // lv2:portProperty
+	LilvNode* inline_display_in_gui; // lv2:optionalFeature
 #endif
 
 private:
@@ -390,6 +391,7 @@ LV2Plugin::init(const void* c_plugin, framecnt_t rate)
 	_was_activated          = false;
 	_has_state_interface    = false;
 	_can_write_automation   = false;
+	_inline_display_in_gui  = false;
 	_max_latency            = 0;
 	_current_latency        = 0;
 	_impl->block_length     = _session.get_block_size();
@@ -547,8 +549,6 @@ LV2Plugin::init(const void* c_plugin, framecnt_t rate)
 	_display_interface = (const LV2_Inline_Display_Interface*)
 		extension_data (LV2_INLINEDISPLAY__interface);
 
-	_show_display_in_generic_gui = (bool) extension_data (LV2_INLINEDISPLAY__in_gui);
-
 	_midname_interface = (const LV2_Midnam_Interface*)
 		extension_data (LV2_MIDNAM__interface);
 	if (_midname_interface) {
@@ -594,6 +594,9 @@ LV2Plugin::init(const void* c_plugin, framecnt_t rate)
 	}
 	if (lilv_nodes_contains (optional_features, _world.auto_can_write_automatation)) {
 		_can_write_automation = true;
+	}
+	if (lilv_nodes_contains (optional_features, _world.inline_display_in_gui)) {
+		_inline_display_in_gui = true;
 	}
 	lilv_nodes_free(optional_features);
 #endif
@@ -966,7 +969,7 @@ LV2Plugin::has_inline_display () {
 
 bool
 LV2Plugin::inline_display_in_gui () {
-	return _show_display_in_generic_gui;
+	return _inline_display_in_gui;
 }
 
 Plugin::Display_Image_Surface*
@@ -3163,6 +3166,7 @@ LV2World::LV2World()
 	auto_automation_control     = lilv_new_uri(world, LV2_AUTOMATE_URI__control);
 	auto_automation_controlled  = lilv_new_uri(world, LV2_AUTOMATE_URI__controlled);
 	auto_automation_controller  = lilv_new_uri(world, LV2_AUTOMATE_URI__controller);
+	inline_display_in_gui       = lilv_new_uri(world, LV2_INLINEDISPLAY__in_gui);
 #endif
 #ifdef HAVE_LV2_1_2_0
 	bufz_powerOf2BlockLength = lilv_new_uri(world, LV2_BUF_SIZE__powerOf2BlockLength);

--- a/libs/ardour/lv2_plugin.cc
+++ b/libs/ardour/lv2_plugin.cc
@@ -547,6 +547,8 @@ LV2Plugin::init(const void* c_plugin, framecnt_t rate)
 	_display_interface = (const LV2_Inline_Display_Interface*)
 		extension_data (LV2_INLINEDISPLAY__interface);
 
+	_show_display_in_generic_gui = (bool) extension_data (LV2_INLINEDISPLAY__in_gui);
+
 	_midname_interface = (const LV2_Midnam_Interface*)
 		extension_data (LV2_MIDNAM__interface);
 	if (_midname_interface) {
@@ -960,6 +962,11 @@ LV2Plugin::ui_is_resizable () const
 bool
 LV2Plugin::has_inline_display () {
 	return _display_interface ? true : false;
+}
+
+bool
+LV2Plugin::inline_display_in_gui () {
+	return _show_display_in_generic_gui;
 }
 
 Plugin::Display_Image_Surface*

--- a/libs/plugins/a-comp.lv2/a-comp#stereo.ttl.in
+++ b/libs/plugins/a-comp.lv2/a-comp#stereo.ttl.in
@@ -14,7 +14,8 @@
     a lv2:Plugin, doap:Project, lv2:CompressorPlugin ;
 
     lv2:optionalFeature <http://lv2plug.in/ns/lv2core#hardRTCapable> ;
-		lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#queue_draw> ;
+    lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#queue_draw> ;
+    lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#in_gui> ;
 
     lv2:port [
         a lv2:InputPort, lv2:ControlPort ;

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -876,9 +876,6 @@ extension_data(const char* uri)
 	if (!strcmp(uri, LV2_INLINEDISPLAY__interface)) {
 		return &display;
 	}
-	if (!strcmp(uri, LV2_INLINEDISPLAY__in_gui)) {
-		return &display;
-	}
 #endif
 	return NULL;
 }

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -588,6 +588,8 @@ render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
 	AComp* self = (AComp*)instance;
 	uint32_t h = MIN (w, max_h);
 
+	const float makeup_thres = self->v_thresdb + self->v_makeup;
+
 	if (!self->display || self->w != w || self->h != h) {
 		if (self->display) cairo_surface_destroy(self->display);
 		self->display = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, w, h);
@@ -626,7 +628,7 @@ render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
 	}
 	if (self->v_thresdb < 0) {
 		cairo_set_source_rgba (cr, 0.5, 0.5, 0.5, 1.0);
-		const float y = -.5 + floorf (h * (self->v_thresdb / -60.f));
+		const float y = -.5 + floorf (h * (makeup_thres / -60.f));
 		cairo_set_dash(cr, dash1, 2, 2);
 		cairo_move_to (cr, 0, y);
 		cairo_line_to (cr, w, y);
@@ -658,16 +660,16 @@ render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
 	// draw signal level & reduction/gradient
 	const float top = comp_curve (self, 0);
 	cairo_pattern_t* pat = cairo_pattern_create_linear (0.0, 0.0, 0.0, h);
-	if (top > self->v_thresdb) {
+	if (top > makeup_thres) {
 		cairo_pattern_add_color_stop_rgba (pat, 0.0, 0.8, 0.1, 0.1, 0.5);
 		cairo_pattern_add_color_stop_rgba (pat, top / -60.f, 0.8, 0.1, 0.1, 0.5);
 	}
 	if (self->v_knee > 0) {
-		cairo_pattern_add_color_stop_rgba (pat, (self->v_thresdb / -60.f), 0.7, 0.7, 0.2, 0.5);
-		cairo_pattern_add_color_stop_rgba (pat, ((self->v_thresdb - self->v_knee) / -60.f), 0.5, 0.5, 0.5, 0.5);
+		cairo_pattern_add_color_stop_rgba (pat, (makeup_thres / -60.f), 0.7, 0.7, 0.2, 0.5);
+		cairo_pattern_add_color_stop_rgba (pat, ((makeup_thres - self->v_knee) / -60.f), 0.5, 0.5, 0.5, 0.5);
 	} else {
-		cairo_pattern_add_color_stop_rgba (pat, (self->v_thresdb / -60.f), 0.7, 0.7, 0.2, 0.5);
-		cairo_pattern_add_color_stop_rgba (pat, ((self->v_thresdb - .01) / -60.f), 0.5, 0.5, 0.5, 0.5);
+		cairo_pattern_add_color_stop_rgba (pat, (makeup_thres / -60.f), 0.7, 0.7, 0.2, 0.5);
+		cairo_pattern_add_color_stop_rgba (pat, ((makeup_thres - .01) / -60.f), 0.5, 0.5, 0.5, 0.5);
 	}
 	cairo_pattern_add_color_stop_rgba (pat, 1.0, 0.5, 0.5, 0.5, 0.5);
 

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -129,6 +129,7 @@ instantiate(const LV2_Descriptor* descriptor,
 	acomp->tau = (1.0 - exp (-2.f * M_PI * 25.f / acomp->srate));
 #ifdef LV2_EXTENDED
 	acomp->need_expose = true;
+	acomp->v_lvl_out = -70.f;
 #endif
 
 	return (LV2_Handle)acomp;
@@ -394,7 +395,8 @@ run_mono(LV2_Handle instance, uint32_t n_samples)
 		// >= 1dB difference
 		acomp->need_expose = true;
 		acomp->v_lvl_in = v_lvl_in;
-		acomp->v_lvl_out = v_lvl_out - to_dB(makeup_gain);
+		const float relax_coef = exp(-(float)n_samples/srate);
+		acomp->v_lvl_out = fmaxf (v_lvl_out, relax_coef*acomp->v_lvl_out + (1.f-relax_coef)*v_lvl_out);
 	}
 	if (acomp->need_expose && acomp->queue_draw) {
 		acomp->need_expose = false;
@@ -547,7 +549,8 @@ run_stereo(LV2_Handle instance, uint32_t n_samples)
 		// >= 1dB difference
 		acomp->need_expose = true;
 		acomp->v_lvl_in = v_lvl_in;
-		acomp->v_lvl_out = v_lvl_out - to_dB(makeup_gain);
+		const float relax_coef = exp(-2.0*n_samples/srate);
+		acomp->v_lvl_out = fmaxf (v_lvl_out, relax_coef*acomp->v_lvl_out + (1.f-relax_coef)*v_lvl_out);
 	}
 	if (acomp->need_expose && acomp->queue_draw) {
 		acomp->need_expose = false;
@@ -582,7 +585,7 @@ cleanup(LV2_Handle instance)
 
 #ifdef LV2_EXTENDED
 static float
-comp_curve (AComp* self, float xg) {
+comp_curve (const AComp* self, float xg) {
 	const float knee = self->v_knee;
 	const float ratio = self->v_ratio;
 	const float thresdb = self->v_thresdb;
@@ -604,22 +607,13 @@ comp_curve (AComp* self, float xg) {
 	return yg;
 }
 
-static LV2_Inline_Display_Image_Surface *
-render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
+static void
+render_inline_full (cairo_t* cr, const AComp* self)
 {
-	AComp* self = (AComp*)instance;
-	uint32_t h = MIN (w, max_h);
+	const float w = self->w;
+	const float h = self->h;
 
 	const float makeup_thres = self->v_thresdb + self->v_makeup;
-
-	if (!self->display || self->w != w || self->h != h) {
-		if (self->display) cairo_surface_destroy(self->display);
-		self->display = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, w, h);
-		self->w = w;
-		self->h = h;
-	}
-
-	cairo_t* cr = cairo_create (self->display);
 
 	// clear background
 	cairo_rectangle (cr, 0, 0, w, h);
@@ -737,10 +731,130 @@ render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
 	cairo_fill (cr);
 
 	cairo_pattern_destroy (pat); // TODO cache pattern
+}
 
+static void
+render_inline_only_bars (cairo_t* cr, const AComp* self)
+{
+	const float w = self->w;
+	const float h = self->h;
 
-	// create RGBA surface
+	cairo_rectangle (cr, 0, 0, w, h);
+	cairo_set_source_rgba (cr, .2, .2, .2, 1.0);
+	cairo_fill (cr);
+
+	cairo_set_line_width (cr, 1.0);
+
+	cairo_save (cr);
+
+	const float ht = 0.333f * h;
+
+	const float x1 = w*0.05;
+	const float wd = w - 2.0f*x1;
+
+	const float y1 = 0.1*h;
+	const float y2 = h - y1 - ht;
+
+	cairo_set_source_rgba (cr, 0.5, 0.5, 0.5, 0.5);
+
+	cairo_rectangle (cr, x1, y1, wd, ht);
+	cairo_fill (cr);
+
+	cairo_rectangle (cr, x1, y2, wd, ht);
+	cairo_fill (cr);
+
+	cairo_set_source_rgba (cr, 0.75, 0.0, 0.0, 1.0);
+	const float w_gr = (self->v_gainr > 60.f) ? wd : wd * self->v_gainr * (1.f/60.f);
+	cairo_rectangle (cr, x1+wd-w_gr, y2, w_gr, ht);
+	cairo_fill (cr);
+
+	if (self->v_lvl_out > -60.f) {
+		if (self->v_lvl_out > 10.f) {
+			cairo_set_source_rgba (cr, 0.75, 0.0, 0.0, 1.0);
+		} else if (self->v_lvl_out > 0.f) {
+			cairo_set_source_rgba (cr, 0.66, 0.66, 0.0, 1.0);
+		} else {
+			cairo_set_source_rgba (cr, 0.0, 0.66, 0.0, 1.0);
+		}
+		const float w_g = (self->v_lvl_out > 10.f) ? wd : wd * (60.f+self->v_lvl_out) / 70.f;
+		cairo_rectangle (cr, x1, y1, w_g, ht);
+		cairo_fill (cr);
+	}
+
+	cairo_set_source_rgba (cr, 1.0, 1.0, 1.0, 1.0);
+
+	const float tck = 0.25*ht;
+
+	for (uint32_t d = 1; d < 7; ++d) {
+		const float x = x1 + (d * wd * (10.f / 70.f));
+
+		cairo_move_to (cr, x, y1);
+		cairo_line_to (cr, x, y1+tck);
+
+		cairo_move_to (cr, x, y1+ht);
+		cairo_line_to (cr, x, y1+ht-tck);
+
+		cairo_move_to (cr, x, y2);
+		cairo_line_to (cr, x, y2+tck);
+
+		cairo_move_to (cr, x, y2+ht);
+		cairo_line_to (cr, x, y2+ht-tck);
+	}
+
+	cairo_set_line_width (cr, 2.0);
+
+	const float x_0dB = x1 + wd*(60.f/70.f);
+
+	cairo_move_to (cr, x_0dB, y1);
+	cairo_line_to (cr, x_0dB, y1+ht);
+
+	cairo_rectangle (cr, x1, y1, wd, ht);
+	cairo_rectangle (cr, x1, y2, wd, ht);
+	cairo_stroke (cr);
+
+	// visualize threshold
+	const float tr = x1 + wd * (60.f+self->v_thresdb) / 70.f;
+	cairo_set_source_rgba (cr, 0.95, 0.95, 0.0, 1.0);
+	cairo_move_to (cr, tr, y1);
+	cairo_line_to (cr, tr, y1+ht);
+	cairo_stroke (cr);
+
+	// visualize ratio
+	const float reduced_0dB = self->v_thresdb * (1.f - 1.f/self->v_ratio);
+	const float rt = x1 + wd * (60.f+reduced_0dB) / 70.f;
+	cairo_set_source_rgba (cr, 0.95, 0.0, 0.0, 1.0);
+	cairo_move_to (cr, rt, y1);
+	cairo_line_to (cr, rt, y1+ht);
+	cairo_stroke (cr);
+}
+
+static LV2_Inline_Display_Image_Surface *
+render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
+{
+	AComp* self = (AComp*)instance;
+
+	uint32_t h = MIN (w, max_h);
+	if (w < 200) {
+		h = 40;
+	}
+
+	if (!self->display || self->w != w || self->h != h) {
+		if (self->display) cairo_surface_destroy(self->display);
+		self->display = cairo_image_surface_create (CAIRO_FORMAT_ARGB32, w, h);
+		self->w = w;
+		self->h = h;
+	}
+
+	cairo_t* cr = cairo_create (self->display);
+
+	if (w >= 200) {
+		render_inline_full (cr, self);
+	} else {
+		render_inline_only_bars (cr, self);
+	}
+
 	cairo_destroy (cr);
+
 	cairo_surface_flush (self->display);
 	self->surf.width = cairo_image_surface_get_width (self->display);
 	self->surf.height = cairo_image_surface_get_height (self->display);

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -99,6 +99,7 @@ typedef struct {
 	float v_knee;
 	float v_ratio;
 	float v_thresdb;
+	float v_makeup;
 	float v_lvl;
 	float v_lvl_in;
 	float v_lvl_out;
@@ -283,7 +284,8 @@ run_mono(LV2_Handle instance, uint32_t n_samples)
 
 	float ratio = *acomp->ratio;
 	float thresdb = *acomp->thresdb;
-	float makeup_target = from_dB(*acomp->makeup);
+	float makeup = *acomp->makeup;
+	float makeup_target = from_dB(makeup);
 	float makeup_gain = acomp->makeup_gain;
 
 	const float tau = acomp->tau;
@@ -291,6 +293,7 @@ run_mono(LV2_Handle instance, uint32_t n_samples)
 	if (*acomp->enable <= 0) {
 		ratio = 1.f;
 		thresdb = 0.f;
+		makeup = 0.f;
 		makeup_target = 1.f;
 	}
 
@@ -307,6 +310,11 @@ run_mono(LV2_Handle instance, uint32_t n_samples)
 
 	if (acomp->v_thresdb != thresdb) {
 		acomp->v_thresdb = thresdb;
+		acomp->need_expose = true;
+	}
+
+	if (acomp->v_makeup != makeup) {
+		acomp->v_makeup = makeup;
 		acomp->need_expose = true;
 	}
 #endif
@@ -550,6 +558,7 @@ comp_curve (AComp* self, float xg) {
 	const float knee = self->v_knee;
 	const float ratio = self->v_ratio;
 	const float thresdb = self->v_thresdb;
+	const float makeup = self->v_makeup;
 
 	const float width = 6.f * knee + 0.01f;
 	float yg = 0.f;
@@ -561,6 +570,9 @@ comp_curve (AComp* self, float xg) {
 	} else {
 		yg = xg + (1.f / ratio - 1.f ) * (xg - thresdb + width / 2.f) * (xg - thresdb + width / 2.f) / (2.f * width);
 	}
+
+	yg += makeup;
+
 	return yg;
 }
 
@@ -655,8 +667,8 @@ render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
 
 	// maybe cut off at x-position?
 	const float x = w * (self->v_lvl_in + 60) / 60.f;
-	//const float y = h * (self->v_lvl_out + 60) / 60.f;
-	cairo_rectangle (cr, 0, h - x, x, h);
+	const float y = x + h*self->v_makeup;
+	cairo_rectangle (cr, 0, h - y, x, y);
 	if (self->v_ratio > 1.0) {
 		cairo_set_source (cr, pat);
 	} else {

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -432,6 +432,7 @@ run_stereo(LV2_Handle instance, uint32_t n_samples)
 	if (*acomp->enable <= 0) {
 		ratio = 1.f;
 		thresdb = 0.f;
+		makeup = 0.f;
 		makeup_target = 1.f;
 	}
 

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -873,6 +873,9 @@ extension_data(const char* uri)
 	if (!strcmp(uri, LV2_INLINEDISPLAY__interface)) {
 		return &display;
 	}
+	if (!strcmp(uri, LV2_INLINEDISPLAY__in_gui)) {
+		return &display;
+	}
 #endif
 	return NULL;
 }

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -99,6 +99,7 @@ typedef struct {
 	float v_knee;
 	float v_ratio;
 	float v_thresdb;
+	float v_gainr;
 	float v_makeup;
 	float v_lvl;
 	float v_lvl_in;
@@ -320,6 +321,7 @@ run_mono(LV2_Handle instance, uint32_t n_samples)
 #endif
 
 	float in_peak = 0;
+	acomp->v_gainr = 0.0;
 
 	for (i = 0; i < n_samples; i++) {
 		in0 = input[i];
@@ -353,6 +355,9 @@ run_mono(LV2_Handle instance, uint32_t n_samples)
 		Lgain = from_dB(cdb);
 
 		*(acomp->gainr) = Lyl;
+		if (Lyl > acomp->v_gainr) {
+			acomp->v_gainr = Lyl;
+		}
 
 		lgaininp = in0 * Lgain;
 
@@ -459,6 +464,7 @@ run_stereo(LV2_Handle instance, uint32_t n_samples)
 #endif
 
 	float in_peak = 0;
+	acomp->v_gainr = 0.0;
 
 	for (i = 0; i < n_samples; i++) {
 		in0 = input0[i];
@@ -494,6 +500,9 @@ run_stereo(LV2_Handle instance, uint32_t n_samples)
 		Lgain = from_dB(cdb);
 
 		*(acomp->gainr) = Lyl;
+		if (Lyl > acomp->v_gainr) {
+			acomp->v_gainr = Lyl;
+		}
 
 		lgaininp = in0 * Lgain;
 		rgaininp = in1 * Lgain;
@@ -653,6 +662,23 @@ render_inline (LV2_Handle instance, uint32_t w, uint32_t max_h)
 		cairo_stroke (cr);
 	}
 
+	{ // GR
+		const float x = -.5 + floorf (w * (62.5f / 70.f));
+		const float y = -.5 + floorf (h * (10.0f / 70.f));
+		const float wd = floorf (w * (5.f / 70.f));
+		const float ht = floorf (h * (55.f / 70.f));
+		cairo_rectangle (cr, x, y, wd, ht);
+		cairo_fill (cr);
+
+		const float h_gr = fminf (ht, floorf (h * self->v_gainr / 70.f));
+		cairo_set_source_rgba (cr, 0.95, 0.0, 0.0, 1.0);
+		cairo_rectangle (cr, x, y, wd, h_gr);
+		cairo_fill (cr);
+		cairo_set_source_rgba (cr, 0.5, 0.5, 0.5, 0.5);
+		cairo_rectangle (cr, x, y, wd, ht);
+		cairo_set_source_rgba (cr, 0.75, 0.75, 0.75, 1.0);
+		cairo_stroke (cr);
+	}
 
 	// draw curve
 	cairo_set_source_rgba (cr, .8, .8, .8, 1.0);

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -423,7 +423,8 @@ run_stereo(LV2_Handle instance, uint32_t n_samples)
 
 	float ratio = *acomp->ratio;
 	float thresdb = *acomp->thresdb;
-	float makeup_target = from_dB(*acomp->makeup);
+	float makeup = *acomp->makeup;
+	float makeup_target = from_dB(makeup);
 	float makeup_gain = acomp->makeup_gain;
 
 	const float tau = acomp->tau;
@@ -447,6 +448,11 @@ run_stereo(LV2_Handle instance, uint32_t n_samples)
 
 	if (acomp->v_thresdb != thresdb) {
 		acomp->v_thresdb = thresdb;
+		acomp->need_expose = true;
+	}
+
+	if (acomp->v_makeup != makeup) {
+		acomp->v_makeup = makeup;
 		acomp->need_expose = true;
 	}
 #endif

--- a/libs/plugins/a-comp.lv2/a-comp.c
+++ b/libs/plugins/a-comp.lv2/a-comp.c
@@ -743,16 +743,15 @@ render_inline_only_bars (cairo_t* cr, const AComp* self)
 	cairo_set_source_rgba (cr, .2, .2, .2, 1.0);
 	cairo_fill (cr);
 
-	cairo_set_line_width (cr, 1.0);
 
 	cairo_save (cr);
 
-	const float ht = 0.333f * h;
+	const float ht = 0.25f * h;
 
 	const float x1 = w*0.05;
 	const float wd = w - 2.0f*x1;
 
-	const float y1 = 0.1*h;
+	const float y1 = 0.17*h;
 	const float y2 = h - y1 - ht;
 
 	cairo_set_source_rgba (cr, 0.5, 0.5, 0.5, 0.5);
@@ -783,7 +782,9 @@ render_inline_only_bars (cairo_t* cr, const AComp* self)
 
 	cairo_set_source_rgba (cr, 1.0, 1.0, 1.0, 1.0);
 
-	const float tck = 0.25*ht;
+	const float tck = 0.33*ht;
+
+	cairo_set_line_width (cr, .5);
 
 	for (uint32_t d = 1; d < 7; ++d) {
 		const float x = x1 + (d * wd * (10.f / 70.f));
@@ -801,7 +802,7 @@ render_inline_only_bars (cairo_t* cr, const AComp* self)
 		cairo_line_to (cr, x, y2+ht-tck);
 	}
 
-	cairo_set_line_width (cr, 2.0);
+	cairo_stroke (cr);
 
 	const float x_0dB = x1 + wd*(60.f/70.f);
 
@@ -811,6 +812,8 @@ render_inline_only_bars (cairo_t* cr, const AComp* self)
 	cairo_rectangle (cr, x1, y1, wd, ht);
 	cairo_rectangle (cr, x1, y2, wd, ht);
 	cairo_stroke (cr);
+
+	cairo_set_line_width (cr, 2.0);
 
 	// visualize threshold
 	const float tr = x1 + wd * (60.f+self->v_thresdb) / 70.f;

--- a/libs/plugins/a-comp.lv2/a-comp.ttl.in
+++ b/libs/plugins/a-comp.lv2/a-comp.ttl.in
@@ -14,7 +14,8 @@
     a lv2:Plugin, doap:Project, lv2:CompressorPlugin ;
 
     lv2:optionalFeature <http://lv2plug.in/ns/lv2core#hardRTCapable> ;
-		lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#queue_draw> ;
+    lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#queue_draw> ;
+    lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#in_gui> ;
 
     lv2:port [
         a lv2:InputPort, lv2:ControlPort ;

--- a/libs/plugins/a-eq.lv2/a-eq.ttl.in
+++ b/libs/plugins/a-eq.lv2/a-eq.ttl.in
@@ -32,7 +32,8 @@ unit:db1
     a lv2:Plugin, doap:Project, lv2:FilterPlugin ;
 
     lv2:optionalFeature <http://lv2plug.in/ns/lv2core#hardRTCapable> ;
-		lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#queue_draw> ;
+    lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#queue_draw> ;
+    lv2:optionalFeature <http://harrisonconsoles.com/lv2/inlinedisplay#in_gui> ;
 
     lv2:requiredFeature <http://lv2plug.in/ns/ext/options#options> ,
                         <http://lv2plug.in/ns/ext/urid#map> ;


### PR DESCRIPTION
This is a renewed and rebased version of #365.

* Caching of allocated pixmap buffers is dropped as discussion in #365 has shown that caching empty pixmap buffers to save mere memory allocation does not increase performance to be worth it.

* Plugins now signal their wish to draw the display in the generic gui more in the spirit of LV2 by a `lv2:optionalFeature` in the .ttl file instead of in code by `extension_data()`.