### PR TITLE
Update blueberry_milk-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -115,12 +115,12 @@
     <Color name="meter color7" value="0xff8700ff"/>
     <Color name="meter color8" value="0xff0000ff"/>
     <Color name="meter color9" value="0xff0000ff"/>
-    <Color name="midi color0" value="0x1e7727ff"/>
-    <Color name="midi color1" value="0x52af25ff"/>
-    <Color name="midi color2" value="0x85e524ff"/>
-    <Color name="midi color3" value="0xcbba0fff"/>
-    <Color name="midi color4" value="0xe2ab09ff"/>
-    <Color name="midi color5" value="0xff9900ff"/>
+    <Color name="midi color0" value="0x7f4b47ff"/>
+    <Color name="midi color1" value="0x694a89ff"/>
+    <Color name="midi color2" value="0x855ce9ff"/>
+    <Color name="midi color3" value="0x507af3ff"/>
+    <Color name="midi color4" value="0x1d94feff"/>
+    <Color name="midi color5" value="0x00ffffff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="color 1"/>
@@ -283,7 +283,7 @@
     <ColorAlias name="midi meter color8" alias="midi color4"/>
     <ColorAlias name="midi meter color9" alias="midi color5"/>
     <ColorAlias name="midi note inactive channel" alias="color 4"/>
-    <ColorAlias name="midi note selected outline" alias="color 67"/>
+    <ColorAlias name="midi note selected outline" alias="color 17"/>
     <ColorAlias name="midi note velocity text" alias="color 32"/>
     <ColorAlias name="midi patch change fill" alias="color 60"/>
     <ColorAlias name="midi patch change outline" alias="color 26"/>


### PR DESCRIPTION
![blueberry_milk_correction_150718](https://user-images.githubusercontent.com/19673308/42737883-61c2a1d4-887a-11e8-8148-67c412ba878c.png)
Hello Paul & people! Good day to everybody:)
I've got three questions:
1.This is my attempt to change a theme file as an example. If this my example PR is correct and good from your vision, may I make the same to others (cainville, clear-gray & cubasish - illustrations are already prepared :))?
2. Are you planning to add an item 'midi note selected fill', because only the outline of the selected notes are not so visible as it was in ardour 5.x (at my view)? Or may be the outline could be more thick?
3. Is it the right place to edit the ardour6's theme files (I mean the thread or folder or how it's correctly called here in 'github')?

_Specifically to Blueberry-milk:_
This commit changes all the default midi colors (0-5) to the specific design of the theme. Also the default dark color of the selected midi note outline is changing to the bright green color (more visible and matchs to design).

Big thanks!

