### PR TITLE
Save and Edit template descriptions

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -3192,9 +3192,10 @@ ARDOUR_UI::save_template ()
 		return;
 	}
 
-	SaveTemplateDialog* d = new SaveTemplateDialog (*_session);
+	SaveTemplateDialog* d = new SaveTemplateDialog (_session->name());
 
 	d->signal_response().connect (sigc::bind (sigc::mem_fun (*this, &ARDOUR_UI::save_template_dialog_response), d));
+
 	d->show ();
 }
 

--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -3192,10 +3192,9 @@ ARDOUR_UI::save_template ()
 		return;
 	}
 
-	SaveTemplateDialog* d = new SaveTemplateDialog (_session->name());
-
+	const std::string desc = SessionMetadata::Metadata()->description ();
+	SaveTemplateDialog* d = new SaveTemplateDialog (_session->name (), desc);
 	d->signal_response().connect (sigc::bind (sigc::mem_fun (*this, &ARDOUR_UI::save_template_dialog_response), d));
-
 	d->show ();
 }
 

--- a/gtk2_ardour/ardour_ui.h
+++ b/gtk2_ardour/ardour_ui.h
@@ -127,6 +127,7 @@ class MainClock;
 class Mixer_UI;
 class PublicEditor;
 class SaveAsDialog;
+class SaveTemplateDialog;
 class SessionDialog;
 class SessionOptionEditorWindow;
 class Splash;
@@ -621,7 +622,7 @@ private:
 
 	void open_session ();
 	void open_recent_session ();
-	bool process_save_template_prompter (ArdourWidgets::Prompter& prompter);
+	void save_template_dialog_response (int response, SaveTemplateDialog* d);
 	void save_template ();
 	void manage_templates ();
 

--- a/gtk2_ardour/route_ui.cc
+++ b/gtk2_ardour/route_ui.cc
@@ -1928,8 +1928,7 @@ RouteUI::save_as_template ()
 		return;
 	}
 
-	SaveTemplateDialog* d = new SaveTemplateDialog (_route->name());
-
+	SaveTemplateDialog* d = new SaveTemplateDialog (_route->name(), _route->comment());
 	d->signal_response().connect (sigc::bind (sigc::mem_fun (*this, &RouteUI::save_as_template_dialog_response), d));
 	d->show ();
 }

--- a/gtk2_ardour/route_ui.cc
+++ b/gtk2_ardour/route_ui.cc
@@ -1921,9 +1921,7 @@ RouteUI::save_as_template_dialog_response (int response, SaveTemplateDialog* d)
 void
 RouteUI::save_as_template ()
 {
-	std::string dir;
-
-	dir = ARDOUR::user_route_template_directory ();
+	const std::string dir = ARDOUR::user_route_template_directory ();
 
 	if (g_mkdir_with_parents (dir.c_str(), 0755)) {
 		error << string_compose (_("Cannot create route template directory %1"), dir) << endmsg;

--- a/gtk2_ardour/route_ui.h
+++ b/gtk2_ardour/route_ui.h
@@ -63,6 +63,7 @@ namespace ArdourWidgets {
 class ArdourWindow;
 class IOSelectorWindow;
 class ControlSlaveUI;
+class SaveTemplateDialog;
 
 class RoutePinWindowProxy : public WM::ProxyBase
 {
@@ -243,7 +244,7 @@ public:
 	virtual void map_frozen ();
 
 	void adjust_latency ();
-	bool process_save_template_prompter (ArdourWidgets::Prompter& prompter, const std::string& dir);
+	void save_as_template_dialog_response (int response, SaveTemplateDialog* d);
 	void save_as_template ();
 
 	static Gtkmm2ext::ActiveState solo_active_state (boost::shared_ptr<ARDOUR::Stripable>);

--- a/gtk2_ardour/save_template_dialog.cc
+++ b/gtk2_ardour/save_template_dialog.cc
@@ -1,0 +1,71 @@
+/*
+    Copyright (C) 2017 Paul Davis
+    Author: Johannes Mueller
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#include <gtkmm/box.h>
+#include <gtkmm/frame.h>
+#include <gtkmm/label.h>
+#include <gtkmm/stock.h>
+
+#include "pbd/i18n.h"
+#include "ardour/session.h"
+
+#include "save_template_dialog.h"
+
+using namespace Gtk;
+using namespace ARDOUR;
+
+SaveTemplateDialog::SaveTemplateDialog (const Session& s)
+	: ArdourDialog (_("Save as template"))
+{
+	_name_editor.get_buffer()->set_text (s.name() + _("-template"));
+	_description_editor.set_wrap_mode (Gtk::WRAP_WORD);
+	_description_editor.set_size_request(400, 300);
+
+	HBox* hb = manage (new HBox);
+	hb->set_spacing (8);
+	Label* lb = manage (new Label(_("Template name:")));
+	hb->pack_start (*lb, false, true);
+	hb->pack_start (_name_editor, true, true);
+
+	Frame* fd = manage (new Frame(_("Description:")));
+	fd->add (_description_editor);
+
+	get_vbox()->set_spacing (8);
+	get_vbox()->pack_start (*fd);
+	get_vbox()->pack_start (*hb);
+
+	add_button(Gtk::Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	add_button(Gtk::Stock::SAVE, Gtk::RESPONSE_ACCEPT);
+
+	show_all_children ();
+}
+
+
+std::string
+SaveTemplateDialog::get_template_name () const
+{
+	return _name_editor.get_buffer()->get_text();
+}
+
+std::string
+SaveTemplateDialog::get_description () const
+{
+	return _description_editor.get_buffer()->get_text();
+}

--- a/gtk2_ardour/save_template_dialog.cc
+++ b/gtk2_ardour/save_template_dialog.cc
@@ -35,6 +35,7 @@ SaveTemplateDialog::SaveTemplateDialog (const std::string& name, const std::stri
 	: ArdourDialog (_("Save as template"))
 {
 	_name_entry.get_buffer()->set_text (name + _("-template"));
+	_description_editor.get_buffer()->set_text (desc);
 	_description_editor.set_wrap_mode (Gtk::WRAP_WORD);
 	_description_editor.set_size_request(400, 300);
 

--- a/gtk2_ardour/save_template_dialog.cc
+++ b/gtk2_ardour/save_template_dialog.cc
@@ -31,10 +31,10 @@
 using namespace Gtk;
 using namespace ARDOUR;
 
-SaveTemplateDialog::SaveTemplateDialog (const Session& s)
+SaveTemplateDialog::SaveTemplateDialog (const std::string& name, const std::string& desc)
 	: ArdourDialog (_("Save as template"))
 {
-	_name_editor.get_buffer()->set_text (s.name() + _("-template"));
+	_name_editor.get_buffer()->set_text (name + _("-template"));
 	_description_editor.set_wrap_mode (Gtk::WRAP_WORD);
 	_description_editor.set_size_request(400, 300);
 

--- a/gtk2_ardour/save_template_dialog.cc
+++ b/gtk2_ardour/save_template_dialog.cc
@@ -68,5 +68,11 @@ SaveTemplateDialog::get_template_name () const
 std::string
 SaveTemplateDialog::get_description () const
 {
-	return _description_editor.get_buffer()->get_text();
+	std::string desc_txt = _description_editor.get_buffer()->get_text ();
+	std::string::reverse_iterator wss = desc_txt.rbegin();
+	while (wss != desc_txt.rend() && isspace (*wss)) {
+		desc_txt.erase (--(wss++).base());
+	}
+
+	return desc_txt;
 }

--- a/gtk2_ardour/save_template_dialog.cc
+++ b/gtk2_ardour/save_template_dialog.cc
@@ -34,7 +34,7 @@ using namespace ARDOUR;
 SaveTemplateDialog::SaveTemplateDialog (const std::string& name, const std::string& desc)
 	: ArdourDialog (_("Save as template"))
 {
-	_name_editor.get_buffer()->set_text (name + _("-template"));
+	_name_entry.get_buffer()->set_text (name + _("-template"));
 	_description_editor.set_wrap_mode (Gtk::WRAP_WORD);
 	_description_editor.set_size_request(400, 300);
 
@@ -42,7 +42,7 @@ SaveTemplateDialog::SaveTemplateDialog (const std::string& name, const std::stri
 	hb->set_spacing (8);
 	Label* lb = manage (new Label(_("Template name:")));
 	hb->pack_start (*lb, false, true);
-	hb->pack_start (_name_editor, true, true);
+	hb->pack_start (_name_entry, true, true);
 
 	Frame* fd = manage (new Frame(_("Description:")));
 	fd->add (_description_editor);
@@ -61,7 +61,7 @@ SaveTemplateDialog::SaveTemplateDialog (const std::string& name, const std::stri
 std::string
 SaveTemplateDialog::get_template_name () const
 {
-	return _name_editor.get_buffer()->get_text();
+	return _name_entry.get_buffer()->get_text();
 }
 
 std::string

--- a/gtk2_ardour/save_template_dialog.h
+++ b/gtk2_ardour/save_template_dialog.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2017 Paul Davis
+    Author: Johannes Mueller
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+*/
+
+#ifndef __ardour_gtk_save_template_dialog_h__
+#define __ardour_gtk_save_template_dialog_h__
+
+#include <gtkmm/entry.h>
+#include <gtkmm/textview.h>
+
+#include "ardour_dialog.h"
+
+namespace ARDOUR
+{
+class Session;
+}
+
+class SaveTemplateDialog : public ArdourDialog
+{
+public:
+	SaveTemplateDialog (const ARDOUR::Session& s);
+
+	std::string get_template_name () const;
+	std::string get_description () const;
+
+private:
+	Gtk::Entry _name_editor;
+	Gtk::TextView _description_editor;
+};
+
+#endif /* __ardour_gtk_save_template_dialog_h__ */

--- a/gtk2_ardour/save_template_dialog.h
+++ b/gtk2_ardour/save_template_dialog.h
@@ -38,7 +38,7 @@ public:
 	std::string get_description () const;
 
 private:
-	Gtk::Entry _name_editor;
+	Gtk::Entry _name_entry;
 	Gtk::TextView _description_editor;
 };
 

--- a/gtk2_ardour/save_template_dialog.h
+++ b/gtk2_ardour/save_template_dialog.h
@@ -21,20 +21,18 @@
 #ifndef __ardour_gtk_save_template_dialog_h__
 #define __ardour_gtk_save_template_dialog_h__
 
+#include <string>
+
 #include <gtkmm/entry.h>
 #include <gtkmm/textview.h>
 
 #include "ardour_dialog.h"
 
-namespace ARDOUR
-{
-class Session;
-}
 
 class SaveTemplateDialog : public ArdourDialog
 {
 public:
-	SaveTemplateDialog (const ARDOUR::Session& s);
+	SaveTemplateDialog (const std::string& name, const std::string& description = "");
 
 	std::string get_template_name () const;
 	std::string get_description () const;

--- a/gtk2_ardour/template_dialog.cc
+++ b/gtk2_ardour/template_dialog.cc
@@ -420,7 +420,12 @@ TemplateManager::save_template_desc ()
 {
 	const string file_path = template_file (_current_selection);
 
-	const string desc_txt = _description_editor.get_buffer()->get_text ();
+	string desc_txt = _description_editor.get_buffer()->get_text ();
+	string::reverse_iterator wss = desc_txt.rbegin();
+	while (wss != desc_txt.rend() && isspace (*wss)) {
+		desc_txt.erase (--(wss++).base());
+	}
+
 	_current_selection->set_value (_template_columns.description, desc_txt);
 
 	XMLTree tree;

--- a/gtk2_ardour/template_dialog.cc
+++ b/gtk2_ardour/template_dialog.cc
@@ -256,13 +256,13 @@ TemplateManager::save_template_desc ()
 		return;
 	}
 
-	XMLNode* desc = tree.root()->child (X_("description"));
-	if (!desc) {
-		desc = new XMLNode (X_("description"));
-		tree.root()->add_child_nocopy (*desc);
-	}
+	tree.root()->remove_nodes (X_("description"));
+	XMLNode* desc = new XMLNode (X_("description"));
+
 	XMLNode* dn = new XMLNode (X_("content"), desc_txt);
 	desc->add_child_nocopy (*dn);
+
+	tree.root()->add_child_nocopy (*desc);
 
 	if (!tree.write ()) {
 		error << string_compose(X_("Could not write to template file \"%1\"."), file_path) << endmsg;

--- a/gtk2_ardour/template_dialog.cc
+++ b/gtk2_ardour/template_dialog.cc
@@ -256,15 +256,10 @@ TemplateManager::save_template_desc ()
 		return;
 	}
 
-	XMLNode* md = tree.root()->child (X_("Metadata"));
-	if (!md) {
-		md = new XMLNode (X_("Metadata"));
-		tree.root()->add_child_nocopy (*md);
-	}
-	XMLNode* desc = md->child (X_("description"));
+	XMLNode* desc = tree.root()->child (X_("description"));
 	if (!desc) {
 		desc = new XMLNode (X_("description"));
-		md->add_child_nocopy (*desc);
+		tree.root()->add_child_nocopy (*desc);
 	}
 	XMLNode* dn = new XMLNode (X_("content"), desc_txt);
 	desc->add_child_nocopy (*dn);

--- a/gtk2_ardour/template_dialog.cc
+++ b/gtk2_ardour/template_dialog.cc
@@ -191,7 +191,7 @@ TemplateDialog::TemplateDialog ()
 	nb->append_page (*route_tm, _("Track Templates"));
 
 	get_vbox()->pack_start (*nb);
-	add_button (_("Ok"), Gtk::RESPONSE_OK);
+	add_button (_("Done"), Gtk::RESPONSE_OK);
 
 	get_vbox()->show_all();
 

--- a/gtk2_ardour/template_dialog.h
+++ b/gtk2_ardour/template_dialog.h
@@ -25,6 +25,7 @@
 
 #include <gtkmm/liststore.h>
 #include <gtkmm/progressbar.h>
+#include <gtkmm/textview.h>
 #include <gtkmm/treeview.h>
 
 #include "ardour_dialog.h"
@@ -64,15 +65,20 @@ protected:
 	void validate_edit (const Glib::ustring& path_string, const Glib::ustring& new_name);
 	void start_edit ();
 
+	void set_desc_dirty ();
+
 	bool key_event (GdkEventKey* ev);
 
 	virtual void rename_template (Gtk::TreeModel::iterator& item, const Glib::ustring& new_name) = 0;
 	virtual void delete_selected_template () = 0;
 
+	virtual void save_template_desc ();
+
 	void export_all_templates ();
 	void import_template_set ();
 
 	virtual std::string templates_dir () const = 0;
+	virtual std::string template_file (const Gtk::TreeModel::const_iterator& item) const = 0;
 
 	virtual bool adjust_xml_tree (XMLTree& tree, const std::string& old_name, const std::string& new_name) const = 0;
 
@@ -82,10 +88,12 @@ protected:
 		SessionTemplateColumns () {
 			add (name);
 			add (path);
+			add (description);
 		}
 
 		Gtk::TreeModelColumn<std::string> name;
 		Gtk::TreeModelColumn<std::string> path;
+		Gtk::TreeModelColumn<std::string> description;
 	};
 
 	SessionTemplateColumns _template_columns;
@@ -94,6 +102,10 @@ protected:
 	Gtk::TreeView _template_treeview;
 	Gtk::CellRendererText _validating_cellrenderer;
 	Gtk::TreeView::Column _validated_column;
+
+	Gtk::TextView _description_editor;
+	Gtk::Button _save_desc;
+	bool _desc_dirty;
 
 	Gtk::Button _remove_button;
 	Gtk::Button _rename_button;
@@ -120,6 +132,7 @@ private:
 	void delete_selected_template ();
 
 	std::string templates_dir () const;
+	std::string template_file (const Gtk::TreeModel::const_iterator& item) const;
 
 	bool adjust_xml_tree (XMLTree& tree, const std::string& old_name, const std::string& new_name) const;
 };
@@ -138,6 +151,7 @@ private:
 	void delete_selected_template ();
 
 	std::string templates_dir () const;
+	std::string template_file (const Gtk::TreeModel::const_iterator& item) const;
 
 	bool adjust_xml_tree (XMLTree& tree, const std::string& old_name, const std::string& new_name) const;
 };

--- a/gtk2_ardour/template_dialog.h
+++ b/gtk2_ardour/template_dialog.h
@@ -21,22 +21,7 @@
 #ifndef __gtk2_ardour_template_dialog_h__
 #define __gtk2_ardour_template_dialog_h__
 
-#include <vector>
-
-#include <gtkmm/liststore.h>
-#include <gtkmm/progressbar.h>
-#include <gtkmm/textview.h>
-#include <gtkmm/treeview.h>
-
 #include "ardour_dialog.h"
-#include "progress_reporter.h"
-
-namespace ARDOUR {
-	struct TemplateInfo;
-}
-
-class XMLTree;
-class XMLNode;
 
 class TemplateDialog : public ArdourDialog,
 		       public PBD::ScopedConnectionList
@@ -44,120 +29,6 @@ class TemplateDialog : public ArdourDialog,
 public:
 	TemplateDialog ();
 	~TemplateDialog () {}
-};
-
-class TemplateManager : public Gtk::HBox,
-			public ProgressReporter
-{
-	friend class TemplateDialog;
-public:
-	virtual ~TemplateManager () {}
-	virtual void init () = 0;
-
-	PBD::Signal0<void> TemplatesImported;
-
-protected:
-	TemplateManager ();
-
-	void setup_model (const std::vector<ARDOUR::TemplateInfo>& templates);
-
-	void row_selection_changed ();
-	void render_template_names (Gtk::CellRenderer* rnd, const Gtk::TreeModel::iterator& it);
-	void validate_edit (const Glib::ustring& path_string, const Glib::ustring& new_name);
-	void start_edit ();
-
-	void set_desc_dirty ();
-
-	bool key_event (GdkEventKey* ev);
-
-	virtual void rename_template (Gtk::TreeModel::iterator& item, const Glib::ustring& new_name) = 0;
-	virtual void delete_selected_template () = 0;
-
-	void handle_dirty_description ();
-	virtual void save_template_desc ();
-
-	void export_all_templates ();
-	void import_template_set ();
-
-	virtual std::string templates_dir () const = 0;
-	virtual std::string template_file (const Gtk::TreeModel::const_iterator& item) const = 0;
-
-	virtual bool adjust_xml_tree (XMLTree& tree, const std::string& old_name, const std::string& new_name) const = 0;
-
-	bool adjust_plugin_paths (XMLNode* node, const std::string& name, const std::string& new_name) const;
-
-	struct SessionTemplateColumns : public Gtk::TreeModel::ColumnRecord {
-		SessionTemplateColumns () {
-			add (name);
-			add (path);
-			add (description);
-		}
-
-		Gtk::TreeModelColumn<std::string> name;
-		Gtk::TreeModelColumn<std::string> path;
-		Gtk::TreeModelColumn<std::string> description;
-	};
-
-	SessionTemplateColumns _template_columns;
-	Glib::RefPtr<Gtk::ListStore>  _template_model;
-
-	Gtk::TreeModel::const_iterator _current_selection;
-
-	Gtk::TreeView _template_treeview;
-	Gtk::CellRendererText _validating_cellrenderer;
-	Gtk::TreeView::Column _validated_column;
-
-	Gtk::TextView _description_editor;
-	Gtk::Button _save_desc;
-	bool _desc_dirty;
-
-	Gtk::Button _remove_button;
-	Gtk::Button _rename_button;
-
-	Gtk::Button _export_all_templates_button;
-	Gtk::Button _import_template_set_button;
-
-	Gtk::ProgressBar _progress_bar;
-	std::string _current_action;
-
-	void update_progress_gui (float p);
-};
-
-class SessionTemplateManager : public TemplateManager
-{
-public:
-	SessionTemplateManager () : TemplateManager () {}
-	~SessionTemplateManager () {}
-
-	void init ();
-
-private:
-	void rename_template (Gtk::TreeModel::iterator& item, const Glib::ustring& new_name);
-	void delete_selected_template ();
-
-	std::string templates_dir () const;
-	std::string template_file (const Gtk::TreeModel::const_iterator& item) const;
-
-	bool adjust_xml_tree (XMLTree& tree, const std::string& old_name, const std::string& new_name) const;
-};
-
-
-class RouteTemplateManager : public TemplateManager
-{
-public:
-	RouteTemplateManager () : TemplateManager () {}
-	~RouteTemplateManager () {}
-
-	void init ();
-
-private:
-	void rename_template (Gtk::TreeModel::iterator& item, const Glib::ustring& new_name);
-	void delete_selected_template ();
-
-	std::string templates_dir () const;
-	std::string template_file (const Gtk::TreeModel::const_iterator& item) const;
-
-	bool adjust_xml_tree (XMLTree& tree, const std::string& old_name, const std::string& new_name) const;
 };
 
 

--- a/gtk2_ardour/template_dialog.h
+++ b/gtk2_ardour/template_dialog.h
@@ -49,6 +49,7 @@ public:
 class TemplateManager : public Gtk::HBox,
 			public ProgressReporter
 {
+	friend class TemplateDialog;
 public:
 	virtual ~TemplateManager () {}
 	virtual void init () = 0;
@@ -72,6 +73,7 @@ protected:
 	virtual void rename_template (Gtk::TreeModel::iterator& item, const Glib::ustring& new_name) = 0;
 	virtual void delete_selected_template () = 0;
 
+	void handle_dirty_description ();
 	virtual void save_template_desc ();
 
 	void export_all_templates ();
@@ -98,6 +100,8 @@ protected:
 
 	SessionTemplateColumns _template_columns;
 	Glib::RefPtr<Gtk::ListStore>  _template_model;
+
+	Gtk::TreeModel::const_iterator _current_selection;
 
 	Gtk::TreeView _template_treeview;
 	Gtk::CellRendererText _validating_cellrenderer;

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -218,6 +218,7 @@ gtk2_ardour_sources = [
         'route_ui.cc',
         'ruler_dialog.cc',
         'save_as_dialog.cc',
+        'save_template_dialog.cc',
         'search_path_option.cc',
         'script_selector.cc',
         'selection.cc',

--- a/libs/ardour/ardour/route.h
+++ b/libs/ardour/ardour/route.h
@@ -381,7 +381,7 @@ public:
 
 	boost::weak_ptr<Route> weakroute ();
 
-	int save_as_template (const std::string& path, const std::string& name);
+	int save_as_template (const std::string& path, const std::string& name, const std::string& description );
 
 	PBD::Signal1<void,void*> SelectedChanged;
 

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -259,7 +259,7 @@ class LIBARDOUR_API Session : public PBD::StatefulDestructible, public PBD::Scop
 	 */
 	RouteList new_route_from_template (uint32_t how_many, PresentationInfo::order_t insert_at, const std::string& template_path, const std::string& name, PlaylistDisposition pd = NewPlaylist);
 	RouteList new_route_from_template (uint32_t how_many, PresentationInfo::order_t insert_at, XMLNode&, const std::string& name, PlaylistDisposition pd = NewPlaylist);
-	std::vector<std::string> get_paths_for_new_sources (bool allow_replacing, const std::string& import_file_path, 
+	std::vector<std::string> get_paths_for_new_sources (bool allow_replacing, const std::string& import_file_path,
 	                                                    uint32_t channels, std::vector<std::string> const & smf_track_names);
 
 	int bring_all_sources_into_session (boost::function<void(uint32_t,uint32_t,std::string)> callback);
@@ -531,7 +531,7 @@ class LIBARDOUR_API Session : public PBD::StatefulDestructible, public PBD::Scop
 	int archive_session (const std::string&, const std::string&, ArchiveEncode compress_audio = FLAC_16BIT, bool only_used_sources = false, Progress* p = 0);
 
 	int restore_state (std::string snapshot_name);
-	int save_template (std::string template_name, bool replace_existing = false);
+	int save_template (const std::string& template_name, const std::string& description = "", bool replace_existing = false);
 	int save_history (std::string snapshot_name = "");
 	int restore_history (std::string snapshot_name);
 	void remove_state (std::string snapshot_name);

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -4014,13 +4014,21 @@ Route::set_plugin_state_dir (boost::weak_ptr<Processor> p, const std::string& d)
 }
 
 int
-Route::save_as_template (const string& path, const string& name)
+Route::save_as_template (const string& path, const string& name, const string& description)
 {
 	std::string state_dir = path.substr (0, path.find_last_of ('.')); // strip template_suffix
 	PBD::Unwinder<std::string> uw (_session._template_state_dir, state_dir);
 
 	XMLNode& node (state (false));
 	node.set_property (X_("name"), name);
+
+	if (!description.empty()) {
+		XMLNode* desc = new XMLNode(X_("description"));
+		XMLNode* desc_cont = new XMLNode(X_("content"), description);
+		desc->add_child_nocopy (*desc_cont);
+
+		node.add_child_nocopy (*desc);
+	}
 
 	XMLTree tree;
 

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -4022,6 +4022,7 @@ Route::save_as_template (const string& path, const string& name, const string& d
 	XMLNode& node (state (false));
 	node.set_property (X_("name"), name);
 
+	node.remove_nodes (X_("description"));
 	if (!description.empty()) {
 		XMLNode* desc = new XMLNode(X_("description"));
 		XMLNode* desc_cont = new XMLNode(X_("content"), description);

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -2414,12 +2414,13 @@ Session::save_template (const string& template_name, const string& description, 
 	XMLNode* root;
 	{
 		PBD::Unwinder<std::string> uw (_template_state_dir, template_dir_path);
-		root = &get_template();
+		root = &get_template ();
 	}
 
+	root->remove_nodes (X_("description"));
 	if (!description.empty()) {
-		XMLNode* desc = new XMLNode(X_("description"));
-		XMLNode* desc_cont = new XMLNode(X_("content"), description);
+		XMLNode* desc = new XMLNode (X_("description"));
+		XMLNode* desc_cont = new XMLNode (X_("content"), description);
 		desc->add_child_nocopy (*desc_cont);
 
 		root->add_child_nocopy (*desc);

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -2356,7 +2356,7 @@ Session::XMLSourceFactory (const XMLNode& node)
 }
 
 int
-Session::save_template (string template_name, bool replace_existing)
+Session::save_template (const string& template_name, const string& description, bool replace_existing)
 {
 	if ((_state_of_the_state & CannotSave) || template_name.empty ()) {
 		return -1;
@@ -2411,11 +2411,21 @@ Session::save_template (string template_name, bool replace_existing)
 	SessionSaveUnderway (); /* EMIT SIGNAL */
 
 	XMLTree tree;
-
+	XMLNode* root;
 	{
 		PBD::Unwinder<std::string> uw (_template_state_dir, template_dir_path);
-		tree.set_root (&get_template());
+		root = &get_template();
 	}
+
+	if (!description.empty()) {
+		XMLNode* desc = new XMLNode(X_("description"));
+		XMLNode* desc_cont = new XMLNode(X_("content"), description);
+		desc->add_child_nocopy (*desc_cont);
+
+		root->add_child_nocopy (*desc);
+	}
+
+	tree.set_root (root);
 
 	if (!tree.write (template_file_path)) {
 		error << _("template not saved") << endmsg;

--- a/libs/ardour/template_utils.cc
+++ b/libs/ardour/template_utils.cc
@@ -149,10 +149,17 @@ find_route_templates (vector<TemplateInfo>& template_names)
 
 		XMLNode* root = tree.root();
 
+		string description = "No Description";
+		XMLNode* desc = tree.root()->child ("description");
+		if (desc) {
+			description = desc->attribute_value ();
+		}
+
 		TemplateInfo rti;
 
 		rti.name = IO::name_from_state (*root->children().front());
 		rti.path = fullpath;
+		rti.description = description;
 
 		template_names.push_back (rti);
 	}

--- a/libs/ardour/template_utils.cc
+++ b/libs/ardour/template_utils.cc
@@ -106,13 +106,13 @@ find_session_templates (vector<TemplateInfo>& template_names, bool read_xml)
 				continue;
 			}
 
-			string created_with = "(unknown)";
+			string created_with = _("(unknown)");
 			XMLNode *pv = tree.root()->child("ProgramVersion");
 			if (pv != 0) {
 				pv->get_property (X_("created-with"), created_with);
 			}
 
-			string description = "No Description";
+			string description = _("No Description");
 			XMLNode *desc = tree.root()->child("description");
 			if (desc != 0) {
 				description = desc->attribute_value();
@@ -149,7 +149,7 @@ find_route_templates (vector<TemplateInfo>& template_names)
 
 		XMLNode* root = tree.root();
 
-		string description = "No Description";
+		string description = _("No Description");
 		XMLNode* desc = tree.root()->child ("description");
 		if (desc) {
 			description = desc->attribute_value ();

--- a/libs/ardour/template_utils.cc
+++ b/libs/ardour/template_utils.cc
@@ -111,19 +111,16 @@ find_session_templates (vector<TemplateInfo>& template_names, bool read_xml)
 			if (pv != 0) {
 				pv->get_property (X_("created-with"), created_with);
 			}
-			
+
 			string description = "No Description";
-			XMLNode *md = tree.root()->child("Metadata");
-			if (md != 0) {
-				XMLNode *desc = md->child("description");
-				if (desc != 0) {
-					description = desc->attribute_value();
-				}
+			XMLNode *desc = tree.root()->child("description");
+			if (desc != 0) {
+				description = desc->attribute_value();
 			}
-			
+
 			rti.created_with = created_with;
 			rti.description = description;
-			
+
 		}
 
 		template_names.push_back (rti);


### PR DESCRIPTION
This makes the recently introduced template descriptions savable in "Save As Template" and editable in the template manager.

Template descriptions are now stored in the top-level of the template XMLTree rather than in `<Metadata/>`. This avoids that template descriptions spill into tags in exported audio files.

When saving a track or session as template, the user is prompted to give a template description with the session description resp. the track comment as a default.

Trailing whitespace of the descriptions is silently stripped before saving.