### PR TITLE
Update clear_gray-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -114,12 +114,12 @@
     <Color name="meter color7" value="0xff8800ff"/>
     <Color name="meter color8" value="0xff0000ff"/>
     <Color name="meter color9" value="0xff0000ff"/>
-    <Color name="midi color0" value="0x1e7727ff"/>
-    <Color name="midi color1" value="0x52af25ff"/>
-    <Color name="midi color2" value="0x85e524ff"/>
-    <Color name="midi color3" value="0xcbba0fff"/>
-    <Color name="midi color4" value="0xe2ab09ff"/>
-    <Color name="midi color5" value="0xff9900ff"/>
+    <Color name="midi color0" value="0x383838ff"/>
+    <Color name="midi color1" value="0x7b7b7bff"/>
+    <Color name="midi color2" value="0xabababff"/>
+    <Color name="midi color3" value="0xc6c6c6ff"/>
+    <Color name="midi color4" value="0xd7d7d7ff"/>
+    <Color name="midi color5" value="0xffffffff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="color 1"/>
@@ -283,7 +283,7 @@
     <ColorAlias name="midi meter color8" alias="midi color4"/>
     <ColorAlias name="midi meter color9" alias="midi color5"/>
     <ColorAlias name="midi note inactive channel" alias="color 4"/>
-    <ColorAlias name="midi note selected outline" alias="color 67"/>
+    <ColorAlias name="midi note selected outline" alias="color 19"/>
     <ColorAlias name="midi note velocity text" alias="color 13"/>
     <ColorAlias name="midi patch change fill" alias="color 60"/>
     <ColorAlias name="midi patch change outline" alias="color 26"/>


### PR DESCRIPTION
![clear_gray_correction_150718](https://user-images.githubusercontent.com/19673308/42759122-247b3d4a-8906-11e8-9516-0b9f0fe02aeb.png)
This commit changes all the default midi colors (0-5) to the specific design of the theme. Also the default dark color of the selected midi note outline is changing to the red color (more visible and matchs to design).