### PR TITLE
Do not let transport_table grow wider than necessary

### DIFF
--- a/gtk2_ardour/ardour_ui2.cc
+++ b/gtk2_ardour/ardour_ui2.cc
@@ -429,6 +429,7 @@ ARDOUR_UI::setup_transport ()
 	transport_table.set_spacings (0);
 	transport_table.set_row_spacings (4);
 	transport_table.set_border_width (0);
+	transport_table.set_size_request (0, -1);
 
 	transport_frame.set_name ("TransportFrame");
 	transport_frame.set_shadow_type (Gtk::SHADOW_NONE);


### PR DESCRIPTION
1. Set screen resolution to 1024x768
2. Open Ardour
3. Maximize window to fit screen
4. Save session and exit
5. Reopen Ardour
6. Window width is larger than the expected 1024px

This patch helps restoring the correct main window geometry on a small screen.
