### PR TITLE
Fix/PluginDisplay

### DIFF
--- a/gtk2_ardour/plugin_display.cc
+++ b/gtk2_ardour/plugin_display.cc
@@ -75,17 +75,9 @@ PluginDisplay::update_height_alloc (uint32_t height)
 {
 	uint32_t shm = std::min (_max_height, height);
 
-	Gtk::Container* pr = get_parent();
-	for (uint32_t i = 0; i < 4 && pr; ++i) {
-		// VBox, EventBox, ViewPort, ScrolledWindow
-		pr = pr->get_parent();
-	}
-
 	if (shm != _cur_height) {
-		if (_cur_height < shm) {
-			queue_resize ();
-		}
 		_cur_height = shm;
+		queue_resize ();
 	}
 }
 

--- a/gtk2_ardour/plugin_display.h
+++ b/gtk2_ardour/plugin_display.h
@@ -40,7 +40,7 @@ protected:
 		_qdraw_connection.disconnect ();
 	}
 
-	void update_height_alloc (uint32_t inline_height);
+	virtual void update_height_alloc (uint32_t inline_height);
 	virtual uint32_t render_inline (cairo_t *, uint32_t width);
 
 	virtual void display_frame (cairo_t* cr, double w, double h);


### PR DESCRIPTION
37b03e3 has broken `ProcessorBox` resizing by hiding `ProcessorBox::PluginInlineDisplay::update_height_alloc()` behind a non-virtual method. This fix should probably make it into 5.11.

Sorry for messing this up.

Furthermore some irrelevant code is removed (second commit of the PR).