### PR TITLE
Reject HTTP connections to the websockets surface

### DIFF
--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -411,9 +411,11 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 		case LWS_CALLBACK_UNLOCK_POLL:
 		case LWS_CALLBACK_WS_PEER_INITIATED_CLOSE:
 		case LWS_CALLBACK_FILTER_HTTP_CONNECTION:
+#if LWS_LIBRARY_VERSION_MAJOR >= 3
 		case LWS_CALLBACK_HTTP_BIND_PROTOCOL:
 		case LWS_CALLBACK_ADD_HEADERS:
 		case LWS_CALLBACK_HTTP_CONFIRM_UPGRADE:
+#endif
 			break;
 
 		/* TODO: handle HTTP connections.

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -295,6 +295,14 @@ WebsocketsServer::write_client (Client wsi)
 	}
 }
 
+void
+WebsocketsServer::reject_http_client (Client wsi)
+{
+	const char *html_body = "<p>This URL is not meant to be accessed via HTTP; for example using"
+		" a web browser. Refer to Ardour documentation for further information.</p>";
+	lws_return_http_status (wsi, 404, html_body);
+}
+
 bool
 WebsocketsServer::io_handler (Glib::IOCondition ioc, lws_sockfd_type fd)
 {
@@ -388,6 +396,10 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 			server->write_client (wsi);
 			break;
 
+		case LWS_CALLBACK_HTTP:
+			server->reject_http_client (wsi);
+			break;
+
 		case LWS_CALLBACK_FILTER_NETWORK_CONNECTION:
 		case LWS_CALLBACK_FILTER_PROTOCOL_CONNECTION:
 		case LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED:
@@ -398,6 +410,10 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 		case LWS_CALLBACK_LOCK_POLL:
 		case LWS_CALLBACK_UNLOCK_POLL:
 		case LWS_CALLBACK_WS_PEER_INITIATED_CLOSE:
+		case LWS_CALLBACK_FILTER_HTTP_CONNECTION:
+		case LWS_CALLBACK_HTTP_BIND_PROTOCOL:
+		case LWS_CALLBACK_ADD_HEADERS:
+		case LWS_CALLBACK_HTTP_CONFIRM_UPGRADE:
 			break;
 
 		/* TODO: handle HTTP connections.

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -398,6 +398,7 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 
 		case LWS_CALLBACK_HTTP:
 			server->reject_http_client (wsi);
+			return 1;
 			break;
 
 		case LWS_CALLBACK_FILTER_NETWORK_CONNECTION:

--- a/libs/surfaces/websockets/server.h
+++ b/libs/surfaces/websockets/server.h
@@ -81,6 +81,7 @@ private:
 	void del_client (Client);
 	void recv_client (Client, void* buf, size_t len);
 	void write_client (Client);
+	void reject_http_client (Client);
 
 	bool io_handler (Glib::IOCondition, lws_sockfd_type);
 


### PR DESCRIPTION
According discussion on the IRC channel some users tried to connect to the websockets surface using a web browser. The surface currently does not serve any content over HTTP; to avoid confusion this patch detects HTTP connections and sends back a meaningful error message.
