### PR TITLE
Add plugin version and parameter count to VST user presets

### DIFF
--- a/libs/ardour/ardour/vestige/vestige.h
+++ b/libs/ardour/ardour/vestige/vestige.h
@@ -308,8 +308,8 @@ struct _AEffect
 	void *user;
 	// Id 48-4b
 	int32_t uniqueID;
-	// Don't know 4c-4f
-	char unknown1[4];
+	// Version 4c-4f
+	int32_t version;
 	// processReplacing 50-53
 	void (* processReplacing) (struct _AEffect *, float **, float **, int);
 };

--- a/libs/ardour/ardour/vst_plugin.h
+++ b/libs/ardour/ardour/vst_plugin.h
@@ -81,8 +81,9 @@ public:
 	const char * label () const;
 	const char * name () const;
 	const char * maker () const;
+	int32_t version () const;
 	uint32_t parameter_count () const;
-        void print_parameter (uint32_t, char*, uint32_t len) const;
+	void print_parameter (uint32_t, char*, uint32_t len) const;
 
 	bool has_editor () const;
 

--- a/libs/ardour/vst_plugin.cc
+++ b/libs/ardour/vst_plugin.cc
@@ -540,8 +540,6 @@ VSTPlugin::do_save_preset (string name)
 	sha1_result_hash (&s, hash);
 
 	string const uri = string_compose (X_("VST:%1:x%2"), unique_id (), hash);
-	string const str_ver = std::to_string (version ());
-	string const num_params = std::to_string (parameter_count ());
 
 	if (_plugin->flags & 32 /* effFlagsProgramsChunks */) {
 		p = new XMLNode (X_("ChunkPreset"));
@@ -550,9 +548,9 @@ VSTPlugin::do_save_preset (string name)
 	}
 
 	p->set_property (X_("uri"), uri);
-	p->set_property (X_("version"), str_ver);
+	p->set_property (X_("version"), version ());
 	p->set_property (X_("label"), name);
-	p->set_property (X_("numParams"), num_params);
+	p->set_property (X_("numParams"), parameter_count ());
 
 	if (_plugin->flags & 32) {
 

--- a/libs/ardour/vst_plugin.cc
+++ b/libs/ardour/vst_plugin.cc
@@ -540,21 +540,27 @@ VSTPlugin::do_save_preset (string name)
 	sha1_result_hash (&s, hash);
 
 	string const uri = string_compose (X_("VST:%1:x%2"), unique_id (), hash);
+	string const str_ver = std::to_string (version ());
+	string const num_params = std::to_string (parameter_count ());
 
 	if (_plugin->flags & 32 /* effFlagsProgramsChunks */) {
-
 		p = new XMLNode (X_("ChunkPreset"));
-		p->set_property (X_("uri"), uri);
-		p->set_property (X_("label"), name);
+	} else {
+		p = new XMLNode (X_("Preset"));
+	}
+
+	p->set_property (X_("uri"), uri);
+	p->set_property (X_("version"), str_ver);
+	p->set_property (X_("label"), name);
+	p->set_property (X_("numParams"), num_params);
+
+	if (_plugin->flags & 32) {
+
 		gchar* data = get_chunk (true);
 		p->add_content (string (data));
 		g_free (data);
 
 	} else {
-
-		p = new XMLNode (X_("Preset"));
-		p->set_property (X_("uri"), uri);
-		p->set_property (X_("label"), name);
 
 		for (uint32_t i = 0; i < parameter_count(); ++i) {
 			if (parameter_is_input (i)) {
@@ -759,6 +765,12 @@ const char *
 VSTPlugin::label () const
 {
 	return _handle->name;
+}
+
+int32_t
+VSTPlugin::version () const
+{
+	return _plugin->version;
 }
 
 uint32_t


### PR DESCRIPTION
# Background

While writing a [converter](https://github.com/SpotlightKid/ardour2fxp) for ardour VST user presets to FXP files, I noticed that the XML files, which Ardour writes are missing two crucial pieces of information about a preset resp. the plugin the preset belongs to:

* the plugin version.
* the number of parameters the plugin has.

These two fields are part of the binary structure of FXP preset files, which other VST hosts generally read, as can be seen by the definition of the `fxProgram` struct in the `pluginterfaces/vst2.x/vstfxstore.h` header of the VST SDK.

The plugin version is important when a preset of an earlier plugin version is loaded in a session with an instance of the plugin in a newer version. Some DAWs give a warning then or refuse to load the preset. Ardour, since it doesn't write any plugin version information with the preset, will happily try to load a potentially outdated preset.

The parameter count is important, because when a preset is written as a chunk (`ChunkPreset`), a reader has no way of knowing the parameters count without loading the plugin. With non-chunked presets (`Preset`) the param count could be inferred from the number of `Parameter` nodes, but its still useful to write it to the Ardour preset file, if only for consistency.

# Changes

This PR changes the `do_save_preset` method of the `VSTPlugin` class, so that a `version` and `numParams` attribute are added to each `Preset` / `ChunkPreset` in an Ardour VST user preset file. The preset files stay backwards-compatible with preset files written by Ardour versions without this change and the preset loading version currently ignores the new attributes (though it could check that their values match those of the plugin instance).

To be able to access the plugin version number, also the `vestige.h` header had to be adapted to set the correct type of the `version` field in the `AEffect` struct.

# Notes

This is my first PR to the project and I am by no means a C++ expert, so if any stylistic changes are necessary, or if I used any language features, which should not be used in this project, let me know. For example, I used `std:to:string`, which requires C++11, I believe.

# Tests

I tried to run the unit tests (following the somewhat inaccurate directions in `doc/unit_tests.txt`), but got unrelated compilation errors. I manually checked that the preset files are correctly written with the new attributes and that they can still be read by Ardour 5.x.

```
[394/428] cxx: libs/ardour/test/samplewalk_to_beats_test.cc -> build/libs/ardour/test/samplewalk_to_beats_test.cc.4.o
../libs/ardour/test/lua_script_test.cc: In Elementfunktion »void LuaScriptTest::session_script_test()«:
../libs/ardour/test/lua_script_test.cc:35:28: Warnung: polymorpher Typ »class Glib::FileError« wird per Wertzuweisung gefangen [-Wcatch-value=]
   } catch (Glib::FileError e) {
                            ^
../libs/ardour/test/lua_script_test.cc:43:29: Warnung: polymorpher Typ »class ARDOUR::SessionException« wird per Wertzuweisung gefangen [-Wcatch-value=]
   } catch (SessionException e) {
                             ^
In file included from ../libs/ardour/test/midi_clock_slave_test.cc:2:
../libs/ardour/test/midi_clock_slave_test.h:29:57: Fehler: expected class-name before »{« token
 class TestSlaveSessionProxy : public ISlaveSessionProxy {
                                                         ^
../libs/ardour/test/midi_clock_slave_test.h:79:1: Fehler: expected class-name before »{« token
 {
 ^
[...]
```
