### PR TITLE
generic_midi: add proper handling of midi controll toggles

### DIFF
--- a/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
+++ b/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
@@ -813,6 +813,7 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 	MIDI::eventType ev;
 	int intval;
 	bool momentary;
+	MIDIControllable::CtlType ctltype;
 	MIDIControllable::Encoder encoder = MIDIControllable::No_enc;
 	bool rpn_value = false;
 	bool nrpn_value = false;
@@ -820,6 +821,10 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 	bool nrpn_change = false;
 
 	if ((prop = node.property (X_("ctl"))) != 0) {
+		ctltype = MIDIControllable::Ctl_Momentary;
+		ev = MIDI::controller;
+	} else if ((prop = node.property (X_("ctl-toggle"))) !=0) {
+		ctltype = MIDIControllable::Ctl_Toggle;
 		ev = MIDI::controller;
 	} else if ((prop = node.property (X_("note"))) != 0) {
 		ev = MIDI::on;
@@ -895,6 +900,7 @@ GenericMidiControlProtocol::create_binding (const XMLNode& node)
 	} else if (nrpn_change) {
 		mc->bind_nrpn_change (channel, detail);
 	} else {
+		mc->set_ctltype (ctltype);
 		mc->set_encoder (encoder);
 		mc->bind_midi (channel, ev, detail);
 	}

--- a/libs/surfaces/generic_midi/midicontrollable.cc
+++ b/libs/surfaces/generic_midi/midicontrollable.cc
@@ -54,6 +54,7 @@ MIDIControllable::MIDIControllable (GenericMidiControlProtocol* s, MIDI::Parser&
 	, _momentary (m)
 {
 	_learned = false; /* from URI */
+	_ctltype = Ctl_Momentary;
 	_encoder = No_enc;
 	setting = false;
 	last_value = 0; // got a better idea ?
@@ -74,6 +75,7 @@ MIDIControllable::MIDIControllable (GenericMidiControlProtocol* s, MIDI::Parser&
 	set_controllable (&c);
 
 	_learned = true; /* from controllable */
+	_ctltype = Ctl_Momentary;
 	_encoder = No_enc;
 	setting = false;
 	last_value = 0; // got a better idea ?
@@ -392,10 +394,18 @@ MIDIControllable::midi_sense_controller (Parser &, EventTwoBytes *msg)
 			 * (0x40). It is hard to imagine why anyone would make
 			 * a MIDI controller button that sent 0x0 when pressed.
 			 */
-
 			if (msg->value >= 0x40) {
 				controllable->set_value (controllable->get_value() >= 0.5 ? 0.0 : 1.0, Controllable::UseGroup);
 				DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("Midi CC %1 value 1  %2\n", (int) msg->controller_number, current_uri()));
+			} else {
+				switch (get_ctltype()) {
+					case Ctl_Momentary:
+						break;
+					case Ctl_Toggle:
+						controllable->set_value (0.0, Controllable::NoGroup);
+						DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("Midi CC %1 value 0  %2\n", (int) msg->controller_number, current_uri()));
+						break;
+				}
 			}
 		}
 

--- a/libs/surfaces/generic_midi/midicontrollable.h
+++ b/libs/surfaces/generic_midi/midicontrollable.h
@@ -59,6 +59,11 @@ class MIDIControllable : public PBD::Stateful
 	uint32_t rid() const { return _rid; }
 	std::string what() const { return _what; }
 
+	enum CtlType {
+		Ctl_Momentary,
+		Ctl_Toggle,
+	};
+
 	enum Encoder {
 		No_enc,
 		Enc_R,
@@ -79,6 +84,9 @@ class MIDIControllable : public PBD::Stateful
 	float midi_to_control(int val);
 
 	bool learned() const { return _learned; }
+
+	CtlType get_ctltype() const { return _ctltype; }
+	void set_ctltype (CtlType val) { _ctltype = val; }
 
 	Encoder get_encoder() const { return _encoder; }
 	void set_encoder (Encoder val) { _encoder = val; }
@@ -122,6 +130,7 @@ class MIDIControllable : public PBD::Stateful
 	bool            _momentary;
 	bool            _is_gain_controller;
 	bool            _learned;
+	CtlType         _ctltype;
 	Encoder			_encoder;
 	int              midi_msg_id;      /* controller ID or note number */
 	PBD::ScopedConnection midi_sense_connection[2];


### PR DESCRIPTION
as discussed on irc, this is the patch set to handle controller knobs that send "toggle" instead of momentary.