### PR TITLE
Update caineville-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -114,12 +114,12 @@
     <Color name="meter color7" value="0xff8800ff"/>
     <Color name="meter color8" value="0xff0000ff"/>
     <Color name="meter color9" value="0xff0000ff"/>
-    <Color name="midi color0" value="0x1e7727ff"/>
-    <Color name="midi color1" value="0x52af25ff"/>
-    <Color name="midi color2" value="0x85e524ff"/>
-    <Color name="midi color3" value="0xcbba0fff"/>
-    <Color name="midi color4" value="0xe2ab09ff"/>
-    <Color name="midi color5" value="0xff9900ff"/>
+    <Color name="midi color0" value="0xfcffabff"/>
+    <Color name="midi color1" value="0xffec9aff"/>
+    <Color name="midi color2" value="0xffce64ff"/>
+    <Color name="midi color3" value="0xd98d0fff"/>
+    <Color name="midi color4" value="0xef5e08ff"/>
+    <Color name="midi color5" value="0xff0000ff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="color 1"/>
@@ -283,7 +283,7 @@
     <ColorAlias name="midi meter color8" alias="midi color4"/>
     <ColorAlias name="midi meter color9" alias="midi color5"/>
     <ColorAlias name="midi note inactive channel" alias="color 4"/>
-    <ColorAlias name="midi note selected outline" alias="color 67"/>
+    <ColorAlias name="midi note selected outline" alias="color 13"/>
     <ColorAlias name="midi note velocity text" alias="color 32"/>
     <ColorAlias name="midi patch change fill" alias="color 60"/>
     <ColorAlias name="midi patch change outline" alias="color 26"/>


### PR DESCRIPTION
![caineville_correction_150718](https://user-images.githubusercontent.com/19673308/42758472-f2962f80-8903-11e8-97f1-ed4a86adb472.png)
This commit changes all the default midi colors (0-5) to the specific design of the theme. Also the default dark color of the selected midi note outline is changing to the white color (more visible and matchs to design).