### PR TITLE
Fix drag and drop from nautilus/dolphin

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -3391,66 +3391,6 @@ Editor::convert_drop_to_paths (
 
 	vector<string> uris = data.get_uris();
 
-	if (uris.empty()) {
-
-		/* This is seriously fucked up. Nautilus doesn't say that its URI lists
-		   are actually URI lists. So do it by hand.
-		*/
-
-		if (data.get_target() != "text/plain") {
-			return -1;
-		}
-
-		/* Parse the "uri-list" format that Nautilus provides,
-		   where each pathname is delimited by \r\n.
-
-		   THERE MAY BE NO NULL TERMINATING CHAR!!!
-		*/
-
-		string txt = data.get_text();
-		char* p;
-		const char* q;
-
-		p = (char *) malloc (txt.length() + 1);
-		txt.copy (p, txt.length(), 0);
-		p[txt.length()] = '\0';
-
-		while (p)
-		{
-			if (*p != '#')
-			{
-				while (g_ascii_isspace (*p))
-					p++;
-
-				q = p;
-				while (*q && (*q != '\n') && (*q != '\r')) {
-					q++;
-				}
-
-				if (q > p)
-				{
-					q--;
-					while (q > p && g_ascii_isspace (*q))
-						q--;
-
-					if (q > p)
-					{
-						uris.push_back (string (p, q - p + 1));
-					}
-				}
-			}
-			p = strchr (p, '\n');
-			if (p)
-				p++;
-		}
-
-		free ((void*)p);
-
-		if (uris.empty()) {
-			return -1;
-		}
-	}
-
 	for (vector<string>::iterator i = uris.begin(); i != uris.end(); ++i) {
 		if ((*i).substr (0,7) == "file://") {
 			paths.push_back (Glib::filename_from_uri (*i));

--- a/gtk2_ardour/editor_canvas.cc
+++ b/gtk2_ardour/editor_canvas.cc
@@ -252,8 +252,8 @@ Editor::initialize_canvas ()
 	// Drag-N-Drop from the region list can generate this target
 	target_table.push_back (TargetEntry ("regions"));
 
-	target_table.push_back (TargetEntry ("text/plain"));
 	target_table.push_back (TargetEntry ("text/uri-list"));
+	target_table.push_back (TargetEntry ("text/plain"));
 	target_table.push_back (TargetEntry ("application/x-rootwin-drop"));
 
 	_track_canvas->drag_dest_set (target_table);


### PR DESCRIPTION
Drag and drop from nautilus or dolphin is now considered as a list of uri rather than a plain text. 
* Fix bug ID 0007253 https://tracker.ardour.org/view.php?id=7253
* remove hand written code to parse plain-text description of the filenames