### PR TITLE
Added MIDI Remap Lua DSP plugin

### DIFF
--- a/scripts/midi_remap.lua
+++ b/scripts/midi_remap.lua
@@ -22,7 +22,7 @@ end
 function dsp_params ()
 
     local map_scalepoints = {}
-    map_scalepoints["Off"] = OFF_NOTE
+    map_scalepoints["None"] = OFF_NOTE
     for note=0,127 do
         local name = ARDOUR.ParameterDescriptor.midi_note_name(note)
         map_scalepoints[string.format("%03d (%s)", note, name)] = note
@@ -72,7 +72,7 @@ function dsp_run (_, _, n_samples)
     local translation_table = {}
     local ctrl = CtrlPorts:array()
     for i=1,N_REMAPINGS*2,2 do
-        if not (ctrl[i] == OFF_NOTE or ctrl[i + 1] == OFF_NOTE) then
+        if not (ctrl[i] == OFF_NOTE) then
             translation_table[ctrl[i]] = ctrl[i + 1]
         end
     end
@@ -87,7 +87,9 @@ function dsp_run (_, _, n_samples)
         if (#d == 3) and (event_type == 9 or event_type == 8 or event_type == 10) then -- note on, note off, poly. afterpressure
             -- Do the mapping - 2 is note byte for these types
             d[2] = translation_table[d[2]] or d[2]
-            tx_midi (t, d)
+            if not (d[2] == OFF_NOTE) then
+                tx_midi (t, d)
+            end
         else
             tx_midi (t, d)
         end

--- a/scripts/midi_remap.lua
+++ b/scripts/midi_remap.lua
@@ -1,0 +1,103 @@
+ardour {
+    ["type"]    = "dsp",
+    name        = "MIDI Remap Notes",
+    category    = "Utility",
+    license     = "MIT",
+    author      = "Alby Musaelian",
+    description = [[Map arbitrary MIDI notes to others. Affects Note On/Off and polyphonic key pressure.]]
+}
+
+-- The number of remapping pairs to allow. Increasing this (at least in theory)
+-- decreases performace, so it's set fairly low as a default. The user can
+-- increase this if they have a need to.
+N_REMAPINGS = 10
+
+function dsp_ioconfig ()
+    return { { midi_in = 1, midi_out = 1, audio_in = 0, audio_out = 0}, }
+end
+
+function dsp_params ()
+    local note_names = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"}
+
+    local map_scalepoints = {}
+    for note=0,127 do
+        local octave = -5 + math.floor(note / 12)
+        local name = note_names[(note % 12) + 1]
+        map_scalepoints[string.format("%03d (%s%d)", note, name, octave)] = note
+    end
+
+    local map_params = {}
+
+    i = 1
+    for mapnum = 1,N_REMAPINGS do
+        -- From and to
+        for _,name in pairs({"| #" .. mapnum .. "  Map note", "|__   to"}) do
+            map_params[i] = {
+                ["type"] = "input",
+                name = name,
+                min = 0,
+                max = 127,
+                default = 0,
+                integer = true,
+                enum = true,
+                scalepoints = map_scalepoints
+            }
+            i = i + 1
+        end
+    end
+
+    return map_params
+end
+
+function dsp_init(samplerate)
+    -- Init translation table, reserve memory
+    translation_table = {}
+    for i = 0,127 do
+        translation_table[i] = i
+    end
+end
+
+
+function dsp_run (_, _, n_samples)
+    assert (type(midiin) == "table")
+    assert (type(midiout) == "table")
+    local cnt = 1;
+
+    function tx_midi (time, data)
+        midiout[cnt] = {}
+        midiout[cnt]["time"] = time;
+        midiout[cnt]["data"] = data;
+        cnt = cnt + 1;
+    end
+
+    -- We build the translation table every buffer because, as far as I can tell,
+    -- there's no way to only rebuild it when the parameters have changed.
+    -- As a result, it has to be updated every buffer for the parameters to have
+    -- any effect.
+
+    -- Restore translation table
+    for i = 0,127 do
+        translation_table[i] = i
+    end
+    -- Update it
+    local ctrl = CtrlPorts:array()
+    for i=1,N_REMAPINGS*2,2 do
+        translation_table[ctrl[i]] = ctrl[i + 1]
+    end
+
+    -- for each incoming midi event
+    for _,b in pairs (midiin) do
+        local t = b["time"] -- t = [ 1 .. n_samples ]
+        local d = b["data"] -- get midi-event
+        local event_type
+        if #d == 0 then event_type = -1 else event_type = d[1] >> 4 end
+
+        if (#d == 3) and (event_type == 9 or event_type == 8 or event_type == 10) then -- note on, note off, poly. afterpressure
+            -- Do the mapping - 2 is note byte for these types
+            d[2] = translation_table[d[2]]
+            tx_midi (t, d)
+        else
+            tx_midi (t, d)
+        end
+    end
+end


### PR DESCRIPTION
Hi all,

This is an Ardour Lua DSP script I put together for remapping arbitrary MIDI notes in real time. I [posted it on the forums](https://discourse.ardour.org/t/lua-dsp-plugin-for-real-time-midi-remapping/100475), and at the suggestion of Robin Gareus, I'm submitting a PR to have it added to Ardour.

It can map any MIDI note to any other. Polyphonic aftertouch should also be remapped, though I haven't tested that, lacking any easy way to produce polyphonic aftertouch data. Timing and velocities are unaffected, and all other MIDI data is passed through untouched. By default it allows up to 10 remappings; just change `N_REMAPINGS` in the code if you need more.

One major improvement -- if possible -- would be to update the `translation_table` only when the parameters have changed, rather than every single buffer. I was unable to find any callback for when the parameters have been modified, but if one does exist, I'll certainly update the code to take advantage of it. 

Thanks,
A.