### PR TITLE
Fix thread-safety issue in a-fluidsynth.

### DIFF
--- a/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
+++ b/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
@@ -514,7 +514,7 @@ run (LV2_Handle instance, uint32_t n_samples)
 			}
 		}
 		else if (ev->body.type == self->midi_MidiEvent) {
-			if (ev->body.size > 3 || ev->time.frames >= n_samples) {
+			if (ev->body.size > 3 || ev->time.frames >= n_samples || self->reinit_in_progress) {
 				continue;
 			}
 


### PR DESCRIPTION
This fix ensures that the a-fluidsynth "synth" object is not used in two threads at the same time during midi event handling (run() in RT thread vs. load_sf2() in worker thread), which could result in crashes.