### PR TITLE
Nsm switch 

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -3586,10 +3586,6 @@ ARDOUR_UI::get_session_parameters (bool quit_on_cancel, bool should_be_new, stri
 				/* not connected to the AudioEngine, so quit to avoid an infinite loop */
 				exit (1);
 			}
-			
-			if (_nsm_switches && ret != 0 ) {
-				exit (1);
-			}
 
 			if (!ARDOUR_COMMAND_LINE::immediate_save.empty()) {
 				_session->save_state (ARDOUR_COMMAND_LINE::immediate_save, false);
@@ -3602,6 +3598,11 @@ ARDOUR_UI::get_session_parameters (bool quit_on_cancel, bool should_be_new, stri
 
 			ARDOUR_COMMAND_LINE::session_name = "";
 		}
+	}
+	
+	if (_nsm_switches && ret != 0 ) {
+			/*If there is an error at nsm open or switch, don't loop an error dialog, just quit. */
+			exit (1);
 	}
 
 	_nsm_switches = false;

--- a/gtk2_ardour/ardour_ui.h
+++ b/gtk2_ardour/ardour_ui.h
@@ -381,6 +381,7 @@ private:
 	Mixer_UI*      mixer;
 	Gtk::Tooltips _tooltips;
 	NSM_Client*    nsm;
+	bool          _nsm_switches;
 	bool          _was_dirty;
 	bool          _mixer_on_top;
 	bool          _initial_verbose_plugin_scan;

--- a/gtk2_ardour/ardour_ui_dialogs.cc
+++ b/gtk2_ardour/ardour_ui_dialogs.cc
@@ -264,7 +264,7 @@ ARDOUR_UI::unload_session (bool hide_stuff)
 		ARDOUR_UI::instance()->video_timeline->sync_session_state();
 	}
 
-	if (_session && _session->dirty()) {
+	if (_session && _session->dirty() && !_nsm_switches) {
 		std::vector<std::string> actions;
 		actions.push_back (_("Don't close"));
 		actions.push_back (_("Just close"));


### PR DESCRIPTION
NSM switch implementation which allows NSM to switch directly from a session to another one without closing and re-launching Ardour.

For better NSM experience, I also change behaviour of  folder argument, it now prefer the last snapshot to the default snapshot (I mean, this is a bug which appends too whit launching ardour6 mysessionfolder).

The main thing to do was to prevent "save or not" dialogs  and any saves during switch (ardour becomes dirty as a JACK port appears or disapears, so we prefer not save after switch order).