### PR TITLE
Fixes mistakes in the French and German translation files

### DIFF
--- a/gtk2_ardour/po/de.po
+++ b/gtk2_ardour/po/de.po
@@ -10175,7 +10175,6 @@ msgstr ""
 msgid "  -b, --bindings              Display all current key bindings\n"
 msgstr ""
 "  -b, --bindings                   Alle momentanen Tastaturkürzel ausgeben\n"
-"\""
 
 #: opts.cc:73
 msgid ""
@@ -10200,7 +10199,6 @@ msgstr "  -C, --curvetest filename    Curve algorithm debugger\n"
 msgid "  -d, --disable-plugins       Disable all plugins (safe mode)\n"
 msgstr ""
 "  -d, --disable-plugins            Alle Plugins deaktivieren (safe mode)\n"
-"\""
 
 #: opts.cc:80
 msgid ""

--- a/gtk2_ardour/po/fr.po
+++ b/gtk2_ardour/po/fr.po
@@ -7594,7 +7594,7 @@ msgstr "Voulez-vous vraiment enlever ce pré-réglage ?"
 
 #: export_report.cc:56
 msgid "Export Report/Analysis"
-msgstr Exporter le/la rapport/analyse""
+msgstr "Exporter le/la rapport/analyse"
 
 #: export_report.cc:147 export_report.cc:327 sfdb_ui.cc:149
 msgid "Format:"


### PR DESCRIPTION
This PR fixes a mistake in the French translation file introduced in https://github.com/Ardour/ardour/pull/445 yesterday.

While building it, I saw that it was complaining about 2 `fatal errors` in the de.po file:

```
Generating po/de.po
po/de.po:10176: 'msgid' and 'msgstr' entries do not both end with '\n'
po/de.po:10201: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 2 fatal errors
```

I'm trying here to correct those as well but please @x42 , double check that I'm not introducing another mistake in the German file while doing that.
