### PR TITLE
Update cubasish-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -114,12 +114,12 @@
     <Color name="meter color7" value="0xff8800ff"/>
     <Color name="meter color8" value="0xff0000ff"/>
     <Color name="meter color9" value="0xff0000ff"/>
-    <Color name="midi color0" value="0x1e7727ff"/>
-    <Color name="midi color1" value="0x52af25ff"/>
-    <Color name="midi color2" value="0x85e524ff"/>
-    <Color name="midi color3" value="0xcbba0fff"/>
-    <Color name="midi color4" value="0xe2ab09ff"/>
-    <Color name="midi color5" value="0xff9900ff"/>
+    <Color name="midi color0" value="0x132eb4ff"/>
+    <Color name="midi color1" value="0x5637d1ff"/>
+    <Color name="midi color2" value="0x8924e5ff"/>
+    <Color name="midi color3" value="0xc30fcbff"/>
+    <Color name="midi color4" value="0xe20986ff"/>
+    <Color name="midi color5" value="0xff002dff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="color 1"/>
@@ -282,9 +282,8 @@
     <ColorAlias name="midi meter color7" alias="midi color4"/>
     <ColorAlias name="midi meter color8" alias="midi color4"/>
     <ColorAlias name="midi meter color9" alias="midi color5"/>
-    <ColorAlias name="midi meter color9" alias="meter color3"/>
     <ColorAlias name="midi note inactive channel" alias="color 4"/>
-    <ColorAlias name="midi note selected outline" alias="color 67"/>
+    <ColorAlias name="midi note selected outline" alias="color 9"/>
     <ColorAlias name="midi note velocity text" alias="color 32"/>
     <ColorAlias name="midi patch change fill" alias="color 60"/>
     <ColorAlias name="midi patch change outline" alias="color 26"/>


### PR DESCRIPTION
![cubasish_correction_150718](https://user-images.githubusercontent.com/19673308/42760032-4728136a-8909-11e8-9cb5-b94166703481.png)
This commit changes all the default midi colors (0-5) to the specific design of the theme.

The 'midi color5' was not used by ardour, because there was a supernumerary string (285), which enforces ardour to use the wrong color ('meter color 3') - so the string285 was deleted.

 Also the default dark color of the selected midi note outline is changing to the white color (more visible and matchs to design).
