### PR TITLE
Mackie protocol fixes

### DIFF
--- a/libs/surfaces/mackie/mackie_control_protocol.cc
+++ b/libs/surfaces/mackie/mackie_control_protocol.cc
@@ -218,7 +218,7 @@ void
 MackieControlProtocol::next_track()
 {
 	Sorted sorted = get_sorted_stripables();
-	if (_current_initial_bank + n_strips() < sorted.size()) {
+	if (_current_initial_bank + 1 < sorted.size()) {
 		switch_banks (_current_initial_bank + 1);
 	}
 }

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -120,7 +120,7 @@ MackieControlProtocol::left_press (Button &)
 LedState
 MackieControlProtocol::left_release (Button &)
 {
-	return none;
+	return off;
 }
 
 LedState
@@ -144,13 +144,13 @@ MackieControlProtocol::right_press (Button &)
 		(void) switch_banks (new_initial);
 	}
 
-	return none;
+	return on;
 }
 
 LedState
 MackieControlProtocol::right_release (Button &)
 {
-	return none;
+	return off;
 }
 
 LedState

--- a/libs/surfaces/mackie/surface.cc
+++ b/libs/surfaces/mackie/surface.cc
@@ -1138,7 +1138,7 @@ Surface::update_view_mode_display (bool with_helpful_text)
 	if (id >= 0) {
 
 		for (vector<int>::iterator i = view_mode_buttons.begin(); i != view_mode_buttons.end(); ++i) {
-			map<int,Control*>::iterator x = controls_by_device_independent_id.find (id);
+			map<int,Control*>::iterator x = controls_by_device_independent_id.find (*i);
 
 			if (x != controls_by_device_independent_id.end()) {
 				Button* button = dynamic_cast<Button*> (x->second);


### PR DESCRIPTION
Both changes are utterly trivial, but they solve two nagging issues with the MCP interface for me, so I hope that they can be merged at some point (also if there ever is another 5.x bugfix release before Ardour 6 officially comes out). I'm using these with the 5.12 release, but as far as I can tell, this part hasn't changed since, and Paul's article on Ardour 6 development doesn't mention any planned changes there either.

The first commit just fixes up the broken feedback for the bank left/right buttons, and should hopefully be uncontroversial.

The second commit is probably a bit more problematic, so let me elaborate. ;-)

Ardour places a restriction on channel-right, it will only move the bank to the right one channel if there's still a full bank there. This has been there for a very long time, and probably for a good reason. But I'm using a single-strip device, the [X-Touch ONE](http://www.musictribe.com/Categories/Behringer/Computer-Audio/Desktop-Controllers/X-TOUCH-ONE/p/P0CAP), together with other MCP-compatible devices such as the nanoKONTROL2 or a full-size X-Touch, which are both connected to Ardour's Mackie port at the same time. Which works great, except that I can't access all strips with the X-Touch ONE with a bank size of 8. Just changing the device description to a bank size of 1 works, but is impossible if I want to use an 8-strip device along with it. Also, being able to flip through a large number of strips more quickly with the bank controls is just *so* convenient even if using just the single-strip device on its own.

This wouldn't be much of an issue if Ardour would allow different MCP devices to be connected at the same time, each with their own device device description, but that isn't possible right now, and I'd consider this overkill (and confusing) anyway. I'd say that the present Mackie interface works just fine as it is except for this single issue. So the easiest way to get single-strip devices working with a >1 bank size is to simply relax the condition on the initial bank number in `MackieControlProtocol::next_track()`, which is what I've done here.