### PR TITLE
LCXL: implement mute, solo and record arm toggles

### DIFF
--- a/libs/surfaces/launch_control_xl/controllers.cc
+++ b/libs/surfaces/launch_control_xl/controllers.cc
@@ -451,6 +451,36 @@ LaunchControlXL::button_device_long_press()
 
 }
 
+void
+LaunchControlXL::button_mute()
+{
+	if (buttons_down.find(Device) != buttons_down.end()) {
+		access_action ("Editor/track-mute-toggle");
+	} else {
+		button_track_mode(TrackMute);
+	}
+}
+
+void
+LaunchControlXL::button_solo()
+{
+	if (buttons_down.find(Device) != buttons_down.end()) {
+		access_action ("Editor/track-solo-toggle");
+	} else {
+		button_track_mode(TrackSolo);
+	}
+}
+
+void
+LaunchControlXL::button_record()
+{
+	if (buttons_down.find(Device) != buttons_down.end()) {
+		access_action ("Editor/track-record-enable-toggle");
+	} else {
+		button_track_mode(TrackRecord);
+	}
+}
+
 bool
 LaunchControlXL::button_long_press_timeout (ButtonID id, Button* button)
 {

--- a/libs/surfaces/launch_control_xl/launch_control_xl.h
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.h
@@ -455,9 +455,9 @@ private:
 	void button_device();
 	void button_device_long_press();
 	void button_track_mode(TrackMode state);
-	void button_mute() { button_track_mode(TrackMute); }
-	void button_solo() { button_track_mode(TrackSolo); }
-	void button_record() { button_track_mode(TrackRecord); }
+	void button_mute();
+	void button_solo();
+	void button_record();
 	void button_select_up();
 	void button_select_down();
 	void button_select_left();


### PR DESCRIPTION
    Holding the Device button and pressing one
    of mute, solo and record arm will toggle
    selected tracks (use Track Focus buttons)
    accordingly.