### PR TITLE
Compatibility with libwebsockets 4

### DIFF
--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -552,9 +552,12 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 #if LWS_LIBRARY_VERSION_MAJOR >= 3
 		case LWS_CALLBACK_HTTP_BIND_PROTOCOL:
 		case LWS_CALLBACK_ADD_HEADERS:
-#if LWS_LIBRARY_VERSION_MINOR >= 1
-		case LWS_CALLBACK_HTTP_CONFIRM_UPGRADE:
 #endif
+#if LWS_LIBRARY_VERSION_MAJOR >= 4
+		case LWS_CALLBACK_HTTP_FILE_COMPLETION:
+#endif
+#if (LWS_LIBRARY_VERSION_MAJOR >= 4) || (LWS_LIBRARY_VERSION_MAJOR >= 3 && LWS_LIBRARY_VERSION_MINOR >= 1)
+		case LWS_CALLBACK_HTTP_CONFIRM_UPGRADE:
 #endif
 			/* do nothing but keep connection alive */
 			rc = 0;

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -110,6 +110,10 @@ WebsocketsServer::WebsocketsServer (ArdourSurface::ArdourWebsockets& surface)
 int
 WebsocketsServer::start ()
 {
+	if (_lws_context) {
+		stop ();
+	}
+
 	_lws_context = lws_create_context (&_lws_info);
 
 	if (!_lws_context) {

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -537,7 +537,7 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 			rc = server->send_availsurf_body (wsi);
 			break;
 
-		case LWS_CALLBACK_CLOSED_HTTP:
+		//case LWS_CALLBACK_CLOSED_HTTP:
 		case LWS_CALLBACK_FILTER_NETWORK_CONNECTION:
 		case LWS_CALLBACK_FILTER_PROTOCOL_CONNECTION:
 		case LWS_CALLBACK_SERVER_NEW_CLIENT_INSTANTIATED:
@@ -555,6 +555,7 @@ WebsocketsServer::lws_callback (struct lws* wsi, enum lws_callback_reasons reaso
 #endif
 #if LWS_LIBRARY_VERSION_MAJOR >= 4
 		case LWS_CALLBACK_HTTP_FILE_COMPLETION:
+		case LWS_CALLBACK_HTTP_DROP_PROTOCOL:
 #endif
 #if (LWS_LIBRARY_VERSION_MAJOR >= 4) || (LWS_LIBRARY_VERSION_MAJOR >= 3 && LWS_LIBRARY_VERSION_MINOR >= 1)
 		case LWS_CALLBACK_HTTP_CONFIRM_UPGRADE:

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -118,7 +118,7 @@ WebsocketsServer::start ()
 #endif
 
 #ifndef NDEBUG
-	lws_set_log_level (LLL_USER | LLL_ERR | LLL_WARN | LLL_DEBUG, 0);
+	lws_set_log_level (LLL_ERR | LLL_WARN | LLL_DEBUG, 0);
 #endif
 
 	if (_lws_context) {

--- a/share/web_surfaces/shared/message.js
+++ b/share/web_surfaces/shared/message.js
@@ -19,19 +19,19 @@
 export const JSON_INF = 1.0e+128;
 
 export const ANode = Object.freeze({
-	TEMPO:                    'tempo',
-	POSITION_TIME:            'position_time',
-	TRANSPORT_ROLL:           'transport_roll',
-	RECORD_STATE:             'record_state',
-	STRIP_DESC:               'strip_desc',
-	STRIP_METER:              'strip_meter',
-	STRIP_GAIN:               'strip_gain',
-	STRIP_PAN:                'strip_pan',
-	STRIP_MUTE:               'strip_mute',
-	STRIP_PLUGIN_DESC:        'strip_plugin_desc',
-	STRIP_PLUGIN_ENABLE:      'strip_plugin_enable',
-	STRIP_PLUGIN_PARAM_DESC:  'strip_plugin_param_desc',
-	STRIP_PLUGIN_PARAM_VALUE: 'strip_plugin_param_value'
+	TEMPO:                          'tempo',
+	POSITION_TIME:                  'position_time',
+	TRANSPORT_ROLL:                 'transport_roll',
+	RECORD_STATE:                   'record_state',
+	STRIP_DESCRIPTION:              'strip_description',
+	STRIP_METER:                    'strip_meter',
+	STRIP_GAIN:                     'strip_gain',
+	STRIP_PAN:                      'strip_pan',
+	STRIP_MUTE:                     'strip_mute',
+	STRIP_PLUGIN_DESCRIPTION:       'strip_plugin_description',
+	STRIP_PLUGIN_ENABLE:            'strip_plugin_enable',
+	STRIP_PLUGIN_PARAM_DESCRIPTION: 'strip_plugin_param_description',
+	STRIP_PLUGIN_PARAM_VALUE:       'strip_plugin_param_value'
 });
 
 export class Message {


### PR DESCRIPTION
The WebSockets Server surface did not work when compiling against lws 4. This is a simple patch that fixes that.

~~I plan to better integrate lws by leveraging its built-in glib event loop integration, new in 4.0.0
https://github.com/warmcat/libwebsockets/blob/224b59c00b134f3aa5d6f10fb833c9ab30720352/changelog~~

Leverages libwebsockets built-in glib loop integration.
