### PR TITLE
Issue 7549 Duplicate Track Order

### DIFF
--- a/gtk2_ardour/duplicate_routes_dialog.h
+++ b/gtk2_ardour/duplicate_routes_dialog.h
@@ -45,6 +45,9 @@ public:
 
 	int restart (ARDOUR::Session*);
 
+protected:
+	 void get_ordered_selected_route_list(ARDOUR::RouteList&);
+
 private:
 	Gtk::Entry name_template_entry;
 	Gtk::VBox playlist_button_box;


### PR DESCRIPTION
Problem: http://tracker.ardour.org/view.php?id=7549

The duplicated Routes are now ordered like in the UI. 
Previous they were ordered in the order of their selection. 

