### PR TITLE
tools: make ardour.keys generation reproducible

### DIFF
--- a/tools/fmt-bindings
+++ b/tools/fmt-bindings
@@ -309,7 +309,7 @@ while (<SOURCE>) {
 if ($make_accelmap) {
     print "<BindingSet name=\"" . $bindings_name . "\">\n";
     
-    foreach $owner (keys %owner_bindings) {
+    foreach $owner (sort keys %owner_bindings) {
 	print " <Bindings name=\"$owner\">\n  <Press>\n";
 	$bindings = $owner_bindings{$owner};
 	shift (@$bindings); # remove initial empty element


### PR DESCRIPTION
By default perl hashes are random when iterating over them this makes
ardour not reproducible. As it ships with a random order generated
ardour.keys file, simply sorting the keys before iterating over them
makes the file reproducible.

Motivation: https://reproducible-builds.org