### PR TITLE
Observe user preference to prompt for 'marker' names for ranges

### DIFF
--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -714,7 +714,7 @@ private:
 	void mouse_add_new_range (samplepos_t);
 	void mouse_add_new_loop (samplepos_t);
 	void mouse_add_new_punch (samplepos_t);
-	bool choose_new_marker_name(std::string &name);
+	bool choose_new_marker_name(std::string &name, bool is_range);
 	void update_cd_marker_display ();
 	void ensure_cd_marker_updated (LocationMarkers * lam, ARDOUR::Location * location);
 

--- a/gtk2_ardour/editor_markers.cc
+++ b/gtk2_ardour/editor_markers.cc
@@ -650,7 +650,7 @@ Editor::mouse_add_new_marker (samplepos_t where, bool is_cd)
 
 	if (_session) {
 		_session->locations()->next_available_name(markername, _("mark"));
-		if (!choose_new_marker_name(markername)) {
+		if (!choose_new_marker_name(markername, false)) {
 			return;
 		}
 		Location *location = new Location (*_session, where, where, markername, (Location::Flags) flags, get_grid_music_divisions (0));

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -2153,7 +2153,7 @@ Editor::temporal_zoom_to_sample (bool coarser, samplepos_t sample)
 
 
 bool
-Editor::choose_new_marker_name(string &name) {
+Editor::choose_new_marker_name(string &name, bool is_range) {
 
 	if (!UIConfiguration::instance().get_name_new_markers()) {
 		/* don't prompt user for a new name */
@@ -2164,7 +2164,11 @@ Editor::choose_new_marker_name(string &name) {
 
 	dialog.set_prompt (_("New Name:"));
 
-	dialog.set_title (_("New Location Marker"));
+    if (is_range) {
+        dialog.set_title(_("New Range"));
+    } else {
+	    dialog.set_title (_("New Location Marker"));
+    }
 
 	dialog.set_name ("MarkNameWindow");
 	dialog.set_size_request (250, -1);
@@ -2205,6 +2209,9 @@ Editor::add_location_from_selection ()
 	samplepos_t end = selection->time[clicked_selection].end;
 
 	_session->locations()->next_available_name(rangename,"selection");
+	if (!choose_new_marker_name(rangename, true)) {
+		return;
+	}
 	Location *location = new Location (*_session, start, end, rangename, Location::IsRangeMarker, get_grid_music_divisions(0));
 
 	begin_reversible_command (_("add marker"));
@@ -2225,7 +2232,7 @@ Editor::add_location_mark (samplepos_t where)
 	select_new_marker = true;
 
 	_session->locations()->next_available_name(markername,"mark");
-	if (!choose_new_marker_name(markername)) {
+	if (!choose_new_marker_name(markername, false)) {
 		return;
 	}
 	Location *location = new Location (*_session, where, where, markername, Location::IsMark, get_grid_music_divisions (0));
@@ -2393,7 +2400,7 @@ Editor::add_location_from_region ()
 		markername = region->name();
 	}
 
-	if (!choose_new_marker_name(markername)) {
+	if (!choose_new_marker_name(markername, false)) {
 		return;
 	}
 
@@ -2457,7 +2464,7 @@ Editor::set_mark ()
 	string markername;
 	_session->locations()->next_available_name (markername, "mark");
 
-	if (!choose_new_marker_name (markername)) {
+	if (!choose_new_marker_name (markername, false)) {
 		return;
 	}
 


### PR DESCRIPTION
This option did not work if you add a range from selection. 

Now it does. I reused translation string "New Range" for the dialog box, and added a flag to choose_new_marker_name for whether it is_range or not. This is only for the title.. I suspect there is a more preferred way to do this.