### PR TITLE
Add a JavaScript client library for the WebSockets surface

### DIFF
--- a/libs/surfaces/websockets/manifest.cc
+++ b/libs/surfaces/websockets/manifest.cc
@@ -54,10 +54,12 @@ SurfaceManifest::SurfaceManifest (std::string path)
 			_name = value;
 		} else if (name == "Description") {
 			_description = value;
+		} else if (name == "Version") {
+			_version = value;
 		}
 	}
 
-	if (_name.empty () || _description.empty ()) {
+	if (_name.empty () || _description.empty () || _version.empty ()) {
 #ifndef NDEBUG
 		std::cerr << "SurfaceManifest: missing properties in " << xml_path << std::endl;
 #endif
@@ -76,6 +78,7 @@ SurfaceManifest::to_json ()
 		<< "\"path\":\"" << Glib::path_get_basename (_path) << "\""
 		<< ",\"name\":\"" << _name << "\""
 		<< ",\"description\":\"" << _description << "\""
+		<< ",\"version\":\"" << _version << "\""
 		<< "}";
 
 	return ss.str ();

--- a/libs/surfaces/websockets/manifest.h
+++ b/libs/surfaces/websockets/manifest.h
@@ -24,7 +24,7 @@
 class SurfaceManifest
 {
 public:
-	// all ardour control surfaces store presets in xml format
+	// all ardour control surfaces implement presets using xml format
 	SurfaceManifest (std::string);
 
 	bool valid () { return _valid; }
@@ -32,6 +32,7 @@ public:
 	std::string path () { return _path; }
 	std::string name () { return _name; }
 	std::string description () { return _description; }
+	std::string version () { return _version; }
 
 	std::string to_json ();
 
@@ -43,6 +44,7 @@ private:
 	std::string _path;
 	std::string _name;
 	std::string _description;
+	std::string _version;
 };
 
 #endif // _ardour_surface_websockets_manifest_h_

--- a/libs/surfaces/websockets/resources.cc
+++ b/libs/surfaces/websockets/resources.cc
@@ -84,7 +84,7 @@ ServerResources::scan ()
 	SurfaceManifestVector builtin = read_manifests (builtin_dir_str);
 
 	ss << "[{"
-		<< "\"diskPath\":\"" << builtin_dir_str << "\""
+		<< "\"filesystemPath\":\"" << builtin_dir_str << "\""
 		<< ",\"path\":\"" << builtin_dir_name << "\""
 		<< ",\"surfaces\":"
 		<< "[";
@@ -100,7 +100,7 @@ ServerResources::scan ()
 	SurfaceManifestVector user = read_manifests (user_dir_str);
 
 	ss << "]},{" 
-		<< "\"diskPath\":\"" << user_dir_str << "\""
+		<< "\"filesystemPath\":\"" << user_dir_str << "\""
 		<< ",\"path\":\"" << user_dir_name << "\"" 
 		<< ",\"surfaces\":" 
 		<< "[";

--- a/libs/surfaces/websockets/resources.cc
+++ b/libs/surfaces/websockets/resources.cc
@@ -80,7 +80,7 @@ ServerResources::scan ()
 {
 	std::stringstream ss;
 
-	std::string builtin_dir_str   = builtin_dir ();
+	std::string builtin_dir_str   = PBD::canonical_path (builtin_dir ());
 	SurfaceManifestVector builtin = read_manifests (builtin_dir_str);
 
 	ss << "[{"
@@ -96,7 +96,7 @@ ServerResources::scan ()
 		}
 	}
 
-	std::string user_dir_str   = user_dir ();
+	std::string user_dir_str   = PBD::canonical_path (user_dir ());
 	SurfaceManifestVector user = read_manifests (user_dir_str);
 
 	ss << "]},{" 

--- a/libs/surfaces/websockets/resources.cc
+++ b/libs/surfaces/websockets/resources.cc
@@ -125,7 +125,7 @@ ServerResources::server_data_dir ()
 	bool defined = false;
 	std::string env_dir (Glib::getenv (data_dir_env_var, defined));
 
-	if (defined) {
+	if (defined && !env_dir.empty ()) {
 		/* useful for development */
 		data_dir = env_dir;
 	} else {

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -333,7 +333,7 @@ WebsocketsServer::write_client (Client wsi)
 }
 
 int
-WebsocketsServer::send_index_hdr (Client wsi)
+WebsocketsServer::send_availsurf_hdr (Client wsi)
 {
 	char url[1024];
 
@@ -384,7 +384,7 @@ WebsocketsServer::send_index_hdr (Client wsi)
 }
 
 int
-WebsocketsServer::send_index_body (Client wsi)
+WebsocketsServer::send_availsurf_body (Client wsi)
 {
 	std::string index = _resources.scan ();
 
@@ -505,13 +505,13 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 			break;
 
 		/* will be called only if the requested url is not fulfilled
-		   by the any of the mount configurations (index, builtin, user) */
+		   by the any of the mount configurations (builtin, user) */
 		case LWS_CALLBACK_HTTP:
-			rc = server->send_index_hdr (wsi);
+			rc = server->send_availsurf_hdr (wsi);
 			break;
 
 		case LWS_CALLBACK_HTTP_WRITEABLE:
-			rc = server->send_index_body (wsi);
+			rc = server->send_availsurf_body (wsi);
 			break;
 
 		case LWS_CALLBACK_CLOSED_HTTP:

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -341,7 +341,7 @@ WebsocketsServer::send_index_hdr (Client wsi)
 		return 1;
 	}
 
-	if (strcmp (url, "/index.json") != 0) {
+	if (strcmp (url, "/surfaces.json") != 0) {
 		lws_return_http_status (wsi, 404, 0);
 		return 1;
 	}

--- a/libs/surfaces/websockets/server.h
+++ b/libs/surfaces/websockets/server.h
@@ -86,8 +86,8 @@ private:
 	int del_client (Client);
 	int recv_client (Client, void*, size_t);
 	int write_client (Client);
-	int send_index_hdr (Client);
-	int send_index_body (Client);
+	int send_availsurf_hdr (Client);
+	int send_availsurf_body (Client);
 
 	bool io_handler (Glib::IOCondition, lws_sockfd_type);
 

--- a/share/web_surfaces/builtin/mixer-demo/css/main.css
+++ b/share/web_surfaces/builtin/mixer-demo/css/main.css
@@ -31,6 +31,7 @@ div {
     height: 6em;
     overflow: scroll;
     overflow-x: hidden;
+    background: rgba(0,0,0,0.4);
 }
 
 #log pre {
@@ -75,7 +76,6 @@ div {
     margin: 5%;
     padding: 2.5% 5%;
     background: rgba(0,0,0,0.05);
-    border: solid 1px rgba(255,255,255,0.1);
     border-radius: 5px;
 }
 

--- a/share/web_surfaces/builtin/mixer-demo/css/main.css
+++ b/share/web_surfaces/builtin/mixer-demo/css/main.css
@@ -27,6 +27,12 @@ div {
     box-shadow: 0px 0px 10px #000;
 }
 
+#manifest {
+    padding: 0.25em 0.5em;
+    opacity: 0.5;
+    background: rgba(0,0,0,0.4);
+}
+
 #log {
     height: 6em;
     overflow: scroll;

--- a/share/web_surfaces/builtin/mixer-demo/index.html
+++ b/share/web_surfaces/builtin/mixer-demo/index.html
@@ -8,6 +8,7 @@
     </head>
     <body>
         <div id="main">
+            <div id="manifest"></div>
             <div id="strips"></div>
             <div id="log"></div>
         </div>

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -38,26 +38,28 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
     main();
 
     function main () {
-        ardour.messageCallback = (msg) => {
-            log(`↙ ${msg}`, 'message-in');
+        ardour.addCallback({
+            onMessage: (msg) => {
+                log(`↙ ${msg}`, 'message-in');
 
-            if (msg.node == 'strip_desc') {
-                createStrip (msg.addr, ...msg.val);
-            } else if (msg.node == 'strip_plugin_desc') {
-                createStripPlugin (msg.addr, ...msg.val);
-            } else if (msg.node == 'strip_plugin_param_desc') {
-                createStripPluginParam (msg.addr, ...msg.val);
-            } else if (FEEDBACK_NODES.includes(msg.node)) {
-                if (widgets[msg.hash]) {
-                    widgets[msg.hash].value = msg.val[0];
+                if (msg.node == 'strip_desc') {
+                    createStrip (msg.addr, ...msg.val);
+                } else if (msg.node == 'strip_plugin_desc') {
+                    createStripPlugin (msg.addr, ...msg.val);
+                } else if (msg.node == 'strip_plugin_param_desc') {
+                    createStripPluginParam (msg.addr, ...msg.val);
+                } else if (FEEDBACK_NODES.includes(msg.node)) {
+                    if (widgets[msg.hash]) {
+                        widgets[msg.hash].value = msg.val[0];
+                    }
                 }
+            },
+
+            onError: () => {
+                log('Client error', 'error');
             }
-        };
-
-        ardour.errorCallback = () => {
-            log('Client error', 'error');
-        };
-
+        });
+        
         ardour.open();
     }
 

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -19,7 +19,8 @@
  // This example does not call the high level API methods in ardour.js
  // but interacts directly with the low level message stream instead
 
-import { MessageChannel, Message } from '/shared/channel.js';
+import { Message } from '/shared/message.js';
+import { MessageChannel } from '/shared/channel.js';
 
 import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
         StripPanSlider, StripGainSlider, StripMeter } from './widget.js';

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { MessageChannel } from '/shared/channel.js';
+import { MessageChannel, Message } from '/shared/channel.js';
 
 import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
         StripPanSlider, StripGainSlider, StripMeter } from './widget.js';
@@ -33,18 +33,18 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
     main();
 
     function main () {
-        channel.messageCallback = (node, addr, val) => {
-            log(`↙ ${node} (${addr}) = ${val}`, 'message-in');
+        channel.messageCallback = (msg) => {
+            log(`↙ ${msg}`, 'message-in');
 
-            if (node == 'strip_desc') {
-                createStrip (addr, ...val);
-            } else if (node == 'strip_plugin_desc') {
-                createStripPlugin (addr, ...val);
-            } else if (node == 'strip_plugin_param_desc') {
-                createStripPluginParam (addr, ...val);
-            } else if (FEEDBACK_NODES.includes(node)) {
-                if (widgets[[node, addr]]) {
-                    widgets[[node, addr]].value = val[0];
+            if (msg.node == 'strip_desc') {
+                createStrip (msg.addr, ...msg.val);
+            } else if (msg.node == 'strip_plugin_desc') {
+                createStripPlugin (msg.addr, ...msg.val);
+            } else if (msg.node == 'strip_plugin_param_desc') {
+                createStripPluginParam (msg.addr, ...msg.val);
+            } else if (FEEDBACK_NODES.includes(msg.node)) {
+                if (widgets[[msg.node, msg.addr]]) {
+                    widgets[[msg.node, msg.addr]].value = msg.val[0];
                 }
             }
         };
@@ -127,9 +127,9 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
     }
 
     function send (widget) {
-        const val = widget.value;
-        log(`↗ ${widget.node} (${widget.addr}) = ${val}`, 'message-out');
-        channel.send(widget.node, widget.addr, [val]);
+        const msg = new Message(widget.node, widget.addr, [widget.value]);
+        log(`↗ ${msg}`, 'message-out');
+        channel.send(msg);
     }
 
     function createElem (html, parent) {

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { ArdourMessageChannel } from '/shared/channel.js';
+import { MessageChannel } from '/shared/channel.js';
 
 import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
         StripPanSlider, StripGainSlider, StripMeter } from './widget.js';
@@ -27,7 +27,7 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
     const FEEDBACK_NODES = ['strip_gain', 'strip_pan', 'strip_meter', 'strip_plugin_enable',
         'strip_plugin_param_value'];
     
-    const channel = new ArdourMessageChannel(location.host);
+    const channel = new MessageChannel(location.host);
     const widgets = {};
 
     main();

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -38,6 +38,11 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
     main();
 
     function main () {
+        ardour.getSurfaceManifest().then((manifest) => {
+            const div = document.getElementById('manifest');
+            div.innerHTML = `${manifest.name} v${manifest.version}`;
+        });
+
         ardour.addCallback({
             onMessage: (msg) => {
                 log(`↙ ${msg}`, 'message-in');

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -16,8 +16,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
- // This demo does not use the API methods in ardour.js
- // but interacts directly with the message stream
+ // This example does not call the high level API methods in ardour.js
+ // but interacts directly with the low level message stream instead
 
 import { MessageChannel, Message } from '/shared/channel.js';
 

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -43,8 +43,8 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
             } else if (msg.node == 'strip_plugin_param_desc') {
                 createStripPluginParam (msg.addr, ...msg.val);
             } else if (FEEDBACK_NODES.includes(msg.node)) {
-                if (widgets[[msg.node, msg.addr]]) {
-                    widgets[[msg.node, msg.addr]].value = msg.val[0];
+                if (widgets[msg.hash]) {
+                    widgets[msg.hash].value = msg.val[0];
                 }
             }
         };

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -16,6 +16,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+ // This demo does not use the API methods in ardour.js
+ // but interacts directly with the message stream
+
 import { MessageChannel, Message } from '/shared/channel.js';
 
 import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -20,7 +20,7 @@
  // instead it interacts at a lower level by coupling the widgets
  // tightly to the message stream
 
-import { Message } from '/shared/message.js';
+import { ANode, Message } from '/shared/message.js';
 import { Ardour } from '/shared/ardour.js';
 
 import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
@@ -29,8 +29,8 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
 (() => {
 
     const MAX_LOG_LINES = 1000;
-    const FEEDBACK_NODES = ['strip_gain', 'strip_pan', 'strip_meter', 'strip_plugin_enable',
-        'strip_plugin_param_value'];
+    const FEEDBACK_NODES = [ANode.STRIP_GAIN, ANode.STRIP_PAN, ANode.STRIP_METER,
+                            ANode.STRIP_PLUGIN_ENABLE, ANode.STRIP_PLUGIN_PARAM_VALUE];
     
     const ardour = new Ardour(location.host);
     const widgets = {};
@@ -42,11 +42,11 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
             onMessage: (msg) => {
                 log(`↙ ${msg}`, 'message-in');
 
-                if (msg.node == 'strip_desc') {
+                if (msg.node == ANode.STRIP_DESC) {
                     createStrip (msg.addr, ...msg.val);
-                } else if (msg.node == 'strip_plugin_desc') {
+                } else if (msg.node == ANode.STRIP_PLUGIN_DESC) {
                     createStripPlugin (msg.addr, ...msg.val);
-                } else if (msg.node == 'strip_plugin_param_desc') {
+                } else if (msg.node == ANode.STRIP_PLUGIN_PARAM_DESC) {
                     createStripPluginParam (msg.addr, ...msg.val);
                 } else if (FEEDBACK_NODES.includes(msg.node)) {
                     if (widgets[msg.hash]) {

--- a/share/web_surfaces/builtin/mixer-demo/js/widget.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/widget.js
@@ -39,7 +39,7 @@ export class Widget {
     }
 
     get hash () {
-        return [this.node, this.addr];
+        return [this.node].concat(this.addr).join('_');
     }
 
 }

--- a/share/web_surfaces/builtin/mixer-demo/js/widget.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/widget.js
@@ -16,6 +16,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+import { nodeAddressHash } from '/shared/channel.js';
+
 export class Widget {
 
     constructor (node, addr, html) {
@@ -39,7 +41,7 @@ export class Widget {
     }
 
     get hash () {
-        return [this.node].concat(this.addr).join('_');
+        return nodeAddressHash(this.node, this.addr);
     }
 
 }

--- a/share/web_surfaces/builtin/mixer-demo/js/widget.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/widget.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { nodeAddressHash } from '/shared/channel.js';
+import { Message } from '/shared/message.js';
 
 export class Widget {
 
@@ -41,7 +41,7 @@ export class Widget {
     }
 
     get hash () {
-        return nodeAddressHash(this.node, this.addr);
+        return Message.hash(this.node, this.addr);
     }
 
 }

--- a/share/web_surfaces/builtin/mixer-demo/manifest.xml
+++ b/share/web_surfaces/builtin/mixer-demo/manifest.xml
@@ -2,4 +2,5 @@
 <WebSurface>
   <Name value="Mixer Demo"/>
   <Description value="Mixer control capabilities demo aimed at developers"/>
+  <Version value="1.0.0"/>
 </WebSurface>

--- a/share/web_surfaces/builtin/mixer-demo/manifest.xml
+++ b/share/web_surfaces/builtin/mixer-demo/manifest.xml
@@ -2,5 +2,5 @@
 <WebSurface>
   <Name value="Mixer Demo"/>
   <Description value="Mixer control capabilities demo aimed at developers"/>
-  <Version value="1.0.0"/>
+  <Version value="0.0.1"/>
 </WebSurface>

--- a/share/web_surfaces/builtin/transport/manifest.xml
+++ b/share/web_surfaces/builtin/transport/manifest.xml
@@ -2,4 +2,5 @@
 <WebSurface>
   <Name value="Transport"/>
   <Description value="Provides basic transport control (under construction)"/>
+  <Version value="1.0.0"/>
 </WebSurface>

--- a/share/web_surfaces/builtin/transport/manifest.xml
+++ b/share/web_surfaces/builtin/transport/manifest.xml
@@ -2,5 +2,5 @@
 <WebSurface>
   <Name value="Transport"/>
   <Description value="Provides basic transport control (under construction)"/>
-  <Version value="1.0.0"/>
+  <Version value="0.0.1"/>
 </WebSurface>

--- a/share/web_surfaces/index.html
+++ b/share/web_surfaces/index.html
@@ -16,8 +16,8 @@
                 <h2>This page cannot be loaded from a local file</h2>
                 <p>Follow these steps instead:</p>
                 <ul>
-                    <li>Open Ardour</li>
-                    <li>Enable the WebSockets Server surface</li>
+                    <li>Launch Ardour</li>
+                    <li>Enable the WebSockets Server control surface</li>
                     <li>
                         Click on the following link
                         <a href="http://localhost:3818/">http://localhost:3818</a>

--- a/share/web_surfaces/index.html
+++ b/share/web_surfaces/index.html
@@ -15,19 +15,11 @@
             <div id="index" style="display:none">
                 <h1>Available Web Surfaces</h1>
                 <div class="surface-list" id="builtin">
-                    <h2>
-                        Built-In
-                        &emsp;
-                        <span class="disk-path"></span>
-                    </h2>
+                    <h2>Built-In</h2>
                     <ul></ul>
                 </div>
                 <div class="surface-list" id="user">
-                    <h2>
-                        User
-                        &emsp;
-                        <span class="disk-path"></span>
-                    </h2>
+                    <h2>User</h2>
                     <ul></ul>
                 </div>
             </div>

--- a/share/web_surfaces/index.html
+++ b/share/web_surfaces/index.html
@@ -12,6 +12,18 @@
         <div id="content">
             <h2 id="loading">Loading...</h2>
             <pre id="error" style="display:none"></pre>
+            <div id="local" style="display:none">
+                <h2>This page cannot be loaded from a local file</h2>
+                <p>Follow these steps instead:</p>
+                <ul>
+                    <li>Open Ardour</li>
+                    <li>Enable the WebSockets Server surface</li>
+                    <li>
+                        Click on the following link
+                        <a href="http://localhost:3818/">http://localhost:3818</a>
+                    </li>
+                </ul>
+            </div>
             <div id="index" style="display:none">
                 <h1>Available Web Surfaces</h1>
                 <div class="surface-list" id="builtin">
@@ -24,6 +36,12 @@
                 </div>
             </div>
         </div>
+        <script>
+            if (!location.hostname) {
+                document.getElementById('loading').style.display = 'none';
+                document.getElementById('local').style.display = 'inline';
+            }
+        </script>
         <script type="module" src="index/main.js"></script>
     </body>
 </html>

--- a/share/web_surfaces/index/main.css
+++ b/share/web_surfaces/index/main.css
@@ -80,6 +80,11 @@ h2 {
 	margin: 4ex 0;
 }
 
+.surface-version {
+	color: #337ab7;
+	font-size: 0.75em;
+}
+
 .disk-path {
 	font-family: Monaco, monospace;
 	font-size: 0.66em;

--- a/share/web_surfaces/index/main.css
+++ b/share/web_surfaces/index/main.css
@@ -87,6 +87,6 @@ h2 {
 
 .disk-path {
 	font-family: Monaco, monospace;
-	font-size: 0.66em;
-	color: #bbb;
+	font-size: 0.9em;
+	color: #444;
 }

--- a/share/web_surfaces/index/main.css
+++ b/share/web_surfaces/index/main.css
@@ -85,7 +85,7 @@ h2 {
 	font-size: 0.75em;
 }
 
-.disk-path {
+.filesystem-path {
 	font-family: Monaco, monospace;
 	font-size: 0.9em;
 	color: #444;

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -44,6 +44,8 @@ import { Ardour } from '/shared/ardour.js';
                     const li = document.createElement('li');
                     li.innerHTML = `<li>
                         <a href="${group.path}/${surface.path}/">${surface.name}</a>
+                        &thinsp;
+                        <span class="surface-version">(${surface.version})</span>
                         <p>${surface.description}</p>
                     </li>`;
                     ul.appendChild(li);

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -22,17 +22,17 @@ import { Ardour } from '/shared/ardour.js';
 
     async function main () {
         try {
-            const index = await new Ardour().getAvailableSurfaces();
-            printIndex(index);
+            const surfaces = await new Ardour().getAvailableSurfaces();
+            printSurfaces(surfaces);
         } catch (err) {
-            printError(`Error loading index: ${err.message}`);
+            printError(`Error loading surfaces list: ${err.message}`);
         }
 
         document.getElementById('loading').style.display = 'none';
     }
 
-    function printIndex (index) {
-        for (const group of index) {
+    function printSurfaces (surfaces) {
+        for (const group of surfaces) {
             const ul = document.querySelector(`#${group.path} > ul`);
             
             const li = document.createElement('li');

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -33,20 +33,17 @@ import { Ardour } from '/shared/ardour.js';
 
     function printIndex (index) {
         for (const group of index) {
-            const surfaces = group.surfaces;
-            const groupPath = group['path'];
-            const groupPathSpan = document.querySelector(`#${groupPath} span`);
-            
-            groupPathSpan.innerHTML = group['diskPath'];
+            const span = document.querySelector(`#${group.path} span`);
+            span.innerHTML = group.diskPath;
 
-            if (surfaces.length > 0) {
-                const ul = document.querySelector(`#${groupPath} > ul`);
-                surfaces.sort((a, b) => a.name.localeCompare(b.name));
+            if (group.surfaces.length > 0) {
+                const ul = document.querySelector(`#${group.path} > ul`);
+                group.surfaces.sort((a, b) => a.name.localeCompare(b.name));
                 
-                for (const surface of surfaces) {
+                for (const surface of group.surfaces) {
                     const li = document.createElement('li');
                     li.innerHTML = `<li>
-                        <a href="${groupPath}/${surface.path}/">${surface.name}</a>
+                        <a href="${group.path}/${surface.path}/">${surface.name}</a>
                         <p>${surface.description}</p>
                     </li>`;
                     ul.appendChild(li);
@@ -54,7 +51,7 @@ import { Ardour } from '/shared/ardour.js';
             } else {
                 const p = document.createElement('p');
                 p.innerHTML = '<p>No surfaces found</p>';
-                document.getElementById(groupPath).appendChild(p);
+                document.getElementById(group.path).appendChild(p);
             }
         }
 

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -39,7 +39,7 @@ import { Ardour } from '/shared/ardour.js';
             li.innerHTML = `<li>
                 <span>Filesystem location:</span>
                 &thinsp;
-                <span class="disk-path">${group.diskPath}</span>
+                <span class="filesystem-path">${group.filesystemPath}</span>
             </li>`;
             ul.appendChild(li);
 

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -33,13 +33,19 @@ import { Ardour } from '/shared/ardour.js';
 
     function printIndex (index) {
         for (const group of index) {
-            const span = document.querySelector(`#${group.path} span`);
-            span.innerHTML = group.diskPath;
+            const ul = document.querySelector(`#${group.path} > ul`);
+            
+            const li = document.createElement('li');
+            li.innerHTML = `<li>
+                <span>Filesystem location:</span>
+                &thinsp;
+                <span class="disk-path">${group.diskPath}</span>
+            </li>`;
+            ul.appendChild(li);
 
             if (group.surfaces.length > 0) {
-                const ul = document.querySelector(`#${group.path} > ul`);
                 group.surfaces.sort((a, b) => a.name.localeCompare(b.name));
-                
+
                 for (const surface of group.surfaces) {
                     const li = document.createElement('li');
                     li.innerHTML = `<li>
@@ -51,9 +57,9 @@ import { Ardour } from '/shared/ardour.js';
                     ul.appendChild(li);
                 }
             } else {
-                const p = document.createElement('p');
-                p.innerHTML = '<p>No surfaces found</p>';
-                document.getElementById(group.path).appendChild(p);
+                const li = document.createElement('li');
+                li.innerHTML = 'No surfaces found';
+                ul.appendChild(li);
             }
         }
 

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -139,12 +139,3 @@ export class Ardour {
 	}
 
 }
-
-async function test() {
-	const ardour = new Ardour();
-	await ardour.open();
-	const bpm = await ardour.setTempo(80);
-	console.log(bpm);
-}
-
-test();

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -160,13 +160,3 @@ export class Ardour {
 	}
 
 }
-
-async function main() {
-	const ard = new Ardour();
-	ard.errorCallback = (error) => {
-		alert(error);
-	};
-	await ard.open();
-}
-
-main();

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -65,7 +65,7 @@ export class Ardour {
 		}
 	}
 
-	// Surface control API over WebSockets channel
+	// Surface control API over WebSockets
 	// clients need to call open() before calling these methods
 
 	async getTempo () {

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -33,7 +33,7 @@ export class Ardour {
 	}
 
 	async getAvailableSurfaces () {
-		const response = await fetch('/index.json');
+		const response = await fetch('/surfaces.json');
 		
 		if (response.status == 200) {
 			return await response.json();

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { MessageChannel } from './channel.js';
+import { MessageChannel, Node } from './channel.js';
 
 export class Ardour {
 
@@ -38,7 +38,7 @@ export class Ardour {
 		if (response.status == 200) {
 			return await response.json();
 		} else {
-			throw new Error(`HTTP response status ${response.status}`);
+			throw this._fetchResponseStatusError(response.status);
 		}
 	}
 
@@ -53,10 +53,70 @@ export class Ardour {
 				description: xmlDoc.getElementsByTagName('Description')[0].getAttribute('value')
 			}
 		} else {
-			throw new Error(`HTTP response status ${response.status}`);
+			throw this._fetchResponseStatusError(response.status);
 		}
 	}
 
-	// TO DO - add methods for dealing with messages flowing from/to the WebSockets channel
+	async getTempo () {
+		return await this._sendAndReceive(Node.TEMPO);
+	}
+	
+	async getStripGain (stripId) {
+		return await this._sendAndReceive(Node.STRIP_GAIN, [stripId]);
+	}
+
+	async getStripPan (stripId) {
+		return await this._sendAndReceive(Node.STRIP_PAN, [stripId]);
+	}
+
+	async getStripMute (stripId) {
+		return await this._sendAndReceive(Node.STRIP_MUTE, [stripId]);
+	}
+
+	async getStripPluginEnable (stripId, pluginId) {
+		return await this._sendAndReceive(Node.STRIP_PLUGIN_ENABLE, [stripId, pluginId]);
+	}
+
+	async getStripPluginParamValue (stripId, pluginId, paramId) {
+		return await this._sendAndReceive(Node.STRIP_PLUGIN_PARAM_VALUE, [stripId, pluginId, paramId]);
+	}
+
+	async setTempo (bpm) {
+		this._send(Node.TEMPO, [], [bpm]);
+	}
+
+	async setStripGain (stripId, db) {
+		this._send(Node.STRIP_GAIN, [stripId], [db]);
+	}
+
+	async setStripPan (stripId, value) {
+		this._send(Node.STRIP_PAN, [stripId], [value]);
+	}
+
+	async setStripMute (stripId, value) {
+		this._send(Node.STRIP_MUTE, [stripId], [value]);
+	}
+
+	async setStripPluginEnable (stripId, pluginId, value) {
+		this._send(Node.STRIP_PLUGIN_ENABLE, [stripId, pluginId], [value]);
+	}
+
+	async setStripPluginParamValue (stripId, pluginId, paramId, value) {
+		this._send(Node.STRIP_PLUGIN_PARAM_VALUE, [stripId, pluginId, paramId], [value]);
+	}
+
+	async _send (addr, node, val) {
+		this.channel.send(new Message(addr, node, val));
+	}
+
+	async _sendAndReceive (addr, node, val) {
+		this._send(addr, node, val);
+
+		// TO DO - wait for response
+	}
+
+	_fetchResponseStatusError (status) {
+		return new Error(`HTTP response status ${status}`);
+	}
 
 }

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -34,6 +34,10 @@ export class Ardour {
 		this.channel.close();
 	}
 
+	messageCallback (msg) {
+		// empty
+	}
+
 	// Surface metadata API over HTTP
 
 	async getAvailableSurfaces () {
@@ -62,7 +66,7 @@ export class Ardour {
 	}
 
 	// Surface control API over WebSockets channel
-	// client needs to call open() first
+	// clients need to call open() before calling these methods
 
 	async getTempo () {
 		return (await this._sendAndReceive(Node.TEMPO))[0];
@@ -131,6 +135,8 @@ export class Ardour {
 		if (this.pendingRequest && (this.pendingRequest.hash == msg.hash)) {
 			this.pendingRequest.resolve(msg.val);
 			this.pendingRequest = null;
+		} else {
+			this.messageCallback(msg);
 		}
 	}
 

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -16,12 +16,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { ArdourMessageChannel } from './channel.js';
+import { MessageChannel } from './channel.js';
 
 export class Ardour {
 
 	constructor () {
-		this.channel = new ArdourMessageChannel(location.host);
+		this.channel = new MessageChannel(location.host);
 	}
 
 	async open () {

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -16,7 +16,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { MessageChannel, Message, ANode } from './channel.js';
+import { ANode, Message } from './message.js';
+import { MessageChannel } from './channel.js';
 
 export class Ardour {
 
@@ -38,6 +39,10 @@ export class Ardour {
 	close () {
 		this._channel.closeCallback = () => {};
 		this._channel.close();
+	}
+
+	send (msg) {
+		this._channel.send(msg);
 	}
 	
 	errorCallback (error) {

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { MessageChannel, Message, Node } from './channel.js';
+import { MessageChannel, Message, ANode } from './channel.js';
 
 export class Ardour {
 
@@ -69,51 +69,51 @@ export class Ardour {
 	// clients need to call open() before calling these methods
 
 	async getTempo () {
-		return (await this._sendAndReceive(Node.TEMPO))[0];
+		return (await this._sendAndReceive(ANode.TEMPO))[0];
 	}
 	
 	async getStripGain (stripId) {
-		return (await this._sendAndReceive(Node.STRIP_GAIN, [stripId]))[0];
+		return (await this._sendAndReceive(ANode.STRIP_GAIN, [stripId]))[0];
 	}
 
 	async getStripPan (stripId) {
-		return (await this._sendAndReceive(Node.STRIP_PAN, [stripId]))[0];
+		return (await this._sendAndReceive(ANode.STRIP_PAN, [stripId]))[0];
 	}
 
 	async getStripMute (stripId) {
-		return (await this._sendAndReceive(Node.STRIP_MUTE, [stripId]))[0];
+		return (await this._sendAndReceive(ANode.STRIP_MUTE, [stripId]))[0];
 	}
 
 	async getStripPluginEnable (stripId, pluginId) {
-		return (await this._sendAndReceive(Node.STRIP_PLUGIN_ENABLE, [stripId, pluginId]))[0];
+		return (await this._sendAndReceive(ANode.STRIP_PLUGIN_ENABLE, [stripId, pluginId]))[0];
 	}
 
 	async getStripPluginParamValue (stripId, pluginId, paramId) {
-		return (await this._sendAndReceive(Node.STRIP_PLUGIN_PARAM_VALUE, [stripId, pluginId, paramId]))[0];
+		return (await this._sendAndReceive(ANode.STRIP_PLUGIN_PARAM_VALUE, [stripId, pluginId, paramId]))[0];
 	}
 
 	setTempo (bpm) {
-		this._send(Node.TEMPO, [], [bpm]);
+		this._send(ANode.TEMPO, [], [bpm]);
 	}
 
 	setStripGain (stripId, db) {
-		this._send(Node.STRIP_GAIN, [stripId], [db]);
+		this._send(ANode.STRIP_GAIN, [stripId], [db]);
 	}
 
 	setStripPan (stripId, value) {
-		this._send(Node.STRIP_PAN, [stripId], [value]);
+		this._send(ANode.STRIP_PAN, [stripId], [value]);
 	}
 
 	setStripMute (stripId, value) {
-		this._send(Node.STRIP_MUTE, [stripId], [value]);
+		this._send(ANode.STRIP_MUTE, [stripId], [value]);
 	}
 
 	setStripPluginEnable (stripId, pluginId, value) {
-		this._send(Node.STRIP_PLUGIN_ENABLE, [stripId, pluginId], [value]);
+		this._send(ANode.STRIP_PLUGIN_ENABLE, [stripId, pluginId], [value]);
 	}
 
 	setStripPluginParamValue (stripId, pluginId, paramId, value) {
-		this._send(Node.STRIP_PLUGIN_PARAM_VALUE, [stripId, pluginId, paramId], [value]);
+		this._send(ANode.STRIP_PLUGIN_PARAM_VALUE, [stripId, pluginId, paramId], [value]);
 	}
 
 	// Private methods

--- a/share/web_surfaces/shared/callback.js
+++ b/share/web_surfaces/shared/callback.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+ export class ArdourCallback {
+
+	onTempo (bpm) {}
+	onStripGain (stripId, db) {}
+	onStripPan (stripId, value) {}
+	onStripMute (stripId, value) {}
+	onStripPluginEnable (stripId, pluginId, value) {}
+	onStripPluginParamValue (stripId, pluginId, paramId, value) {}
+
+ 	onMessage (msg) {}	
+ 	onError (error) {}
+
+ }

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -16,26 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-export const JSON_INF = 1.0e+128;
-
-export const ANode = Object.freeze({
-	TEMPO: 'tempo',
-	STRIP_DESC: 'strip_desc',
-	STRIP_METER: 'strip_meter',
-	STRIP_GAIN: 'strip_gain',
-	STRIP_PAN: 'strip_pan',
-	STRIP_MUTE: 'strip_mute',
-	STRIP_PLUGIN_DESC: 'strip_plugin_desc',
-	STRIP_PLUGIN_ENABLE: 'strip_plugin_enable',
-	STRUP_PLUGIN_PARAM_DESC: 'strip_plugin_param_desc',
-	STRIP_PLUGIN_PARAM_VALUE: 'strip_plugin_param_value'
-});
-
-
-export function nodeAddressHash(node, addr) {
-	return [node].concat(addr || []).join('_');
-}
-
+import { ANode, Message } from './message.js';
 
 export class MessageChannel {
 
@@ -82,56 +63,6 @@ export class MessageChannel {
 
 	messageCallback (msg) {
 		// empty
-	}
-
-}
-
-
-export class Message {
-
-	constructor (node, addr, val) {
-		this.node = node;
-		this.addr = addr;
-		this.val = [];
-
-		for (const i in val) {
-			if (val[i] >= JSON_INF) {
-				this.val.push(Infinity);
-			} else if (val[i] <= -JSON_INF) {
-				this.val.push(-Infinity);
-			} else {
-				this.val.push(val[i]);
-			}
-		}
-	}
-
-	static fromJsonText (jsonText) {
-		let rawMsg = JSON.parse(jsonText);
-		return new Message(rawMsg.node, rawMsg.addr || [], rawMsg.val);
-	}
-
-	toJsonText () {
-		let val = [];
-
-		for (const i in this.val) {
-			if (this.val[i] == Infinity) {
-				val.push(JSON_INF);
-			} else if (this.val[i] == -Infinity) {
-				val.push(-JSON_INF);
-			} else {
-				val.push(this.val[i]);
-			}
-		}
-		
-		return JSON.stringify({node: this.node, addr: this.addr, val: val});
-	}
-
-	get hash () {
-		return nodeAddressHash(this.node, this.addr);
-	}
-
-	toString () {
-		return `${this.node} (${this.addr}) = ${this.val}`;
 	}
 
 }

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -61,7 +61,11 @@ export class MessageChannel {
 	}
 
 	send (msg) {
-		this.socket.send(msg.toJsonText());
+		if (this.socket) {
+			this.socket.send(msg.toJsonText());
+		} else {
+			throw Error('MessageChannel: cannot call send() before open()');
+		}
 	}
 
 	closeCallback () {

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -29,19 +29,19 @@ export class MessageChannel {
 		return new Promise((resolve, reject) => {
 			this._socket = new WebSocket(`ws://${this._host}`);
 
-			this._socket.onclose = () => this.closeCallback();
+			this._socket.onclose = () => this.onClose();
 
-			this._socket.onerror = (error) => this.errorCallback(error);
+			this._socket.onerror = (error) => this.onError(error);
 
 			this._socket.onmessage = (event) => {
-				this.messageCallback (Message.fromJsonText(event.data));
+				this.onMessage (Message.fromJsonText(event.data));
 			};
 
 			this._socket.onopen = resolve;
 		});
 	}
 
-	async close () {
+	close () {
 		this._socket.close();
 	}
 
@@ -53,16 +53,8 @@ export class MessageChannel {
 		}
 	}
 
-	closeCallback () {
-		// empty
-	}
-	
-	errorCallback (error) {
-		// empty
-	}
-
-	messageCallback (msg) {
-		// empty
-	}
+	onClose () {}
+	onError (error) {}
+	onMessage (msg) {}
 
 }

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -41,28 +41,32 @@ export class MessageChannel {
 
 	constructor (host) {
 		// https://developer.mozilla.org/en-US/docs/Web/API/URL/host
-		this.host = host;
+		this._host = host;
 	}
 
 	async open () {
 		return new Promise((resolve, reject) => {
-			this.socket = new WebSocket(`ws://${this.host}`);
+			this._socket = new WebSocket(`ws://${this._host}`);
 
-			this.socket.onclose = () => this.closeCallback();
+			this._socket.onclose = () => this.closeCallback();
 
-			this.socket.onerror = (error) => this.errorCallback(error);
+			this._socket.onerror = (error) => this.errorCallback(error);
 
-			this.socket.onmessage = (event) => {
+			this._socket.onmessage = (event) => {
 				this.messageCallback (Message.fromJsonText(event.data));
 			};
 
-			this.socket.onopen = resolve;
+			this._socket.onopen = resolve;
 		});
 	}
 
+	async close () {
+		this._socket.close();
+	}
+
 	send (msg) {
-		if (this.socket) {
-			this.socket.send(msg.toJsonText());
+		if (this._socket) {
+			this._socket.send(msg.toJsonText());
 		} else {
 			throw Error('MessageChannel: cannot call send() before open()');
 		}

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -33,7 +33,7 @@ export const Node = Object.freeze({
 
 
 export function nodeAddressHash(node, addr) {
-	return [node].concat(addr).join('_');
+	return [node].concat(addr || []).join('_');
 }
 
 
@@ -44,7 +44,7 @@ export class MessageChannel {
 		this.host = host;
 	}
 
-	open () {
+	async open () {
 		return new Promise((resolve, reject) => {
 			this.socket = new WebSocket(`ws://${this.host}`);
 

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -19,16 +19,16 @@
 export const JSON_INF = 1.0e+128;
 
 export const Node = Object.freeze({
-	TEMPO: "tempo",
-	STRIP_DESC: "strip_desc",
-	STRIP_METER: "strip_meter",
-	STRIP_GAIN: "strip_gain",
-	STRIP_PAN: "strip_pan",
-	STRIP_MUTE: "strip_mute",
-	STRIP_PLUGIN_DESC: "strip_plugin_desc",
-	STRIP_PLUGIN_ENABLE: "strip_plugin_enable",
-	STRUP_PLUGIN_PARAM_DESC: "strip_plugin_param_desc",
-	STRIP_PLUGIN_PARAM_VALUE: "strip_plugin_param_value"
+	TEMPO: 'tempo',
+	STRIP_DESC: 'strip_desc',
+	STRIP_METER: 'strip_meter',
+	STRIP_GAIN: 'strip_gain',
+	STRIP_PAN: 'strip_pan',
+	STRIP_MUTE: 'strip_mute',
+	STRIP_PLUGIN_DESC: 'strip_plugin_desc',
+	STRIP_PLUGIN_ENABLE: 'strip_plugin_enable',
+	STRUP_PLUGIN_PARAM_DESC: 'strip_plugin_param_desc',
+	STRIP_PLUGIN_PARAM_VALUE: 'strip_plugin_param_value'
 });
 
 

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -18,7 +18,7 @@
 
 export const JSON_INF = 1.0e+128;
 
-export const Node = Object.freeze({
+export const ANode = Object.freeze({
 	TEMPO: 'tempo',
 	STRIP_DESC: 'strip_desc',
 	STRIP_METER: 'strip_meter',

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -18,7 +18,7 @@
 
 const JSON_INF = 1.0e+128;
 
-export class ArdourMessageChannel {
+export class MessageChannel {
 
     constructor (host) {
         // https://developer.mozilla.org/en-US/docs/Web/API/URL/host

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -19,96 +19,96 @@
 const JSON_INF = 1.0e+128;
 
 export function nodeAddressHash(node, addr) {
-    return [node].concat(addr).join('_');
+	return [node].concat(addr).join('_');
 }
 
 export class MessageChannel {
 
-    constructor (host) {
-        // https://developer.mozilla.org/en-US/docs/Web/API/URL/host
-        this.host = host;
-    }
+	constructor (host) {
+		// https://developer.mozilla.org/en-US/docs/Web/API/URL/host
+		this.host = host;
+	}
 
-    open () {
-        return new Promise((resolve, reject) => {
-            this.socket = new WebSocket(`ws://${this.host}`);
+	open () {
+		return new Promise((resolve, reject) => {
+			this.socket = new WebSocket(`ws://${this.host}`);
 
-            this.socket.onclose = () => this.closeCallback();
+			this.socket.onclose = () => this.closeCallback();
 
-            this.socket.onerror = (error) => this.errorCallback(error);
+			this.socket.onerror = (error) => this.errorCallback(error);
 
-            this.socket.onmessage = (event) => {
-                this.messageCallback (Message.fromJsonText(event.data));
-            };
+			this.socket.onmessage = (event) => {
+				this.messageCallback (Message.fromJsonText(event.data));
+			};
 
-            this.socket.onopen = resolve;
-        });
-    }
+			this.socket.onopen = resolve;
+		});
+	}
 
-    send (msg) {
-        this.socket.send(msg.toJsonText());
-    }
+	send (msg) {
+		this.socket.send(msg.toJsonText());
+	}
 
-    closeCallback () {
-        // empty
-    }
-    
-    errorCallback (error) {
-        // empty
-    }
+	closeCallback () {
+		// empty
+	}
+	
+	errorCallback (error) {
+		// empty
+	}
 
-    messageCallback (msg) {
-        // empty
-    }
+	messageCallback (msg) {
+		// empty
+	}
 
 }
 
 
 export class Message {
 
-    constructor (node, addr, val) {
-        this.node = node;
-        this.addr = addr;
-        this.val = [];
+	constructor (node, addr, val) {
+		this.node = node;
+		this.addr = addr;
+		this.val = [];
 
-        for (const i in val) {
-            if (val[i] >= JSON_INF) {
-                this.val.push(Infinity);
-            } else if (val[i] <= -JSON_INF) {
-                this.val.push(-Infinity);
-            } else {
-                this.val.push(val[i]);
-            }
-        }
-    }
+		for (const i in val) {
+			if (val[i] >= JSON_INF) {
+				this.val.push(Infinity);
+			} else if (val[i] <= -JSON_INF) {
+				this.val.push(-Infinity);
+			} else {
+				this.val.push(val[i]);
+			}
+		}
+	}
+	
+	static fromJsonText (jsonText) {
+		let rawMsg = JSON.parse(jsonText);
+		return new Message(rawMsg.node, rawMsg.addr || [], rawMsg.val);
+	}
 
-    toJsonText () {
-        let val = [];
+	toJsonText () {
+		let val = [];
 
-        for (const i in this.val) {
-            if (this.val[i] == Infinity) {
-                val.push(JSON_INF);
-            } else if (this.val[i] == -Infinity) {
-                val.push(-JSON_INF);
-            } else {
-                val.push(this.val[i]);
-            }
-        }
-        
-        return JSON.stringify({node: this.node, addr: this.addr, val: val});
-    }
+		for (const i in this.val) {
+			if (this.val[i] == Infinity) {
+				val.push(JSON_INF);
+			} else if (this.val[i] == -Infinity) {
+				val.push(-JSON_INF);
+			} else {
+				val.push(this.val[i]);
+			}
+		}
+		
+		return JSON.stringify({node: this.node, addr: this.addr, val: val});
+	}
 
-    get hash () {
-        return nodeAddressHash(this.node, this.addr);
-    }
+	get hash () {
+		return nodeAddressHash(this.node, this.addr);
+	}
 
-    toString () {
-        return `${this.node} (${this.addr}) = ${this.val}`;
-    }
+	toString () {
+		return `${this.node} (${this.addr}) = ${this.val}`;
+	}
 
 }
-
-Message.fromJsonText = (jsonText) => {
-    let rawMsg = JSON.parse(jsonText);
-    return new Message(rawMsg.node, rawMsg.addr || [], rawMsg.val);
-};

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -18,6 +18,10 @@
 
 const JSON_INF = 1.0e+128;
 
+export function nodeAddressHash(node, addr) {
+    return [node].concat(addr).join('_');
+}
+
 export class MessageChannel {
 
     constructor (host) {
@@ -95,7 +99,7 @@ export class Message {
     }
 
     get hash () {
-        return [this.node].concat(this.addr).join('_');
+        return nodeAddressHash(this.node, this.addr);
     }
 
     toString () {

--- a/share/web_surfaces/shared/channel.js
+++ b/share/web_surfaces/shared/channel.js
@@ -16,11 +16,26 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-const JSON_INF = 1.0e+128;
+export const JSON_INF = 1.0e+128;
+
+export const Node = Object.freeze({
+	TEMPO: "tempo",
+	STRIP_DESC: "strip_desc",
+	STRIP_METER: "strip_meter",
+	STRIP_GAIN: "strip_gain",
+	STRIP_PAN: "strip_pan",
+	STRIP_MUTE: "strip_mute",
+	STRIP_PLUGIN_DESC: "strip_plugin_desc",
+	STRIP_PLUGIN_ENABLE: "strip_plugin_enable",
+	STRUP_PLUGIN_PARAM_DESC: "strip_plugin_param_desc",
+	STRIP_PLUGIN_PARAM_VALUE: "strip_plugin_param_value"
+});
+
 
 export function nodeAddressHash(node, addr) {
 	return [node].concat(addr).join('_');
 }
+
 
 export class MessageChannel {
 
@@ -81,7 +96,7 @@ export class Message {
 			}
 		}
 	}
-	
+
 	static fromJsonText (jsonText) {
 		let rawMsg = JSON.parse(jsonText);
 		return new Message(rawMsg.node, rawMsg.addr || [], rawMsg.val);

--- a/share/web_surfaces/shared/message.js
+++ b/share/web_surfaces/shared/message.js
@@ -27,7 +27,7 @@ export const ANode = Object.freeze({
 	STRIP_MUTE: 'strip_mute',
 	STRIP_PLUGIN_DESC: 'strip_plugin_desc',
 	STRIP_PLUGIN_ENABLE: 'strip_plugin_enable',
-	STRUP_PLUGIN_PARAM_DESC: 'strip_plugin_param_desc',
+	STRIP_PLUGIN_PARAM_DESC: 'strip_plugin_param_desc',
 	STRIP_PLUGIN_PARAM_VALUE: 'strip_plugin_param_value'
 });
 

--- a/share/web_surfaces/shared/message.js
+++ b/share/web_surfaces/shared/message.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+export const JSON_INF = 1.0e+128;
+
+export const ANode = Object.freeze({
+	TEMPO: 'tempo',
+	STRIP_DESC: 'strip_desc',
+	STRIP_METER: 'strip_meter',
+	STRIP_GAIN: 'strip_gain',
+	STRIP_PAN: 'strip_pan',
+	STRIP_MUTE: 'strip_mute',
+	STRIP_PLUGIN_DESC: 'strip_plugin_desc',
+	STRIP_PLUGIN_ENABLE: 'strip_plugin_enable',
+	STRUP_PLUGIN_PARAM_DESC: 'strip_plugin_param_desc',
+	STRIP_PLUGIN_PARAM_VALUE: 'strip_plugin_param_value'
+});
+
+export class Message {
+
+	constructor (node, addr, val) {
+		this.node = node;
+		this.addr = addr;
+		this.val = [];
+
+		for (const i in val) {
+			if (val[i] >= JSON_INF) {
+				this.val.push(Infinity);
+			} else if (val[i] <= -JSON_INF) {
+				this.val.push(-Infinity);
+			} else {
+				this.val.push(val[i]);
+			}
+		}
+	}
+
+	static hash (node, addr) {
+		return [node].concat(addr || []).join('_');
+	}
+
+	static fromJsonText (jsonText) {
+		let rawMsg = JSON.parse(jsonText);
+		return new Message(rawMsg.node, rawMsg.addr || [], rawMsg.val);
+	}
+
+	toJsonText () {
+		let val = [];
+
+		for (const i in this.val) {
+			if (this.val[i] == Infinity) {
+				val.push(JSON_INF);
+			} else if (this.val[i] == -Infinity) {
+				val.push(-JSON_INF);
+			} else {
+				val.push(this.val[i]);
+			}
+		}
+		
+		return JSON.stringify({node: this.node, addr: this.addr, val: val});
+	}
+
+	get hash () {
+		return Message.hash(this.node, this.addr);
+	}
+
+	toString () {
+		return `${this.node} (${this.addr}) = ${this.val}`;
+	}
+
+}


### PR DESCRIPTION
The library is intended to be used by the built-in web surfaces and also available for the user defined ones.

All layers in the WebSockets component are now complete and ready for creating stuff that can be used in the real world.

Also included:

- Better index page design
- Surfaces got a version attribute
- Minor improvements here and there
