### PR TITLE
Let VST plugins know that we implement plugin window resizing.

### DIFF
--- a/libs/ardour/session_vst.cc
+++ b/libs/ardour/session_vst.cc
@@ -50,7 +50,8 @@ const char* Session::vst_can_do_strings[] = {
 	X_("receiveVstMidiEvent"),
 	X_("supportShell"),
 	X_("shellCategory"),
-	X_("shellCategorycurID")
+	X_("shellCategorycurID"),
+	X_("sizeWindow")
 };
 const int Session::vst_can_do_string_count = sizeof (vst_can_do_strings) / sizeof (char*);
 
@@ -346,7 +347,7 @@ intptr_t Session::vst_callback (
 				plug->VSTSizeWindow (); /* EMIT SIGNAL */
 			}
 		}
-		return 0;
+		return 1;
 
 	case audioMasterGetSampleRate:
 		SHOW_CALLBACK ("audioMasterGetSampleRate");


### PR DESCRIPTION
On windows, the SpectMorph VST uses this code if the user changes the zoom level, which in turn requires resizing the plugin window:

```
int rc = plugin->audioMaster (plugin->aeffect, audioMasterSizeWindow, width, height, 0, 0);
if (rc == 0)
  vst_manual_resize (widget, width, height);
```

So the idea is to let the host do the resizing, and if that didn't work, resize the window ourselves (with platform specific API). Almost all hosts I tested support window resizing and return 1 here.

However Ardour returns 0, although it supports resizing the plugin window, which causes problems for SpectMorph because we also execute the fallback code, which doesn't work well if the host also messes with the window size.

To summarize: since Ardour supports resizing the plugin window, it should return 1 (like other hosts that support changing the window size) and probably also declare "sizeWindow" as host can do string.