### PR TITLE
Drag and drop a file from Dolphin is now working even if the file has…

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -3407,7 +3407,7 @@ Editor::convert_drop_to_paths (
 		   THERE MAY BE NO NULL TERMINATING CHAR!!!
 		*/
 
-		string txt = data.get_text();
+		string txt = Glib::convert(data.get_text(), "ISO-8859-1", "UTF-8");
 		char* p;
 		const char* q;
 


### PR DESCRIPTION
… utf8 non-latin1 characters in its name.

This fix corresponds to bug ID 0007253