### PR TITLE
alsautil: show playback only devices

### DIFF
--- a/libs/backends/jack/jack_utils.cc
+++ b/libs/backends/jack/jack_utils.cc
@@ -273,7 +273,7 @@ void
 ARDOUR::get_jack_alsa_device_names (device_map_t& devices)
 {
 #ifdef HAVE_ALSA
-	get_alsa_audio_device_names(devices);
+	get_alsa_audio_device_names(devices, HalfDuplexOut);
 #else
 	/* silence a compiler unused variable warning */
 	(void) devices;


### PR DESCRIPTION
Hi guys!
I did my first mixing project with ardour and ran into this issue. I wanted to
mix and master on my laptop with a single usb dac. I was puzzled why the
device did not show up, but was working fine with qjackctl. I had a look at
the code and thought this little contribution might help others, as I hope
my use case is not so "beyond .. scope".
I finished the one mixing project without any problems, crashes or
whatsoever, so I would consider the patch slightly tested on linux with a
usb dac.
Regards,
Stefan