### PR TITLE
install_video_tools.sh: Use https instead of http

### DIFF
--- a/tools/videotimeline/install_video_tools.sh
+++ b/tools/videotimeline/install_video_tools.sh
@@ -130,16 +130,16 @@ done
 echo "installing video-tools to '${TARGETDIR}'."
 cd "$TARGETDIR" || exit 1
 
-HARVID_VERSION=$(curl -s http://ardour.org/files/video-tools/harvid_version.txt)
+HARVID_VERSION=$(curl -s https://ardour.org/files/video-tools/harvid_version.txt)
 echo "Downloading harvid-${MULTIARCH}-${HARVID_VERSION}."
 curl -L --progress-bar \
-	http://ardour.org/files/video-tools/harvid-${MULTIARCH}-${HARVID_VERSION}.tgz \
+	https://ardour.org/files/video-tools/harvid-${MULTIARCH}-${HARVID_VERSION}.tgz \
 	| tar -x -z --exclude=README --exclude=harvid.1 --strip-components=1 || exit 1
 
-XJADEO_VERSION=$(curl -s http://ardour.org/files/video-tools/xjadeo_version.txt)
+XJADEO_VERSION=$(curl -s https://ardour.org/files/video-tools/xjadeo_version.txt)
 echo "Downloading xjadeo-${MULTIARCH}-${XJADEO_VERSION}."
 curl -L --progress-bar \
-	http://ardour.org/files/video-tools/xjadeo-${MULTIARCH}-${XJADEO_VERSION}.tgz \
+	https://ardour.org/files/video-tools/xjadeo-${MULTIARCH}-${XJADEO_VERSION}.tgz \
 	| tar -x -z --exclude=README --exclude=xjadeo.1 --strip-components=1 || exit 1
 mv xjadeo xjremote
 


### PR DESCRIPTION
Downloading executables over plain http opens a very wide attack surface on the user's machine, so https should always be used instead.