### PR TITLE
Fix Beats::normalize

### DIFF
--- a/libs/evoral/evoral/Beats.hpp
+++ b/libs/evoral/evoral/Beats.hpp
@@ -38,30 +38,19 @@ public:
 
 	Beats() : _beats(0), _ticks(0) {}
 
-	/** Normalize so ticks is within PPQN. */
+	/** Normalize so ticks is within [0, PPQN). */
 	void normalize() {
-		// First, fix negative ticks with positive beats
-		if (_beats >= 0) {
-			while (_ticks < 0) {
-				--_beats;
-				_ticks += PPQN;
-			}
+		// Fix negative ticks
+		while (_ticks < 0) {
+			--_beats;
+			_ticks += PPQN;
 		}
-
-		// Work with positive beats and ticks to normalize
-		const int32_t sign  = _beats < 0 ? -1 : 1;
-		int32_t       beats = abs(_beats);
-		int32_t       ticks = abs(_ticks);
 
 		// Fix ticks greater than 1 beat
-		while (ticks >= PPQN) {
-			++beats;
-			ticks -= PPQN;
+		while (PPQN <= _ticks) {
+			++_beats;
+			_ticks -= PPQN;
 		}
-
-		// Set fields with appropriate sign
-		_beats = sign * beats;
-		_ticks = sign * ticks;
 	}
 
 	/** Create from a precise BT time. */


### PR DESCRIPTION
Unfortunately I don't how to demonstrate the bug other than by using the WIP pattern editor (aka tracker interface), but I think the issue may seem obvious by reviewing the code.

Basically the problem comes from

https://github.com/Ardour/ardour/blob/master/libs/evoral/evoral/Beats.hpp#L64

that also invert ticks based on _beats, leading to wrong Beats construction, such as
```
Beats(0, -100)
```
ending up having negative `_ticks`.

Hmm, maybe a unit test would be welcome, wouldn't it?