### PR TITLE
Ignore the grid mode for finding the snaped sample

### DIFF
--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -7057,7 +7057,7 @@ Editor::snap_regions_to_grid ()
 		(*r)->region()->clear_changes ();
 
 		MusicSample start ((*r)->region()->first_sample (), 0);
-		snap_to (start);
+		snap_to (start, ARDOUR::RoundNearest, false, true);
 		(*r)->region()->set_position (start.sample, start.division);
 		_session->add_command(new StatefulDiffCommand ((*r)->region()));
 	}


### PR DESCRIPTION
Since the function "snap_regions_to_grid" is only called by user. This has to ignore if grid is on/off/magnetic .