### PR TITLE
Fix Count-in not taking effect when punch-in is enabled.

### DIFF
--- a/libs/ardour/session_transport.cc
+++ b/libs/ardour/session_transport.cc
@@ -1625,7 +1625,7 @@ Session::start_transport ()
 			send_immediate_mmc (MIDI::MachineControlCommand (MIDI::MachineControl::cmdDeferredPlay));
 		}
 
-		if (actively_recording() && click_data && (config.get_count_in () || _count_in_once)) {
+		if ((actively_recording() || (config.get_punch_in() && get_record_enabled())) && click_data && (config.get_count_in () || _count_in_once)) {
 			_count_in_once = false;
 			/* calculate count-in duration (in audio samples)
 			 * - use [fixed] tempo/meter at _transport_sample


### PR DESCRIPTION
While recording some tracks, I noticed that count-in did not work with punch-in enabled.

To fix this, check whether punch-in is enabled and record is enabled in addition to if we are actively recording when deciding whether to run count-in clicks.