### PR TITLE
Fix error when $PATH contains whitespaces

### DIFF
--- a/tools/linux_packaging/build
+++ b/tools/linux_packaging/build
@@ -252,7 +252,7 @@ fi
 # jack in the places where it might be
 #
 
-echo export 'PATH=/usr/local/bin:/opt/bin:$PATH' >> $ENVIRONMENT
+echo export 'PATH="/usr/local/bin:/opt/bin:$PATH"' >> $ENVIRONMENT
 
 # create startup helper script
 if test -d $BUILD_ROOT/vst; then


### PR DESCRIPTION
Previously, if $PATH contains whitespaces the startup script would split
the new exported $PATH on the first whitespace. This was observed on an
Ubuntu system where $PATH contained a directory with whitespaces.

The change adds weak quotation around the new path to prevent expansion
of whitespaces. $PATH though, is still expanded.