### PR TITLE
Find fmt-binding when building out of source tree

### DIFF
--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -897,7 +897,7 @@ def build(bld):
     # NATIVE ARDOUR BINDING FILES
     # explicitly state the use of perl here so that it works on windows too
     #
-    a_rule = 'perl ../tools/fmt-bindings --platform="%s" --winkey="%s" --accelmap ${SRC[0].abspath()} >${TGT}' % (sys.platform, bld.env['WINDOWS_KEY'] )
+    a_rule = 'perl %s/tools/fmt-bindings --platform="%s" --winkey="%s" --accelmap ${SRC[0].abspath()} >${TGT}' % (bld.top_dir, sys.platform, bld.env['WINDOWS_KEY'] )
     for b in [ 'ardour' ] :
         obj = bld(
             target = b + '.keys',


### PR DESCRIPTION
Note that I tested that with backported waf upgrade (no OSX) [1] on 5.12.

[1] https://github.com/schnitzeltony/meta-musicians/tree/master/recipes-musicians/ardour/ardour5/waf-backport