### PR TITLE
LCXL: Add configuration option for handling master

### DIFF
--- a/libs/surfaces/launch_control_xl/gui.cc
+++ b/libs/surfaces/launch_control_xl/gui.cc
@@ -32,6 +32,7 @@
 #include "ardour/audioengine.h"
 #include "ardour/filesystem_paths.h"
 #include "ardour/parameter_descriptor.h"
+#include "ardour/debug.h"
 
 #include "launch_control_xl.h"
 #include "gui.h"
@@ -101,6 +102,7 @@ LCXLGUI::LCXLGUI (LaunchControlXL& p)
 	}
 
 	Gtk::Label* l;
+	Gtk::Alignment* align;
 	int row = 0;
 
 	input_combo.pack_start (midi_port_columns.short_name);
@@ -121,6 +123,20 @@ LCXLGUI::LCXLGUI (LaunchControlXL& p)
 	l->set_alignment (1.0, 0.5);
 	table.attach (*l, 0, 1, row, row+1, AttachOptions(FILL|EXPAND), AttachOptions(0));
 	table.attach (output_combo, 1, 2, row, row+1, AttachOptions(FILL|EXPAND), AttachOptions(0), 0, 0);
+	row++;
+
+	/* User Settings */
+
+	fader8master_button.signal_clicked().connect (sigc::mem_fun (*this, &LCXLGUI::toggle_fader8master));
+
+	l = manage (new Gtk::Label (_("Fader 8 Master")));
+	l->set_alignment (1.0, 0.5);
+	table.attach (*l, 0, 1, row, row+1, AttachOptions(FILL|EXPAND), AttachOptions (0));
+	align = manage (new Alignment);
+	align->set (0.0, 0.5);
+	align->add (fader8master_button);
+	table.attach (*align, 1, 2, row, row+1, AttachOptions(FILL|EXPAND), AttachOptions (0),0,0);
+	fader8master_button.set_active(lcxl.use_fader8master);
 	row++;
 
 	hpacker.pack_start (table, true, true);
@@ -265,4 +281,13 @@ LCXLGUI::active_port_changed (Gtk::ComboBox* combo, bool for_input)
 			lcxl.output_port()->connect (new_port);
 		}
 	}
+}
+
+void
+LCXLGUI::toggle_fader8master ()
+{
+	DEBUG_TRACE(DEBUG::LaunchControlXL, string_compose("use_fader8master WAS: %1\n", lcxl.use_fader8master));
+	lcxl.use_fader8master = !(lcxl.use_fader8master);
+	DEBUG_TRACE(DEBUG::LaunchControlXL, string_compose("use_fader8master IS: %1\n", lcxl.use_fader8master));
+	lcxl.set_fader8master(lcxl.use_fader8master);
 }

--- a/libs/surfaces/launch_control_xl/gui.h
+++ b/libs/surfaces/launch_control_xl/gui.h
@@ -49,6 +49,8 @@ public:
 	LCXLGUI (LaunchControlXL&);
 	~LCXLGUI ();
 
+	void toggle_fader8master ();
+
 private:
 	LaunchControlXL& lcxl;
 	PBD::ScopedConnectionList lcxl_connections;
@@ -58,6 +60,7 @@ private:
 	Gtk::ComboBox input_combo;
 	Gtk::ComboBox output_combo;
 	Gtk::Image    image;
+	Gtk::CheckButton fader8master_button;
 
 	void update_port_combos ();
 	PBD::ScopedConnection connection_change_connection;

--- a/libs/surfaces/launch_control_xl/launch_control_xl.cc
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.cc
@@ -81,9 +81,6 @@ LaunchControlXL::LaunchControlXL (ARDOUR::Session& s)
 
 	/* master cannot be removed, so no need to connect to going-away signal */
 	master = session->master_out ();
-	/* the master bus will always be on the last channel on the lcxl */
-	stripable[7] = master;
-
 
 	run_event_loop ();
 
@@ -104,6 +101,8 @@ LaunchControlXL::LaunchControlXL (ARDOUR::Session& s)
 	session->vca_manager().VCAAdded.connect (session_connections, MISSING_INVALIDATOR, boost::bind (&LaunchControlXL::stripables_added, this), lcxl);
 
 	switch_bank (bank_start);
+
+	set_fader8master(use_fader8master);
 }
 
 LaunchControlXL::~LaunchControlXL ()
@@ -833,8 +832,15 @@ LaunchControlXL::switch_bank (uint32_t base)
 
 	boost::shared_ptr<Stripable> s[8];
 	uint32_t different = 0;
+	int stripable_counter;
 
-	for (int n = 0; n < 7; ++n) {
+	if (LaunchControlXL::use_fader8master) {
+		stripable_counter = 7;
+	} else {
+		stripable_counter = 8;
+	}
+
+	for (int n = 0; n < stripable_counter; ++n) {
 		s[n] = session->get_remote_nth_stripable (base+n, PresentationInfo::Flag (PresentationInfo::Route|PresentationInfo::VCA));
 		if (s[n] != stripable[n]) {
 			different++;
@@ -853,7 +859,7 @@ LaunchControlXL::switch_bank (uint32_t base)
 
 	stripable_connections.drop_connections ();
 
-	for (int n = 0; n < 7; ++n) {
+	for (int n = 0; n < stripable_counter; ++n) {
 		stripable[n] = s[n];
 	}
 
@@ -905,4 +911,13 @@ void LaunchControlXL::set_track_mode (TrackMode mode) {
 	default:
 		break;
 	}
+}
+
+void
+LaunchControlXL::set_fader8master (bool yn)
+{
+	if (yn) {
+		stripable[7] = master;
+	}
+	switch_bank(bank_start);
 }

--- a/libs/surfaces/launch_control_xl/launch_control_xl.h
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.h
@@ -335,6 +335,8 @@ public:
 	void *get_gui() const;
 	void tear_down_gui();
 
+	bool use_fader8master = false;
+
 	int set_active(bool yn);
 	XMLNode &get_state();
 	int set_state(const XMLNode &node, int version);
@@ -352,6 +354,7 @@ public:
 
 	void write(const MidiByteArray &);
 	void reset(uint8_t chan);
+	void set_fader8master (bool yn);
 
 	TrackMode track_mode() const { return _track_mode; }
 	void set_track_mode(TrackMode mode);


### PR DESCRIPTION
    In the Controller's settings you can now
    choose between two operation modes:
    1)  8 track mode
    2)  7 track plus master mode

    In case 2) fader 8 is fixed on the master