### PR TITLE
Remove menu items from bus context menu

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -2100,9 +2100,6 @@ Editor::add_bus_context_items (Menu_Helpers::MenuList& edit_items)
 	select_menu->set_name ("ArdourContextMenu");
 
 	select_items.push_back (MenuElem (_("Select All in Track"), sigc::bind (sigc::mem_fun(*this, &Editor::select_all_in_track), Selection::Set)));
-	select_items.push_back (MenuElem (_("Select All Objects"), sigc::bind (sigc::mem_fun(*this, &Editor::select_all_objects), Selection::Set)));
-	select_items.push_back (MenuElem (_("Invert Selection in Track"), sigc::mem_fun(*this, &Editor::invert_selection_in_track)));
-	select_items.push_back (MenuElem (_("Invert Selection"), sigc::mem_fun(*this, &Editor::invert_selection)));
 	select_items.push_back (SeparatorElem());
 	select_items.push_back (MenuElem (_("Select All After Edit Point"), sigc::bind (sigc::mem_fun(*this, &Editor::select_all_selectables_using_edit), true, true)));
 	select_items.push_back (MenuElem (_("Select All Before Edit Point"), sigc::bind (sigc::mem_fun(*this, &Editor::select_all_selectables_using_edit), false, true)));
@@ -2110,28 +2107,6 @@ Editor::add_bus_context_items (Menu_Helpers::MenuList& edit_items)
 	select_items.push_back (MenuElem (_("Select All Before Playhead"), sigc::bind (sigc::mem_fun(*this, &Editor::select_all_selectables_using_cursor), playhead_cursor, false)));
 
 	edit_items.push_back (MenuElem (_("Select"), *select_menu));
-
-	/* Cut-n-Paste */
-
-	Menu *cutnpaste_menu = manage (new Menu);
-	MenuList& cutnpaste_items = cutnpaste_menu->items();
-	cutnpaste_menu->set_name ("ArdourContextMenu");
-
-	cutnpaste_items.push_back (MenuElem (_("Cut"), sigc::mem_fun(*this, &Editor::cut)));
-	cutnpaste_items.push_back (MenuElem (_("Copy"), sigc::mem_fun(*this, &Editor::copy)));
-	cutnpaste_items.push_back (MenuElem (_("Paste"), sigc::bind (sigc::mem_fun(*this, &Editor::paste), 1.0f, true)));
-
-	Menu *nudge_menu = manage (new Menu());
-	MenuList& nudge_items = nudge_menu->items();
-	nudge_menu->set_name ("ArdourContextMenu");
-
-	edit_items.push_back (SeparatorElem());
-	nudge_items.push_back (MenuElem (_("Nudge Entire Track Later"), (sigc::bind (sigc::mem_fun(*this, &Editor::nudge_track), false, true))));
-	nudge_items.push_back (MenuElem (_("Nudge Track After Edit Point Later"), (sigc::bind (sigc::mem_fun(*this, &Editor::nudge_track), true, true))));
-	nudge_items.push_back (MenuElem (_("Nudge Entire Track Earlier"), (sigc::bind (sigc::mem_fun(*this, &Editor::nudge_track), false, false))));
-	nudge_items.push_back (MenuElem (_("Nudge Track After Edit Point Earlier"), (sigc::bind (sigc::mem_fun(*this, &Editor::nudge_track), true, false))));
-
-	edit_items.push_back (MenuElem (_("Nudge"), *nudge_menu));
 }
 
 GridType


### PR DESCRIPTION
On busses such as the master bus, a context click (right mouse button) will
select the route exclusively (no other route or object is selected).
This means any selection of automation points, regions or markers is cleared
(on any route).

Editor::add_bus_context_items populates menu items for the route context menu.
A bus can not hold regions *1). The "Select" submenu actions will operate
on automation points only.

Some items have been removed from the menu, with the following rational:

Select/"Select All Objects": redundant with "Select All in Track"
Select/"Invert Selection": this can never work (automation selection cleared on context click)
Select/"Invert Selection in Track": redundant with "Invert Selection"

Cut-n-Paste code section removed (unused code, not applicable since no regions)

Nudge/*:
"Nudge Entire Track Later",
"Nudge Track After Edit Point Later",
"Nudge Entire Track Earlier",
"Nudge Track After Edit Point Earlier": removed, not applicable (no regions).

This commit makes the context menu contain only actions that are useful for a bus context.

*1) If there will ever be a bus type that supports regions in the future, code can be copied from
Editor::add_dstream_context_items "again".