### PR TITLE
a-fluidsynth segfault: don't use midnam:update extension in hosts that do not support it

### DIFF
--- a/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
+++ b/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
@@ -310,6 +310,16 @@ instantiate (const LV2_Descriptor*     descriptor,
 		return NULL;
 	}
 
+#ifdef LV2_EXTENDED
+	if (!self->midnam) {
+		lv2_log_warning (&self->logger, "a-fluidsynth.lv2: Host does not support midnam:update\n");
+	}
+
+	if (!self->bankpatch) {
+		lv2_log_warning (&self->logger, "a-fluidsynth.lv2: Host does not support bankpatch:notify\n");
+	}
+#endif
+
 	/* initialize fluid synth */
 	self->settings = new_fluid_settings ();
 

--- a/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
+++ b/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
@@ -581,7 +581,8 @@ run (LV2_Handle instance, uint32_t n_samples)
 		inform_ui (self);
 
 #ifdef LV2_EXTENDED
-		self->midnam->update (self->midnam->handle);
+		if (self->midnam)
+			self->midnam->update (self->midnam->handle);
 #endif
 	}
 


### PR DESCRIPTION
Also logs a warning, if the hosts does not support the midnam or bankpatch extensions.

This allows this plugin to be safely used in other LV2 hosts, even when compiled with `LV_EXTENDED` defined.