### PR TITLE
Support region moving and resizing in list editor

### DIFF
--- a/gtk2_ardour/midi_list_editor.cc
+++ b/gtk2_ardour/midi_list_editor.cc
@@ -148,8 +148,10 @@ MidiListEditor::MidiListEditor (Session* s, boost::shared_ptr<MidiRegion> r, boo
 
 	redisplay_model ();
 
-	region->midi_source(0)->model()->ContentsChanged.connect (content_connection, invalidator (*this),
-								  boost::bind (&MidiListEditor::redisplay_model, this), gui_context());
+	region->midi_source(0)->model()->ContentsChanged.connect (content_connections, invalidator (*this),
+	                                                          boost::bind (&MidiListEditor::redisplay_model, this), gui_context());
+	region->RegionPropertyChanged.connect (content_connections, invalidator (*this),
+	                                       boost::bind (&MidiListEditor::redisplay_model, this), gui_context());
 
 	buttons.attach (sound_notes_button, 0, 1, 0, 1);
 	Glib::RefPtr<Gtk::Action> act = ActionManager::get_action ("Editor", "sound-midi-notes");

--- a/gtk2_ardour/midi_list_editor.h
+++ b/gtk2_ardour/midi_list_editor.h
@@ -100,7 +100,7 @@ private:
 	boost::shared_ptr<ARDOUR::MidiTrack>  track;
 
 	/** connection used to connect to model's ContentChanged signal */
-	PBD::ScopedConnection content_connection;
+	PBD::ScopedConnectionList content_connections;
 
 	void edited (const std::string&, const std::string&);
 	void editing_started (Gtk::CellEditable*, const std::string& path, int);


### PR DESCRIPTION
If the region is moved or resized the list editor gets refreshed accordingly.