### PR TITLE
LCXL: make sends assignable for 32C

### DIFF
--- a/libs/surfaces/launch_control_xl/gui.cc
+++ b/libs/surfaces/launch_control_xl/gui.cc
@@ -126,6 +126,18 @@ LCXLGUI::LCXLGUI (LaunchControlXL& p)
 	row++;
 
 	/* User Settings */
+#ifdef MIXBUS32C
+	l = manage (new Gtk::Label (_("Control sends 7-12 in Mixer Mode")));
+	l->set_alignment (1.0, 0.5);
+	table.attach (*l, 0, 1, row, row+1, AttachOptions(FILL|EXPAND), AttachOptions (0));
+	align = manage (new Alignment);
+	align->set (0.0, 0.5);
+	align->add (ctrllowersends_button);
+	table.attach (*align, 1, 2, row, row+1, AttachOptions(FILL|EXPAND), AttachOptions (0),0,0);
+	ctrllowersends_button.set_active (lcxl.ctrllowersends());
+	ctrllowersends_button.signal_toggled().connect (sigc::mem_fun (*this, &LCXLGUI::toggle_ctrllowersends));
+	row++;
+#endif
 
 	l = manage (new Gtk::Label (_("Fader 8 Master")));
 	l->set_alignment (1.0, 0.5);
@@ -289,3 +301,13 @@ LCXLGUI::toggle_fader8master ()
 	lcxl.set_fader8master (!lcxl.fader8master());
 	DEBUG_TRACE(DEBUG::LaunchControlXL, string_compose("use_fader8master IS: %1\n", lcxl.fader8master()));
 }
+
+#ifdef MIXBUS32C
+void
+LCXLGUI::toggle_ctrllowersends ()
+{
+	DEBUG_TRACE(DEBUG::LaunchControlXL, string_compose("ctrllowersends WAS: %1\n", lcxl.ctrllowersends()));
+	lcxl.set_ctrllowersends (!lcxl.ctrllowersends());
+	DEBUG_TRACE(DEBUG::LaunchControlXL, string_compose("ctrllowersends IS: %1\n", lcxl.ctrllowersends()));
+}
+#endif

--- a/libs/surfaces/launch_control_xl/gui.h
+++ b/libs/surfaces/launch_control_xl/gui.h
@@ -50,6 +50,7 @@ public:
 	~LCXLGUI ();
 
 	void toggle_fader8master ();
+	void toggle_ctrllowersends ();
 
 private:
 	LaunchControlXL& lcxl;
@@ -61,6 +62,7 @@ private:
 	Gtk::ComboBox output_combo;
 	Gtk::Image    image;
 	Gtk::CheckButton fader8master_button;
+	Gtk::CheckButton ctrllowersends_button;
 
 	void update_port_combos ();
 	PBD::ScopedConnection connection_change_connection;

--- a/libs/surfaces/launch_control_xl/launch_control_xl.cc
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.cc
@@ -80,6 +80,7 @@ LaunchControlXL::LaunchControlXL (ARDOUR::Session& s)
 	, _fader8master (false)
 	, _device_mode (false)
 #ifdef MIXBUS32C
+	, _ctrllowersends (false)
 	, _fss_is_mixbus (false)
 #endif
 	, _refresh_leds_flag (false)
@@ -164,6 +165,11 @@ LaunchControlXL::begin_using_device ()
 	if (fader8master()) {
 		set_fader8master (fader8master());
 	}
+#ifdef MIXBUS32C
+	if (ctrllowersends()) {
+		set_ctrllowersends (ctrllowersends());
+	}
+#endif
 
 	return 0;
 }
@@ -770,6 +776,9 @@ LaunchControlXL::get_state()
 
 	child = new XMLNode (X_("Configuration"));
 	child->set_property ("fader8master", fader8master());
+#ifdef MIXBUS32C
+	child->set_property ("ctrllowersends", ctrllowersends());
+#endif
 	node.add_child_nocopy (*child);
 
 	return node;
@@ -805,6 +814,9 @@ LaunchControlXL::set_state (const XMLNode & node, int version)
 	if ((child = node.child (X_("Configuration"))) !=0) {
 		/* this should propably become a for-loop at some point */
 		child->get_property ("fader8master", _fader8master);
+#ifdef MIXBUS32C
+		child->get_property ("ctrllowersends", _ctrllowersends);
+#endif
 	}
 
 	return retval;
@@ -1242,6 +1254,7 @@ LaunchControlXL::init_device_mode()
 	init_knobs();
 	init_buttons(false);
 #ifdef MIXBUS32C
+	set_ctrllowersends(false);
 	store_fss_type();
 #endif
 	init_dm_callbacks();
@@ -1307,6 +1320,9 @@ LaunchControlXL::set_device_mode (bool yn)
 	if (device_mode()) {
 		init_device_mode();
 	} else {
+#ifdef MIXBUS32C
+		set_ctrllowersends(ctrllowersends());
+#endif
 		switch_bank (bank_start);
 	}
 }
@@ -1330,10 +1346,37 @@ LaunchControlXL::set_fader8master (bool yn)
 	switch_bank (bank_start);
 }
 
+#ifdef MIXBUS32C
+void
+LaunchControlXL::set_ctrllowersends (bool yn)
+{
+
+	_ctrllowersends = yn;
+
+	if (device_mode()) { return; }
+
+	/* reinit the send bank */
+	if (_ctrllowersends) {
+		_send_bank_base = 6;
+	} else {
+		_send_bank_base = 0;
+	}
+	set_send_bank(0);
+}
+#endif
+
 void
 LaunchControlXL::set_send_bank (int offset)
 {
-	if ((_send_bank_base == 0 && offset < 0) || (_send_bank_base == 4 && offset > 0)) {
+
+	int lowersendsoffset = 0;
+
+#ifdef MIXBUS32C
+	if (ctrllowersends() && !device_mode()) {
+		lowersendsoffset = 6;
+	}
+#endif
+	if ((_send_bank_base == (0 + lowersendsoffset)  && offset < 0) || (_send_bank_base == (4 + lowersendsoffset) && offset > 0)) {
 		return;
 	}
 
@@ -1348,7 +1391,7 @@ LaunchControlXL::set_send_bank (int offset)
 	}
 
 	_send_bank_base = _send_bank_base + offset;
-	_send_bank_base = max (0, min (4, _send_bank_base));
+	_send_bank_base = max (0 + lowersendsoffset, min (4 + lowersendsoffset, _send_bank_base));
 
 	DEBUG_TRACE (DEBUG::LaunchControlXL, string_compose ("set_send_bank - _send_bank_base: %1 \n", send_bank_base()));
 
@@ -1366,16 +1409,22 @@ LaunchControlXL::set_send_bank (int offset)
 	switch (_send_bank_base) {
 		case 0:
 		case 1:
+		case 6:
+		case 7:
 			write (sbu->state_msg(false));
 			write (sbd->state_msg(true));
 			break;
 		case 2:
 		case 3:
+		case 8:
+		case 9:
 			write (sbu->state_msg(true));
 			write (sbd->state_msg(true));
 			break;
 		case 4:
 		case 5:
+		case 10:
+		case 11:
 			write (sbu->state_msg(true));
 			write (sbd->state_msg(false));
 			break;

--- a/libs/surfaces/launch_control_xl/launch_control_xl.h
+++ b/libs/surfaces/launch_control_xl/launch_control_xl.h
@@ -396,6 +396,9 @@ public:
 	bool device_mode () const { return _device_mode; }
 
 #ifdef MIXBUS32C
+	void set_ctrllowersends (bool yn);
+	bool ctrllowersends () const { return _ctrllowersends; }
+
 	void store_fss_type();
 	bool fss_is_mixbus() const { return _fss_is_mixbus; }
 #endif
@@ -416,6 +419,7 @@ private:
 	bool _fader8master;
 	bool _device_mode;
 #ifdef MIXBUS32C
+	bool _ctrllowersends;
 	bool _fss_is_mixbus;
 #endif
 	bool _refresh_leds_flag;


### PR DESCRIPTION
    * add an option to the controller configuration gui
      to assign the 3x2 send banks in mixer mode
      to either the upper (1-6) or lower (7-12) Mixbus sends
    * This was a user request to better support the workflow
      of the CoMondo Mix system