### PR TITLE
Make wscripts python3 compatible (waf 2.0.19 compatible)

### DIFF
--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -622,6 +622,8 @@ def build(bld):
         obj.source    = list(gtk2_ardour_sources)
         obj.target = 'ardour-' + str (bld.env['VERSION'])
         obj.includes = ['.']
+        obj.includes += bld.env['INCLUDES_LILV']
+        obj.ldflags = ['-l' + lib for lib in bld.env['LIB_LILV']]
         obj.ldflags = ['-no-undefined']
 
         if bld.is_defined('WINDOWS_VST_SUPPORT'):

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -509,7 +509,6 @@ def build(bld):
         obj.source    = list(gtk2_ardour_sources)
         obj.target    = 'luadoc'
         obj.includes  = ['.', '../libs']
-        obj.ldflags   = ['-no-undefined']
         obj.use       = [
                 'libpbd',
                 'libardour',
@@ -549,7 +548,6 @@ def build(bld):
 #        obj.source    = [ 'ardour_button.cc', 'ui_config.cc', 'tooltips.cc' ]
 #        obj.target    = 'canvas_test'
 #        obj.includes  = ['.', '../libs']
-#        obj.ldflags   = ['-no-undefined']
 #        obj.use       = [
 #                'libpbd',
 #                'libardour',
@@ -624,7 +622,6 @@ def build(bld):
         obj.includes = ['.']
         obj.includes += bld.env['INCLUDES_LILV']
         obj.ldflags = ['-l' + lib for lib in bld.env['LIB_LILV']]
-        obj.ldflags = ['-no-undefined']
 
         if bld.is_defined('WINDOWS_VST_SUPPORT'):
         # Windows VST support mingw

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -159,8 +159,7 @@ def build(bld):
         obj.source += 'debug_rt_alloc.c'
 
     obj.export_includes = ['.']
-    obj.includes = ['.']
-    obj.includes += bld.env['INCLUDES_XML']
+    obj.includes = ['.'] + bld.env['INCLUDES_XML']
     obj.name         = 'libpbd'
     obj.target       = 'pbd'
     obj.uselib       = 'GLIBMM SIGCPP XML UUID SNDFILE GIOMM ARCHIVE CURL'

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -159,7 +159,7 @@ def build(bld):
         obj.source += 'debug_rt_alloc.c'
 
     obj.export_includes = ['.']
-    obj.includes     = ['.']
+    obj.includes = '. /usr/include/libxml2'
     obj.name         = 'libpbd'
     obj.target       = 'pbd'
     obj.uselib       = 'GLIBMM SIGCPP XML UUID SNDFILE GIOMM ARCHIVE CURL'

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -159,7 +159,7 @@ def build(bld):
         obj.source += 'debug_rt_alloc.c'
 
     obj.export_includes = ['.']
-    obj.includes = '. /usr/include/libxml2'
+    obj.includes = ['.', bld.env['INCLUDES_XML']]
     obj.name         = 'libpbd'
     obj.target       = 'pbd'
     obj.uselib       = 'GLIBMM SIGCPP XML UUID SNDFILE GIOMM ARCHIVE CURL'

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -159,7 +159,8 @@ def build(bld):
         obj.source += 'debug_rt_alloc.c'
 
     obj.export_includes = ['.']
-    obj.includes = ['.', bld.env['INCLUDES_XML']]
+    obj.includes = ['.']
+    obj.includes += bld.env['INCLUDES_XML']
     obj.name         = 'libpbd'
     obj.target       = 'pbd'
     obj.uselib       = 'GLIBMM SIGCPP XML UUID SNDFILE GIOMM ARCHIVE CURL'

--- a/libs/plugins/a-comp.lv2/wscript
+++ b/libs/plugins/a-comp.lv2/wscript
@@ -24,15 +24,15 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-comp.ttl', 'a-comp#stereo.ttl', 'presets.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-comp.lv2/wscript
+++ b/libs/plugins/a-comp.lv2/wscript
@@ -32,7 +32,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-delay.lv2/wscript
+++ b/libs/plugins/a-delay.lv2/wscript
@@ -24,14 +24,14 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-delay.ttl', 'presets.ttl']:
             obj = bld(features='subst')
             obj.source = i + '.in'
             obj.target = '../../LV2/%s/%s' % (bundle, i)
-            obj.install_path = '${LV2DIR}/%s' % bundle,
-            obj.chmod = Utils.O644,
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
             obj.LIB_EXT = module_ext
 
         # Build plugin library

--- a/libs/plugins/a-delay.lv2/wscript
+++ b/libs/plugins/a-delay.lv2/wscript
@@ -27,12 +27,12 @@ def build(bld):
     if bld.is_defined ('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-delay.ttl', 'presets.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle,
+            obj.chmod = Utils.O644,
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-delay.lv2/wscript
+++ b/libs/plugins/a-delay.lv2/wscript
@@ -32,7 +32,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-eq.lv2/wscript
+++ b/libs/plugins/a-eq.lv2/wscript
@@ -24,15 +24,15 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-eq.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-eq.lv2/wscript
+++ b/libs/plugins/a-eq.lv2/wscript
@@ -32,7 +32,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-exp.lv2/wscript
+++ b/libs/plugins/a-exp.lv2/wscript
@@ -24,15 +24,15 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-exp.ttl', 'a-exp#stereo.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-exp.lv2/wscript
+++ b/libs/plugins/a-exp.lv2/wscript
@@ -32,7 +32,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-fluidsynth.lv2/wscript
+++ b/libs/plugins/a-fluidsynth.lv2/wscript
@@ -23,15 +23,15 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-fluidsynth.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'cxx cshlib',

--- a/libs/plugins/a-fluidsynth.lv2/wscript
+++ b/libs/plugins/a-fluidsynth.lv2/wscript
@@ -31,7 +31,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'cxx cshlib',

--- a/libs/plugins/a-reverb.lv2/wscript
+++ b/libs/plugins/a-reverb.lv2/wscript
@@ -23,15 +23,15 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'a-reverb.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/a-reverb.lv2/wscript
+++ b/libs/plugins/a-reverb.lv2/wscript
@@ -31,7 +31,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/reasonablesynth.lv2/wscript
+++ b/libs/plugins/reasonablesynth.lv2/wscript
@@ -23,15 +23,15 @@ def build(bld):
     module_pat = re.sub('^lib', '', bld.env.cshlib_PATTERN)
     module_ext = module_pat[module_pat.rfind('.'):]
 
-    if bld.is_defined ('HAVE_LV2'):
+    if bld.is_defined('HAVE_LV2'):
         # Build RDF files
         for i in ['manifest.ttl', 'reasonablesynth.ttl']:
-            bld(features     = 'subst',
-                source       = i + '.in',
-                target       = '../../LV2/%s/%s' % (bundle, i),
-                install_path = '${LV2DIR}/%s' % bundle,
-                chmod        = Utils.O644,
-                LIB_EXT      = module_ext)
+            obj = bld(features='subst')
+            obj.source = i + '.in'
+            obj.target = '../../LV2/%s/%s' % (bundle, i)
+            obj.install_path = '${LV2DIR}/%s' % bundle
+            obj.chmod = Utils.O644
+            obj.LIB_EXT = module_ext
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/plugins/reasonablesynth.lv2/wscript
+++ b/libs/plugins/reasonablesynth.lv2/wscript
@@ -31,7 +31,7 @@ def build(bld):
             obj.target = '../../LV2/%s/%s' % (bundle, i)
             obj.install_path = '${LV2DIR}/%s' % bundle
             obj.chmod = Utils.O644
-            obj.LIB_EXT = module_ext
+            obj.dict = {'LIB_EXT': module_ext}
 
         # Build plugin library
         obj = bld(features     = 'c cshlib',

--- a/libs/ptformat/wscript
+++ b/libs/ptformat/wscript
@@ -38,7 +38,7 @@ def build(bld):
         obj.cflags = [ bld.env['compiler_flags_dict']['pic'] ]
         
     obj.export_includes     = ['.']
-    obj.includes     = ['.']
+    obj.includes = '. /usr/include/glib-2.0 /usr/lib/glib-2.0/include'
     obj.name         = 'libptformat'
     obj.target       = 'ptformat'
     obj.use          = 'libpbd'

--- a/libs/ptformat/wscript
+++ b/libs/ptformat/wscript
@@ -38,8 +38,7 @@ def build(bld):
         obj.cflags = [ bld.env['compiler_flags_dict']['pic'] ]
         
     obj.export_includes     = ['.']
-    obj.includes = ['.'],
-    obj.includes += bld.env['INCLUDES_GLIB']
+    obj.includes = ['.'] + bld.env['INCLUDES_GLIB']
     obj.name         = 'libptformat'
     obj.target       = 'ptformat'
     obj.use          = 'libpbd'

--- a/libs/ptformat/wscript
+++ b/libs/ptformat/wscript
@@ -38,7 +38,7 @@ def build(bld):
         obj.cflags = [ bld.env['compiler_flags_dict']['pic'] ]
         
     obj.export_includes     = ['.']
-    obj.includes = '. /usr/include/glib-2.0 /usr/lib/glib-2.0/include'
+    obj.includes = ['.', bld.env['INCLUDES_GLIB']]
     obj.name         = 'libptformat'
     obj.target       = 'ptformat'
     obj.use          = 'libpbd'

--- a/libs/ptformat/wscript
+++ b/libs/ptformat/wscript
@@ -38,7 +38,8 @@ def build(bld):
         obj.cflags = [ bld.env['compiler_flags_dict']['pic'] ]
         
     obj.export_includes     = ['.']
-    obj.includes = ['.', bld.env['INCLUDES_GLIB']]
+    obj.includes = ['.'],
+    obj.includes += bld.env['INCLUDES_GLIB']
     obj.name         = 'libptformat'
     obj.target       = 'ptformat'
     obj.use          = 'libpbd'

--- a/libs/surfaces/contourdesign/wscript
+++ b/libs/surfaces/contourdesign/wscript
@@ -24,7 +24,7 @@ def build(bld):
     obj.export_includes = ['./contourdesign']
     obj.defines      = [ 'PACKAGE="ardour_contourdesign"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes = '. ../libs ../../widgets /usr/include/libxml2'
+    obj.includes = ['.', '../libs', '../../widgets', bld.env['INCLUDES_XML']]
     obj.name         = 'libardour_contourdesign'
     obj.target       = 'ardour_contourdesign'
     obj.uselib       = 'GTKMM USB'

--- a/libs/surfaces/contourdesign/wscript
+++ b/libs/surfaces/contourdesign/wscript
@@ -24,7 +24,8 @@ def build(bld):
     obj.export_includes = ['./contourdesign']
     obj.defines      = [ 'PACKAGE="ardour_contourdesign"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes = ['.', '../libs', '../../widgets', bld.env['INCLUDES_XML']]
+    obj.includes = ['.', '../libs', '../../widgets']
+    obj.includes += bld.env['INCLUDES_XML']
     obj.name         = 'libardour_contourdesign'
     obj.target       = 'ardour_contourdesign'
     obj.uselib       = 'GTKMM USB'

--- a/libs/surfaces/contourdesign/wscript
+++ b/libs/surfaces/contourdesign/wscript
@@ -24,7 +24,7 @@ def build(bld):
     obj.export_includes = ['./contourdesign']
     obj.defines      = [ 'PACKAGE="ardour_contourdesign"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes     = ['.', '../libs', '../../widgets']
+    obj.includes = '. ../libs ../../widgets /usr/include/libxml2'
     obj.name         = 'libardour_contourdesign'
     obj.target       = 'ardour_contourdesign'
     obj.uselib       = 'GTKMM USB'

--- a/libs/surfaces/contourdesign/wscript
+++ b/libs/surfaces/contourdesign/wscript
@@ -24,8 +24,7 @@ def build(bld):
     obj.export_includes = ['./contourdesign']
     obj.defines      = [ 'PACKAGE="ardour_contourdesign"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes = ['.', '../libs', '../../widgets']
-    obj.includes += bld.env['INCLUDES_XML']
+    obj.includes = ['.', '../libs', '../../widgets'] + bld.env['INCLUDES_XML']
     obj.name         = 'libardour_contourdesign'
     obj.target       = 'ardour_contourdesign'
     obj.uselib       = 'GTKMM USB'

--- a/libs/surfaces/launch_control_xl/wscript
+++ b/libs/surfaces/launch_control_xl/wscript
@@ -30,8 +30,7 @@ def build(bld):
     obj.defines = ['PACKAGE="ardour_launch_control_xl"']
     obj.defines += ['ARDOURSURFACE_DLL_EXPORTS']
     obj.defines += ['VERSIONSTRING="' + bld.env['VERSION'] + '"']
-    obj.includes = ['.', './launch_control_xl']
-    obj.includes += bld.env['INCLUDES_XML']
+    obj.includes = ['.', './launch_control_xl'] + bld.env['INCLUDES_XML']
     obj.name = 'libardour_launch_control_xl'
     obj.target = 'ardour_launch_control_xl'
     obj.uselib = 'GTKMM SIGCPP'

--- a/libs/surfaces/launch_control_xl/wscript
+++ b/libs/surfaces/launch_control_xl/wscript
@@ -30,7 +30,8 @@ def build(bld):
     obj.defines = ['PACKAGE="ardour_launch_control_xl"']
     obj.defines += ['ARDOURSURFACE_DLL_EXPORTS']
     obj.defines += ['VERSIONSTRING="' + bld.env['VERSION'] + '"']
-    obj.includes = ['.', './launch_control_xl', bld.env['INCLUDES_XML']]
+    obj.includes = ['.', './launch_control_xl']
+    obj.includes += bld.env['INCLUDES_XML']
     obj.name = 'libardour_launch_control_xl'
     obj.target = 'ardour_launch_control_xl'
     obj.uselib = 'GTKMM SIGCPP'

--- a/libs/surfaces/launch_control_xl/wscript
+++ b/libs/surfaces/launch_control_xl/wscript
@@ -30,7 +30,7 @@ def build(bld):
     obj.defines = ['PACKAGE="ardour_launch_control_xl"']
     obj.defines += ['ARDOURSURFACE_DLL_EXPORTS']
     obj.defines += ['VERSIONSTRING="' + bld.env['VERSION'] + '"']
-    obj.includes = ['.', './launch_control_xl']
+    obj.includes = '. ./launch_control_xl /usr/include/libxml2'
     obj.name = 'libardour_launch_control_xl'
     obj.target = 'ardour_launch_control_xl'
     obj.uselib = 'GTKMM SIGCPP'

--- a/libs/surfaces/launch_control_xl/wscript
+++ b/libs/surfaces/launch_control_xl/wscript
@@ -30,7 +30,7 @@ def build(bld):
     obj.defines = ['PACKAGE="ardour_launch_control_xl"']
     obj.defines += ['ARDOURSURFACE_DLL_EXPORTS']
     obj.defines += ['VERSIONSTRING="' + bld.env['VERSION'] + '"']
-    obj.includes = '. ./launch_control_xl /usr/include/libxml2'
+    obj.includes = ['.', './launch_control_xl', bld.env['INCLUDES_XML']]
     obj.name = 'libardour_launch_control_xl'
     obj.target = 'ardour_launch_control_xl'
     obj.uselib = 'GTKMM SIGCPP'

--- a/libs/surfaces/osc/wscript
+++ b/libs/surfaces/osc/wscript
@@ -27,7 +27,7 @@ def build(bld):
     obj.export_includes = ['.']
     obj.defines      = [ 'PACKAGE="ardour_osc"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes     = ['.', './osc']
+    obj.includes = '. ./osc /usr/include/libxml2'
     obj.name         = 'libardour_osc'
     obj.target       = 'ardour_osc'
     obj.uselib       = 'LO GTKMM GTK GDK'

--- a/libs/surfaces/osc/wscript
+++ b/libs/surfaces/osc/wscript
@@ -27,8 +27,7 @@ def build(bld):
     obj.export_includes = ['.']
     obj.defines      = [ 'PACKAGE="ardour_osc"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes = ['.', './osc']
-    obj.includes += bld.env['INCLUDES_XML']
+    obj.includes = ['.', './osc'] + bld.env['INCLUDES_XML']
     obj.name         = 'libardour_osc'
     obj.target       = 'ardour_osc'
     obj.uselib       = 'LO GTKMM GTK GDK'

--- a/libs/surfaces/osc/wscript
+++ b/libs/surfaces/osc/wscript
@@ -27,7 +27,7 @@ def build(bld):
     obj.export_includes = ['.']
     obj.defines      = [ 'PACKAGE="ardour_osc"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes = '. ./osc /usr/include/libxml2'
+    obj.includes = ['.', './osc', bld.env['INCLUDES_XML']]
     obj.name         = 'libardour_osc'
     obj.target       = 'ardour_osc'
     obj.uselib       = 'LO GTKMM GTK GDK'

--- a/libs/surfaces/osc/wscript
+++ b/libs/surfaces/osc/wscript
@@ -27,7 +27,8 @@ def build(bld):
     obj.export_includes = ['.']
     obj.defines      = [ 'PACKAGE="ardour_osc"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
-    obj.includes = ['.', './osc', bld.env['INCLUDES_XML']]
+    obj.includes = ['.', './osc']
+    obj.includes += bld.env['INCLUDES_XML']
     obj.name         = 'libardour_osc'
     obj.target       = 'ardour_osc'
     obj.uselib       = 'LO GTKMM GTK GDK'

--- a/libs/surfaces/push2/wscript
+++ b/libs/surfaces/push2/wscript
@@ -39,7 +39,7 @@ def build(bld):
     obj.defines      = [ 'PACKAGE="ardour_push2"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
     obj.defines     += [ 'VERSIONSTRING="' + bld.env['VERSION'] + '"' ]
-    obj.includes     = [ '.', './push2']
+    obj.includes = '. ./push2 /usr/include/libxml2'
     obj.name         = 'libardour_push2'
     obj.target       = 'ardour_push2'
     obj.uselib       = 'CAIROMM PANGOMM USB GTKMM SIGCPP'

--- a/libs/surfaces/push2/wscript
+++ b/libs/surfaces/push2/wscript
@@ -39,7 +39,8 @@ def build(bld):
     obj.defines      = [ 'PACKAGE="ardour_push2"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
     obj.defines     += [ 'VERSIONSTRING="' + bld.env['VERSION'] + '"' ]
-    obj.includes = ['.', './push2', bld.env['INCLUDES_XML']]
+    obj.includes = ['.', './push2']
+    obj.includes += bld.env['INCLUDES_XML']
     obj.name         = 'libardour_push2'
     obj.target       = 'ardour_push2'
     obj.uselib       = 'CAIROMM PANGOMM USB GTKMM SIGCPP'

--- a/libs/surfaces/push2/wscript
+++ b/libs/surfaces/push2/wscript
@@ -39,7 +39,7 @@ def build(bld):
     obj.defines      = [ 'PACKAGE="ardour_push2"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
     obj.defines     += [ 'VERSIONSTRING="' + bld.env['VERSION'] + '"' ]
-    obj.includes = '. ./push2 /usr/include/libxml2'
+    obj.includes = ['.', './push2', bld.env['INCLUDES_XML']]
     obj.name         = 'libardour_push2'
     obj.target       = 'ardour_push2'
     obj.uselib       = 'CAIROMM PANGOMM USB GTKMM SIGCPP'

--- a/libs/surfaces/push2/wscript
+++ b/libs/surfaces/push2/wscript
@@ -39,8 +39,7 @@ def build(bld):
     obj.defines      = [ 'PACKAGE="ardour_push2"' ]
     obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
     obj.defines     += [ 'VERSIONSTRING="' + bld.env['VERSION'] + '"' ]
-    obj.includes = ['.', './push2']
-    obj.includes += bld.env['INCLUDES_XML']
+    obj.includes = ['.', './push2'] + bld.env['INCLUDES_XML']
     obj.name         = 'libardour_push2'
     obj.target       = 'ardour_push2'
     obj.uselib       = 'CAIROMM PANGOMM USB GTKMM SIGCPP'

--- a/libs/widgets/wscript
+++ b/libs/widgets/wscript
@@ -74,7 +74,8 @@ def build(bld):
         obj.defines      = [ ]
 
     obj.export_includes = ['.']
-    obj.includes = '. /usr/include/glib-2.0 /usr/lib/glib-2.0/include'
+    obj.includes = ['.']
+    obj.includes += bld.env['INCLUDES_GLIB']
     obj.uselib       = 'SIGCPP CAIROMM GTKMM BOOST XML'
     obj.use          = [ 'libpbd', 'libgtkmm2ext' ]
     obj.name         = 'libwidgets'

--- a/libs/widgets/wscript
+++ b/libs/widgets/wscript
@@ -74,8 +74,7 @@ def build(bld):
         obj.defines      = [ ]
 
     obj.export_includes = ['.']
-    obj.includes = ['.']
-    obj.includes += bld.env['INCLUDES_GLIB']
+    obj.includes = ['.'] + bld.env['INCLUDES_GLIB']
     obj.uselib       = 'SIGCPP CAIROMM GTKMM BOOST XML'
     obj.use          = [ 'libpbd', 'libgtkmm2ext' ]
     obj.name         = 'libwidgets'

--- a/libs/widgets/wscript
+++ b/libs/widgets/wscript
@@ -74,7 +74,7 @@ def build(bld):
         obj.defines      = [ ]
 
     obj.export_includes = ['.']
-    obj.includes     = ['.']
+    obj.includes = '. /usr/include/glib-2.0 /usr/lib/glib-2.0/include'
     obj.uselib       = 'SIGCPP CAIROMM GTKMM BOOST XML'
     obj.use          = [ 'libpbd', 'libgtkmm2ext' ]
     obj.name         = 'libwidgets'

--- a/session_utils/wscript
+++ b/session_utils/wscript
@@ -86,7 +86,7 @@ def build(bld):
     utils = bld.path.ant_glob('*.cc', excl=['example.cc', 'common.cc'])
 
     for util in utils:
-        fn = os.path.basename(str(util))[:-3]
+        fn = os.path.splitext(os.path.basename(str(util)))[0]
         build_ardour_util(bld, fn)
         if bld.env['build_target'] != 'mingw':
             bld.symlink_as(bld.env['BINDIR'] + '/' + pgmprefix + "-" + fn, bld.env['LIBDIR'] + '/utils/ardour-util.sh')

--- a/session_utils/wscript
+++ b/session_utils/wscript
@@ -86,7 +86,7 @@ def build(bld):
     utils = bld.path.ant_glob('*.cc', excl=['example.cc', 'common.cc'])
 
     for util in utils:
-        fn = str(util)[:-3]
+        fn = os.path.basename(str(util))[:-3]
         build_ardour_util(bld, fn)
         if bld.env['build_target'] != 'mingw':
             bld.symlink_as(bld.env['BINDIR'] + '/' + pgmprefix + "-" + fn, bld.env['LIBDIR'] + '/utils/ardour-util.sh')

--- a/tools/bb/wscript
+++ b/tools/bb/wscript
@@ -16,7 +16,7 @@ def build(bld):
         obj.install_path = None
         obj.source    = [ 'bb.cc', 'gui.cc', 'misc.cc' ]
         obj.target    = 'bb'
-        obj.includes  = ['.', '../libs']
+        obj.includes = '. ../libs /usr/include/libxml2'
         obj.ldflags   = ['-no-undefined']
         obj.use       = [ 'libardour', 'libevoral', ]
         obj.uselib    = ' JACK GTKMM '

--- a/tools/bb/wscript
+++ b/tools/bb/wscript
@@ -12,14 +12,14 @@ def configure(ctx):
         pass
 
 def build(bld):
-	obj = bld (features = 'cxx c cxxprogram')
-	obj.install_path = None
-	obj.source    = [ 'bb.cc', 'gui.cc', 'misc.cc' ]
-	obj.target    = 'bb'
-	obj.includes  = ['.', '../libs']
-	obj.ldflags   = ['-no-undefined']
-	obj.use       = [ 'libardour', 'libevoral', ]
-	obj.uselib    = ' JACK GTKMM '
+        obj = bld (features = 'cxx c cxxprogram')
+        obj.install_path = None
+        obj.source    = [ 'bb.cc', 'gui.cc', 'misc.cc' ]
+        obj.target    = 'bb'
+        obj.includes  = ['.', '../libs']
+        obj.ldflags   = ['-no-undefined']
+        obj.use       = [ 'libardour', 'libevoral', ]
+        obj.uselib    = ' JACK GTKMM '
 
         wrapper_subst_dict = {
             'INSTALL_PREFIX' : bld.env['PREFIX'],

--- a/tools/bb/wscript
+++ b/tools/bb/wscript
@@ -17,7 +17,6 @@ def build(bld):
         obj.source    = [ 'bb.cc', 'gui.cc', 'misc.cc' ]
         obj.target    = 'bb'
         obj.includes = '. ../libs /usr/include/libxml2'
-        obj.ldflags   = ['-no-undefined']
         obj.use       = [ 'libardour', 'libevoral', ]
         obj.uselib    = ' JACK GTKMM '
 

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python
+# encoding: utf-8
+# Thomas Nagy, 2006-2010 (ita)
+
+"""
+This tool is totally deprecated
+
+Try using:
+	.pc.in files for .pc files
+	the feature intltool_in - see demos/intltool
+	make-like rules
+"""
+
+import shutil, re, os
+from waflib import TaskGen, Node, Task, Utils, Build, Errors
+from waflib.TaskGen import feature, after_method, before_method
+from waflib.Logs import debug
+
+def copy_attrs(orig, dest, names, only_if_set=False):
+	"""
+	copy class attributes from an object to another
+	"""
+	for a in Utils.to_list(names):
+		u = getattr(orig, a, ())
+		if u or not only_if_set:
+			setattr(dest, a, u)
+
+def copy_func(tsk):
+	"Make a file copy. This might be used to make other kinds of file processing (even calling a compiler is possible)"
+	env = tsk.env
+	infile = tsk.inputs[0].abspath()
+	outfile = tsk.outputs[0].abspath()
+	try:
+		shutil.copy2(infile, outfile)
+	except (OSError, IOError):
+		return 1
+	else:
+		if tsk.chmod: os.chmod(outfile, tsk.chmod)
+		return 0
+
+def action_process_file_func(tsk):
+	"Ask the function attached to the task to process it"
+	if not tsk.fun: raise Errors.WafError('task must have a function attached to it for copy_func to work!')
+	return tsk.fun(tsk)
+
+@feature('cmd')
+def apply_cmd(self):
+	"call a command everytime"
+	if not self.fun: raise Errors.WafError('cmdobj needs a function!')
+	tsk = Task.TaskBase()
+	tsk.fun = self.fun
+	tsk.env = self.env
+	self.tasks.append(tsk)
+	tsk.install_path = self.install_path
+
+@feature('copy')
+@before_method('process_source')
+def apply_copy(self):
+	Utils.def_attrs(self, fun=copy_func)
+	self.default_install_path = 0
+
+	lst = self.to_list(self.source)
+	self.meths.remove('process_source')
+
+	for filename in lst:
+		node = self.path.find_resource(filename)
+		if not node: raise Errors.WafError('cannot find input file %s for processing' % filename)
+
+		target = self.target
+		if not target or len(lst)>1: target = node.name
+
+		# TODO the file path may be incorrect
+		newnode = self.path.find_or_declare(target)
+
+		tsk = self.create_task('copy', node, newnode)
+		tsk.fun = self.fun
+		tsk.chmod = getattr(self, 'chmod', Utils.O644)
+
+		if not tsk.env:
+			tsk.debug()
+			raise Errors.WafError('task without an environment')
+
+def subst_func(tsk):
+	"Substitutes variables in a .in file"
+
+	m4_re = re.compile('@(\w+)@', re.M)
+
+	code = tsk.inputs[0].read() #Utils.readf(infile)
+
+	# replace all % by %% to prevent errors by % signs in the input file while string formatting
+	code = code.replace('%', '%%')
+
+	s = m4_re.sub(r'%(\1)s', code)
+
+	env = tsk.env
+	di = getattr(tsk, 'dict', {}) or getattr(tsk.generator, 'dict', {})
+	if not di:
+		names = m4_re.findall(code)
+		for i in names:
+			di[i] = env.get_flat(i) or env.get_flat(i.upper())
+
+	tsk.outputs[0].write(s % di)
+
+@feature('subst')
+@before_method('process_source')
+def apply_subst(self):
+	Utils.def_attrs(self, fun=subst_func)
+	lst = self.to_list(self.source)
+	self.meths.remove('process_source')
+
+	self.dict = getattr(self, 'dict', {})
+
+	for filename in lst:
+		node = self.path.find_resource(filename)
+		if not node: raise Errors.WafError('cannot find input file %s for processing' % filename)
+
+		if self.target:
+			newnode = self.path.find_or_declare(self.target)
+		else:
+			newnode = node.change_ext('')
+
+		try:
+			self.dict = self.dict.get_merged_dict()
+		except AttributeError:
+			pass
+
+		if self.dict and not self.env['DICT_HASH']:
+			self.env = self.env.derive()
+			keys = list(self.dict.keys())
+			keys.sort()
+			lst = [self.dict[x] for x in keys]
+			self.env['DICT_HASH'] = str(Utils.h_list(lst))
+
+		tsk = self.create_task('copy', node, newnode)
+		tsk.fun = self.fun
+		tsk.dict = self.dict
+		tsk.dep_vars = ['DICT_HASH']
+		tsk.chmod = getattr(self, 'chmod', Utils.O644)
+
+		if not tsk.env:
+			tsk.debug()
+			raise Errors.WafError('task without an environment')
+
+####################
+## command-output ####
+####################
+
+class cmd_arg(object):
+	"""command-output arguments for representing files or folders"""
+	def __init__(self, name, template='%s'):
+		self.name = name
+		self.template = template
+		self.node = None
+
+class input_file(cmd_arg):
+	def find_node(self, base_path):
+		assert isinstance(base_path, Node.Node)
+		self.node = base_path.find_resource(self.name)
+		if self.node is None:
+			raise Errors.WafError("Input file %s not found in " % (self.name, base_path))
+
+	def get_path(self, env, absolute):
+		if absolute:
+			return self.template % self.node.abspath()
+		else:
+			return self.template % self.node.srcpath()
+
+class output_file(cmd_arg):
+	def find_node(self, base_path):
+		assert isinstance(base_path, Node.Node)
+		self.node = base_path.find_or_declare(self.name)
+		if self.node is None:
+			raise Errors.WafError("Output file %s not found in " % (self.name, base_path))
+
+	def get_path(self, env, absolute):
+		if absolute:
+			return self.template % self.node.abspath()
+		else:
+			return self.template % self.node.bldpath()
+
+class cmd_dir_arg(cmd_arg):
+	def find_node(self, base_path):
+		assert isinstance(base_path, Node.Node)
+		self.node = base_path.find_dir(self.name)
+		if self.node is None:
+			raise Errors.WafError("Directory %s not found in " % (self.name, base_path))
+
+class input_dir(cmd_dir_arg):
+	def get_path(self, dummy_env, dummy_absolute):
+		return self.template % self.node.abspath()
+
+class output_dir(cmd_dir_arg):
+	def get_path(self, env, dummy_absolute):
+		return self.template % self.node.abspath()
+
+
+class command_output(Task.Task):
+	color = "BLUE"
+	def __init__(self, env, command, command_node, command_args, stdin, stdout, cwd, os_env, stderr):
+		Task.Task.__init__(self, env=env)
+		assert isinstance(command, (str, Node.Node))
+		self.command = command
+		self.command_args = command_args
+		self.stdin = stdin
+		self.stdout = stdout
+		self.cwd = cwd
+		self.os_env = os_env
+		self.stderr = stderr
+
+		if command_node is not None: self.dep_nodes = [command_node]
+		self.dep_vars = [] # additional environment variables to look
+
+	def run(self):
+		task = self
+		#assert len(task.inputs) > 0
+
+		def input_path(node, template):
+			if task.cwd is None:
+				return template % node.bldpath()
+			else:
+				return template % node.abspath()
+		def output_path(node, template):
+			fun = node.abspath
+			if task.cwd is None: fun = node.bldpath
+			return template % fun()
+
+		if isinstance(task.command, Node.Node):
+			argv = [input_path(task.command, '%s')]
+		else:
+			argv = [task.command]
+
+		for arg in task.command_args:
+			if isinstance(arg, str):
+				argv.append(arg)
+			else:
+				assert isinstance(arg, cmd_arg)
+				argv.append(arg.get_path(task.env, (task.cwd is not None)))
+
+		if task.stdin:
+			stdin = open(input_path(task.stdin, '%s'))
+		else:
+			stdin = None
+
+		if task.stdout:
+			stdout = open(output_path(task.stdout, '%s'), "w")
+		else:
+			stdout = None
+
+		if task.stderr:
+			stderr = open(output_path(task.stderr, '%s'), "w")
+		else:
+			stderr = None
+
+		if task.cwd is None:
+			cwd = ('None (actually %r)' % os.getcwd())
+		else:
+			cwd = repr(task.cwd)
+		debug("command-output: cwd=%s, stdin=%r, stdout=%r, argv=%r" %
+			     (cwd, stdin, stdout, argv))
+
+		if task.os_env is None:
+			os_env = os.environ
+		else:
+			os_env = task.os_env
+		command = Utils.subprocess.Popen(argv, stdin=stdin, stdout=stdout, stderr=stderr, cwd=task.cwd, env=os_env)
+		return command.wait()
+
+@feature('command-output')
+def init_cmd_output(self):
+	Utils.def_attrs(self,
+		stdin = None,
+		stdout = None,
+		stderr = None,
+		# the command to execute
+		command = None,
+
+		# whether it is an external command; otherwise it is assumed
+		# to be an executable binary or script that lives in the
+		# source or build tree.
+		command_is_external = False,
+
+		# extra parameters (argv) to pass to the command (excluding
+		# the command itself)
+		argv = [],
+
+		# dependencies to other objects -> this is probably not what you want (ita)
+		# values must be 'task_gen' instances (not names!)
+		dependencies = [],
+
+		# dependencies on env variable contents
+		dep_vars = [],
+
+		# input files that are implicit, i.e. they are not
+		# stdin, nor are they mentioned explicitly in argv
+		hidden_inputs = [],
+
+		# output files that are implicit, i.e. they are not
+		# stdout, nor are they mentioned explicitly in argv
+		hidden_outputs = [],
+
+		# change the subprocess to this cwd (must use obj.input_dir() or output_dir() here)
+		cwd = None,
+
+		# OS environment variables to pass to the subprocess
+		# if None, use the default environment variables unchanged
+		os_env = None)
+
+@feature('command-output')
+@after_method('init_cmd_output')
+def apply_cmd_output(self):
+	if self.command is None:
+		raise Errors.WafError("command-output missing command")
+	if self.command_is_external:
+		cmd = self.command
+		cmd_node = None
+	else:
+		cmd_node = self.path.find_resource(self.command)
+		assert cmd_node is not None, ('''Could not find command '%s' in source tree.
+Hint: if this is an external command,
+use command_is_external=True''') % (self.command,)
+		cmd = cmd_node
+
+	if self.cwd is None:
+		cwd = None
+	else:
+		assert isinstance(cwd, CmdDirArg)
+		self.cwd.find_node(self.path)
+
+	args = []
+	inputs = []
+	outputs = []
+
+	for arg in self.argv:
+		if isinstance(arg, cmd_arg):
+			arg.find_node(self.path)
+			if isinstance(arg, input_file):
+				inputs.append(arg.node)
+			if isinstance(arg, output_file):
+				outputs.append(arg.node)
+
+	if self.stdout is None:
+		stdout = None
+	else:
+		assert isinstance(self.stdout, str)
+		stdout = self.path.find_or_declare(self.stdout)
+		if stdout is None:
+			raise Errors.WafError("File %s not found" % (self.stdout,))
+		outputs.append(stdout)
+
+	if self.stderr is None:
+		stderr = None
+	else:
+		assert isinstance(self.stderr, str)
+		stderr = self.path.find_or_declare(self.stderr)
+		if stderr is None:
+			raise Errors.WafError("File %s not found" % (self.stderr,))
+		outputs.append(stderr)
+
+	if self.stdin is None:
+		stdin = None
+	else:
+		assert isinstance(self.stdin, str)
+		stdin = self.path.find_resource(self.stdin)
+		if stdin is None:
+			raise Errors.WafError("File %s not found" % (self.stdin,))
+		inputs.append(stdin)
+
+	for hidden_input in self.to_list(self.hidden_inputs):
+		node = self.path.find_resource(hidden_input)
+		if node is None:
+			raise Errors.WafError("File %s not found in dir %s" % (hidden_input, self.path))
+		inputs.append(node)
+
+	for hidden_output in self.to_list(self.hidden_outputs):
+		node = self.path.find_or_declare(hidden_output)
+		if node is None:
+			raise Errors.WafError("File %s not found in dir %s" % (hidden_output, self.path))
+		outputs.append(node)
+
+	if not (inputs or getattr(self, 'no_inputs', None)):
+		raise Errors.WafError('command-output objects must have at least one input file or give self.no_inputs')
+	if not (outputs or getattr(self, 'no_outputs', None)):
+		raise Errors.WafError('command-output objects must have at least one output file or give self.no_outputs')
+
+	cwd = self.bld.variant_dir
+	task = command_output(self.env, cmd, cmd_node, self.argv, stdin, stdout, cwd, self.os_env, stderr)
+	task.generator = self
+	copy_attrs(self, task, 'before after ext_in ext_out', only_if_set=True)
+	self.tasks.append(task)
+
+	task.inputs = inputs
+	task.outputs = outputs
+	task.dep_vars = self.to_list(self.dep_vars)
+
+	for dep in self.dependencies:
+		assert dep is not self
+		dep.post()
+		for dep_task in dep.tasks:
+			task.set_run_after(dep_task)
+
+	if not task.inputs:
+		# the case for svnversion, always run, and update the output nodes
+		task.runnable_status = type(Task.TaskBase.run)(runnable_status, task, task.__class__) # always run
+		task.post_run = type(Task.TaskBase.run)(post_run, task, task.__class__)
+
+	# TODO the case with no outputs?
+
+def post_run(self):
+	for x in self.outputs:
+		x.sig = Utils.h_file(x.abspath())
+
+def runnable_status(self):
+	return self.RUN_ME
+
+Task.task_factory('copy', vars=[], func=action_process_file_func)
+


### PR DESCRIPTION
These changes allowed me to successfully build ardour using the most recent waf (2.0.19).
Some of them might be weird and will probably need refactoring now or later.

The [misc.py](https://gitlab.com/ita1024/waf/raw/waf-1.6.11/waflib/extras/misc.py) script is the only fragment from the currently used waf (1.6.11), that is *required* because of includes to build ardour (and when/if updating the compiled version of waf in this repo, it *has to be added*). However, its use should be refactored and removed after this pull request is merged.

All of this should still work with the current waf setup!
Note: On Arch Linux I'm using a [system-wide waf](https://www.archlinux.org/packages/community/any/waf/), but this workflow should work with the upstream waf just the same (after all, I'm only telling it where its components are through packaging).

Now, to how I made this build (after applying the changes in this pull request):

```
  # making sure, that subdirectories can be picked up with local includes
  touch __init__.py
  # making ancient 'misc' include available to system installed waf                        
  sed -e "s/('misc')/('misc', tooldir='tools')/" \                       
      -i {tools/luadevel,gtk2_ardour,session_utils,libs/fst,headless}/wscript             
  # make custom 'autowaf' include compatible with system installed waf
  find . -type f \                                      
         -iname "*wscript*" \                            
         -exec sed -e 's/from waflib.extras import autowaf/from tools import autowaf/g' \  
                   -e 's/import waflib.extras.autowaf/from tools import autowaf/g' \
                   -i {} \;
```

These should be all required changes to test this with a system installed waf and incorporating the old `misc.py`. The `autowaf.py` in use is still in place below `tools/`.
Aftwards the usual `waf configure`, `waf build` and `waf install` (+ parameters) applies.