### PR TITLE
WebSockets: workaround for index page on Windows

### DIFF
--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
- // This example does not call the API methods in ardour.js,
+ // This example does not call the API methods in control.js,
  // instead it couples the widgets directly to the message stream
 
 import { ANode, Message } from '/shared/message.js';

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -37,23 +37,30 @@ import { ArdourClient } from '/shared/ardour.js';
             
             const li = document.createElement('li');
             li.innerHTML = `<li>
-                <span>Filesystem location:</span>
-                &thinsp;
-                <span class="filesystem-path">${group.filesystemPath}</span>
-            </li>`;
+                    <span>Filesystem location:</span>
+                    &thinsp;
+                    <span class="filesystem-path">${group.filesystemPath}</span>
+                </li>`;
             ul.appendChild(li);
 
             if (group.surfaces.length > 0) {
                 group.surfaces.sort((a, b) => a.name.localeCompare(b.name));
 
                 for (const surface of group.surfaces) {
+                    let path = group.path + '/' + surface.path + '/';
+
+                    // see https://github.com/Ardour/ardour/pull/491
+                    if (navigator.userAgent.indexOf('Windows') != -1) {
+                        path += 'index.html';
+                    }
+
                     const li = document.createElement('li');
                     li.innerHTML = `<li>
-                        <a href="${group.path}/${surface.path}/">${surface.name}</a>
-                        &thinsp;
-                        <span class="surface-version">(${surface.version})</span>
-                        <p>${surface.description}</p>
-                    </li>`;
+                            <a href="${path}">${surface.name}</a>
+                            &thinsp;
+                            <span class="surface-version">(${surface.version})</span>
+                            <p>${surface.description}</p>
+                        </li>`;
                     ul.appendChild(li);
                 }
             } else {


### PR DESCRIPTION
Avoid 404s when following surface links while the issue in https://github.com/Ardour/ardour/pull/491 is better investigated
