### PR TITLE
Remove redundant AZERTY Virtual MIDI Keyboard Layout

### DIFF
--- a/gtk2_ardour/rc_option_editor.cc
+++ b/gtk2_ardour/rc_option_editor.cc
@@ -2908,7 +2908,6 @@ RCOptionEditor::RCOptionEditor ()
 	vkeybdlayout->add ("QWERTY", _("QWERTY"));
 	vkeybdlayout->add ("QWERTZ", _("QWERTZ"));
 	vkeybdlayout->add ("AZERTY", _("AZERTY"));
-	vkeybdlayout->add ("AZERTY", _("AZERTY"));
 	vkeybdlayout->add ("DVORAK", _("DVORAK"));
 	vkeybdlayout->add ("QWERTY Single", _("QWERTY Single"));
 	vkeybdlayout->add ("QWERTZ Single", _("QWERTZ Single"));


### PR DESCRIPTION
In the `Ardour - Preference` screen, `Editor->MIDI->Virtual Keyboard` section, `AZERTY` was offered twice in the `Virtual Keyboard Layout` dropdown menu.