### PR TITLE
More Russian translation updated and fixes

### DIFF
--- a/gtk2_ardour/po/ru.po
+++ b/gtk2_ardour/po/ru.po
@@ -401,7 +401,7 @@ msgstr ""
 "\tИгорь Блинов <pitstop@nm.ru>\n"
 "\tАлександр Прокудин <alexandre.prokoudine@gmail.com>\n"
 "\tАлександр Кольцов <ag1455@mail.ru>\n"
-"\tПетр Семилетов <tea@list.ru>"
+"\tПетр Семилетов <tea@list.ru>\n"
 
 #: about.cc:219
 msgid ""
@@ -551,11 +551,11 @@ msgstr "MIDI-дорожки"
 
 #: add_route_dialog.cc:79 add_route_dialog.cc:225
 msgid "Audio+MIDI Tracks"
-msgstr "Смешанные дорожки (Звук+MIDI)"
+msgstr "Звуковые +MIDI дорожки"
 
 #: add_route_dialog.cc:80 add_route_dialog.cc:219
 msgid "Audio Busses"
-msgstr "Аудиошины"
+msgstr "Звуковые шины"
 
 #: add_route_dialog.cc:81 add_route_dialog.cc:221
 msgid "MIDI Busses"
@@ -563,7 +563,7 @@ msgstr "MIDI-шины"
 
 #: add_route_dialog.cc:82
 msgid "VCA Masters"
-msgstr "VCA-мастер"
+msgstr "VCA-мастера"
 
 #: add_route_dialog.cc:85 add_route_dialog.cc:629 duplicate_routes_dialog.cc:58
 #: duplicate_routes_dialog.cc:209
@@ -678,7 +678,7 @@ msgstr "Бесслойный"
 
 #: add_route_dialog.cc:377 add_route_dialog.cc:392
 msgid "Tape"
-msgstr "Плёночный"
+msgstr "Лента"
 
 #: add_route_dialog.cc:481 monitor_section.cc:277 plugin_pin_dialog.cc:509
 #: plugin_setup_dialog.cc:213
@@ -711,7 +711,7 @@ msgstr "8 каналов"
 
 #: add_route_dialog.cc:528
 msgid "12 Channel"
-msgstr "3 канала"
+msgstr "12 каналов"
 
 #: add_route_dialog.cc:532 gain_meter.cc:193 mixer_strip.cc:2053
 #: mixer_strip.cc:2499
@@ -762,7 +762,7 @@ msgstr "Выбранные выделения"
 
 #: analysis_window.cc:47
 msgid "Selected regions"
-msgstr "Выделенные области"
+msgstr "Выделенные регионы"
 
 #: analysis_window.cc:48
 msgid "Show frequency power range"
@@ -807,11 +807,11 @@ msgstr "@ABCDEFGHIJLKMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
 #: ardour_http.cc:183 ardour_http.cc:197
 msgid "HTTP request failed: (%1) %2"
-msgstr ""
+msgstr "HTTP-запрос провалился: (%1) %2"
 
 #: ardour_http.cc:187 ardour_http.cc:200
 msgid "HTTP request status: %1"
-msgstr ""
+msgstr "Состояние HTTP-запроса: %1"
 
 #: ardour_ui.cc:206
 msgid ""
@@ -830,7 +830,7 @@ msgstr ""
 #: ardour_ui.cc:293 editor_actions.cc:673 rc_option_editor.cc:2768
 #: region_editor.cc:53
 msgid "Audition"
-msgstr "Контроль"
+msgstr "Прослушивание"
 
 #: ardour_ui.cc:294 editor_actions.cc:158 mixer_strip.cc:2249
 #: monitor_section.cc:330 rc_option_editor.cc:2461 route_time_axis.cc:268
@@ -844,7 +844,7 @@ msgstr "Отклик"
 
 #: ardour_ui.cc:307 speaker_dialog.cc:36
 msgid "Speaker Configuration"
-msgstr "Конфигурация громкоговорителей"
+msgstr "Конфигурация динамиков"
 
 #: ardour_ui.cc:308
 msgid "Add Tracks/Busses"
@@ -904,7 +904,7 @@ msgstr "Соединения MIDI"
 
 #: ardour_ui.cc:322 keyeditor.cc:78
 msgid "Keyboard Shortcuts"
-msgstr "Клавиатурные комбинации"
+msgstr "Сочетания клавиш"
 
 #: ardour_ui.cc:333 editor.cc:1313
 msgid "Window|Editor"
@@ -1099,7 +1099,7 @@ msgstr "Выйти"
 
 #: ardour_ui.cc:1252
 msgid "Continue using %1"
-msgstr "Продолжить работу"
+msgstr "Продолжить использование %1"
 
 #: ardour_ui.cc:1283 startup.cc:337
 msgid "%1 is ready for use"
@@ -1279,12 +1279,12 @@ msgstr "X: <span foreground=\"%s\">?</span>"
 
 #: ardour_ui.cc:1716
 msgid "Audio dropouts. Shift+click to reset"
-msgstr ""
+msgstr "Выпадения звука. Shift+клик для сброса."
 
 #: ardour_ui.cc:1729
 #, c-format
 msgid "DSP: <span foreground=\"%s\">%5.1f%%</span>"
-msgstr "ЦП: <span foreground=\"%s\">%5.1f%%</span>"
+msgstr "DSP: <span foreground=\"%s\">%5.1f%%</span>"
 
 #: ardour_ui.cc:1739
 #, c-format
@@ -1339,7 +1339,7 @@ msgstr "Открыть сессию"
 #: ardour_ui.cc:1983 session_dialog.cc:413 session_import_dialog.cc:170
 #: session_metadata_dialog.cc:861
 msgid "%1 sessions"
-msgstr "Cеансы %1"
+msgstr "%1 сессий"
 
 #: ardour_ui.cc:1988 session_dialog.cc:418
 msgid "Session Archives"
@@ -1511,7 +1511,7 @@ msgstr ""
 
 #: ardour_ui.cc:3213
 msgid "Open Existing Session"
-msgstr "Открыть существующую сессю"
+msgstr "Открыть существующую сессию"
 
 #: ardour_ui.cc:3538
 msgid "There is no existing session at \"%1\""
@@ -1783,11 +1783,11 @@ msgstr "Не выбран видеофайл"
 
 #: ardour_ui.cc:4645
 msgid "No LTC detected, video will not be aligned."
-msgstr ""
+msgstr "LTC не обнаружено, видео не будет выровнено"
 
 #: ardour_ui.cc:4651
 msgid "Align video-start to %1 [samples]"
-msgstr ""
+msgstr "Выровнять начало видео к %1 [сэмплов]"
 
 #: ardour_ui.cc:4827
 msgid "xrun"
@@ -1997,7 +1997,7 @@ msgstr "В конец сессии"
 
 #: ardour_ui2.cc:82
 msgid "Play loop range"
-msgstr "Воспроизвести выделение в петле"
+msgstr "Играть петлю"
 
 #: ardour_ui2.cc:83
 msgid ""


### PR DESCRIPTION
Just more Russian translation updated and fixes. When most of messages will be translated and estabilished well, then I'll be able to write a Russian manual for Ardour using the translated terms. Currently it is not possibly due to the differencies in translated terms, and the use of non-common words in the translation. For example, no one say "Циклическое воспроизведение" but all people just say shortly "петля" (i.e. "loop").