### PR TITLE
LCXL: Adopt pan knob behaviour

### DIFF
--- a/libs/surfaces/launch_control_xl/controllers.cc
+++ b/libs/surfaces/launch_control_xl/controllers.cc
@@ -879,8 +879,9 @@ LaunchControlXL::knob_pan(uint8_t n)
 	}
 
 
-	if (ac && check_pick_up(knob, ac)) {
-		ac->set_value ( ac->interface_to_internal( knob->value() / 127.0), PBD::Controllable::UseGroup );
+	if (ac && check_pick_up_rev(knob, ac)) {
+	DEBUG_TRACE (DEBUG::LaunchControlXL, string_compose("knob->value: '%1'\n", (int) knob->value() ));
+		ac->set_value ( ac->interface_to_internal((127 - knob->value()) / 127.0), PBD::Controllable::UseGroup );
 	}
 }
 

--- a/libs/surfaces/launch_control_xl/launch_control_xl.cc
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.cc
@@ -620,6 +620,13 @@ LaunchControlXL::check_pick_up(boost::shared_ptr<Controller> controller, boost::
 	return ( abs( controller->value() / 127.0 -  ac->internal_to_interface(ac->get_value()) ) < 0.007875 );
 }
 
+bool
+LaunchControlXL::check_pick_up_rev(boost::shared_ptr<Controller> controller, boost::shared_ptr<AutomationControl> ac)
+{
+	/* returns false until 127 minus the controller value matches with the current setting of the stripable's ac */
+	return ( abs( (127 - controller->value()) / 127.0  - ac->internal_to_interface(ac->get_value()) ) < 0.007875);
+}
+
 void
 LaunchControlXL::handle_midi_controller_message (MIDI::Parser& parser, MIDI::EventTwoBytes* ev, MIDI::channel_t chan)
 {

--- a/libs/surfaces/launch_control_xl/launch_control_xl.h
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.h
@@ -496,6 +496,8 @@ private:
 	void handle_button_message(boost::shared_ptr<Button> button, MIDI::EventTwoBytes *);
 
 	bool check_pick_up(boost::shared_ptr<Controller> controller, boost::shared_ptr<ARDOUR::AutomationControl> ac);
+	bool check_pick_up_rev(boost::shared_ptr<Controller> controller, boost::shared_ptr<ARDOUR::AutomationControl> ac);
+
 
 	void handle_midi_controller_message(MIDI::Parser &, MIDI::EventTwoBytes *, MIDI::channel_t chan);
 	void handle_midi_note_on_message(MIDI::Parser &, MIDI::EventTwoBytes *, MIDI::channel_t chan);


### PR DESCRIPTION
    * "left/right" changed in A6, adopt for this
    * add a pick_up_rev function to honour this