### PR TITLE
Add pick-up mode and use it for knobs and faders

### DIFF
--- a/libs/surfaces/launch_control_xl/launch_control_xl.cc
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.cc
@@ -444,6 +444,13 @@ LaunchControlXL::handle_button_message(Button* button, MIDI::EventTwoBytes* ev)
   }
 }
 
+bool
+LaunchControlXL::check_pick_up(Controller* controller, boost::shared_ptr<AutomationControl> ac)
+{
+	/* returns false until the controller value matches with the current setting of the stripable's ac */
+	return ( abs( controller->value() / 127.0 -  ac->internal_to_interface(ac->get_value()) ) < 0.007875 );
+}
+
 void
 LaunchControlXL::handle_knob_message (Knob* knob)
 {
@@ -462,7 +469,7 @@ LaunchControlXL::handle_knob_message (Knob* knob)
 		ac = stripable[chan]->pan_azimuth_control();
 	}
 
-	if (ac) {
+	if (ac && check_pick_up(knob, ac)) {
 		ac->set_value ( ac->interface_to_internal( knob->value() / 127.0), PBD::Controllable::UseGroup );
 	}
 }
@@ -476,7 +483,7 @@ LaunchControlXL::handle_fader_message (Fader* fader)
 	}
 
 	boost::shared_ptr<AutomationControl> ac = stripable[fader->id()]->gain_control();
-	if (ac) {
+	if (ac && check_pick_up(fader, ac)) {
 		ac->set_value ( ac->interface_to_internal( fader->value() / 127.0), PBD::Controllable::UseGroup );
 	}
 }

--- a/libs/surfaces/launch_control_xl/launch_control_xl.h
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.h
@@ -429,6 +429,8 @@ private:
 	void handle_fader_message(Fader* fader);
 	void handle_knob_message(Knob* knob);
 
+	bool check_pick_up(Controller* controller, boost::shared_ptr<ARDOUR::AutomationControl> ac);
+
 	void handle_midi_controller_message(MIDI::Parser &, MIDI::EventTwoBytes *, MIDI::channel_t chan);
 	void handle_midi_note_on_message(MIDI::Parser &, MIDI::EventTwoBytes *, MIDI::channel_t chan);
 	void handle_midi_note_off_message(MIDI::Parser &, MIDI::EventTwoBytes *, MIDI::channel_t chan);


### PR DESCRIPTION
The pick up mode ignores new controller values until they match with the current setting of the stripable's ac