### PR TITLE
Fix default midi patch model

### DIFF
--- a/gtk2_ardour/midi_time_axis.cc
+++ b/gtk2_ardour/midi_time_axis.cc
@@ -440,7 +440,7 @@ MidiTimeAxisView::setup_midnam_patches ()
 		model_changed ("");
 	} else if (model.empty() || ! MIDI::Name::MidiPatchManager::instance ().master_device_by_model (model)) {
 		/* invalid model, switch to use default */
-		model_changed ("");
+		model_changed (DEFAULT_MIDNAM_MODEL);
 	} else {
 		model_changed (model);
 	}

--- a/libs/ardour/ardour/midi_patch_manager.h
+++ b/libs/ardour/ardour/midi_patch_manager.h
@@ -53,7 +53,7 @@ public:
 	typedef std::map<std::string, boost::shared_ptr<MIDINameDocument> >    MidiNameDocuments;
 	typedef std::map<std::string, MIDINameDocument::MasterDeviceNamesList> DeviceNamesByMaker;
 
-        ~MidiPatchManager();
+	~MidiPatchManager();
 
 	static MidiPatchManager& instance() {
 		if (_manager == 0) {


### PR DESCRIPTION
I noticed control change names were replaced by `Controller N`, as shown in the screenshot below (from 24d3bf25a9)

![before-fix](https://user-images.githubusercontent.com/819225/80402904-58542380-88c7-11ea-9ec3-086b17c17be6.png)

That PR introduces a possible fix, see below

![after-fix](https://user-images.githubusercontent.com/819225/80402926-5e4a0480-88c7-11ea-94d6-a58b804f1942.png)

I obtained that fix more from trial and error than deep understanding of the code, so be careful.