### PR TITLE
Update caineville-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Ardour theme-name="Caineville">
   <Colors>
-    <Color name="alert:blue" value="2E41E6ff"/>
-    <Color name="alert:cyan" value="20b2b2ff"/>
-    <Color name="alert:green" value="3dcc4cff"/>
+    <Color name="alert:blue" value="2e41e6ff"/>  <!--solo button: fill active,  trim handle,  invert button: fill active-->
+    <Color name="alert:cyan" value="20b2b2ff"/>  <!--location cd marker,  pluginlist hide button: led active-->
+    <Color name="alert:green" value="3dcc4cff"/>  <!--gain line,  gtk_solo,  invert button: led active,  transport active option button: fill active-->
     <Color name="alert:greenish" value="459952ff"/>
-    <Color name="alert:orange" value="e58b05ff"/>
-    <Color name="alert:red" value="f10000ff"/>
-    <Color name="alert:ruddy" value="bb2828ff"/>
-    <Color name="alert:yellow" value="bba900ff"/>
-    <Color name="theme:bg" value="0x515151ff"/>  <!--gtk_background-->
-    <Color name="theme:bg1" value="0x8d8d8dff"/>  <!--gtk_audio_track-->
-    <Color name="theme:bg2" value="0x444444ff"/>  <!--ruler base-->
-    <Color name="theme:contrasting" value="0xff6100ff"/>  <!--play head-->
-    <Color name="theme:contrasting clock" value="0xf0f0f0ff"/>  <!--big clock: text-->
-    <Color name="theme:contrasting less" value="0xE3DABAff"/>  <!--gtk_bg_tooltip-->
-    <Color name="theme:contrasting selection" value="0x8d8d8dff"/>  <!--gtk_bg_selected-->
-    <Color name="theme:contrasting alt" value="0x8cd8f8ff"/>  <!--secondary delta clock: text-->
-    <Color name="neutral:backgroundest" value="000000ff"/>  <!--border color-->
-    <Color name="neutral:background" value="0x7aadf9ff"/>  <!--audio track base-->
-    <Color name="neutral:background2" value="0x8d8d8dff"/>  <!--range marker bar-->
-    <Color name="neutral:midground" value="0xffa500ff"/>  <!--grid line minor-->
-    <Color name="neutral:foreground2" value="0xddddd8ff"/>  <!--marker track-->
-    <Color name="neutral:foreground" value="0xeeeeecff"/>  <!--gtk_foreground-->
-    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major-->
-    <Color name="widget:bg" value="0x9e9e9eff"/>    <!--generic button-->
-    <Color name="widget:blue" value="0x5550A0ff"/>  <!--processor fader: fill-->
-    <Color name="widget:blue darker" value="0x404145ff"/>  <!--gtk_audio_bus-->
-    <Color name="widget:gray" value="0x636363ff"/>  <!--gtk_processor_fader-->
-    <Color name="widget:green" value="0x8d8d8dff"/>  <!--gtk_processor_postfader,  gtk_midi_track-->
-    <Color name="widget:green darker" value="0xcececeff"/>  <!--midi track base-->
-    <Color name="widget:orange" value="0xff0000ff"/>  <!--tempo marker-->
-    <Color name="widget:ruddy" value="0xb5b2b1ff"/>  <!--processor prefader-->
-    <Color name="meter color0" value="008800ff"/>
-    <Color name="meter color1" value="00aa00ff"/>
-    <Color name="meter color2" value="00ff00ff"/>
-    <Color name="meter color3" value="00ff00ff"/>
-    <Color name="meter color4" value="fff000ff"/>
-    <Color name="meter color5" value="fff000ff"/>
-    <Color name="meter color6" value="ff8800ff"/>
-    <Color name="meter color7" value="ff8800ff"/>
-    <Color name="meter color8" value="ff0000ff"/>
-    <Color name="meter color9" value="ff0000ff"/>
-    <Color name="midi meter 52" value="e8faa1ff"/>
-    <Color name="midi meter 53" value="f2c37dff"/>
-    <Color name="midi meter 54" value="ffac44ff"/>
-    <Color name="midi meter 55" value="f48352ff"/>
-    <Color name="midi meter 56" value="f85813ff"/>
+    <Color name="alert:orange" value="ff4e00ff"/>  <!--gtk_monitor,  monitor button: fill active,  processor fader: led active,  transport clock: text-->
+    <Color name="alert:red" value="f10000ff"/>  <!--clipped waveform,  gtk_bright_indicator,  gtk_clip_indicator,  midi select rect outline,  selection,  punch button: led active-->
+    <Color name="alert:ruddy" value="bb2828ff"/>  <!--feedback alert: alt active,  location punch,  punch button: fill active,  solo isolate: led active-->
+    <Color name="alert:yellow" value="bba900ff"/>  <!--gtk_mute,  mute button: fill active,  master monitor section button active: fill active-->
+    <Color name="theme:bg" value="525252ff"/>  <!--arrange base,  gtk_background,  gtk_automation_track_header,  mono panner position outline,  stereo panner rule-->
+    <Color name="theme:bg1" value="373737ff"/>  <!--gtk_control_master,  automation track outline,  gtk_send_bg,  mixer strip button: fill active,  name highlight outline-->
+    <Color name="theme:bg2" value="2b2b2bff"/>  <!--ruler base,  big clock: background,  clock: background,  gtk_bases,  selected waveform outline-->
+    <Color name="theme:contrasting" value="f23d00ff"/>  <!--play head,  automation line,  page switch button: fill active,  gtk_bright_color,  mono panner fill,  stereo panner fill-->
+    <Color name="theme:contrasting clock" value="ff0003ff"/>  <!--big clock: text,  clock: text,  marker drag line,  punch clock: text,  transport punch rect-->
+    <Color name="theme:contrasting less" value="5697b3ff"/>  <!--time stretch fill-->
+    <Color name="theme:contrasting selection" value="5da3c1ff"/>  <!--piano roll black,  -->
+    <Color name="theme:contrasting alt" value="f6ce10ff"/>  <!--secondary delta clock: text,  gtk_bg_tooltip,  selected region base,  location marker,  transport button: fill active-->
+    <Color name="neutral:backgroundest" value="000000ff"/>  <!--border color,  audio master bus base,  time axis frame,  waveform outline,  stereo panner text-->
+    <Color name="neutral:background" value="202020ff"/>  <!--audio track base,  gtk_fg_tooltip,  mono panner text,  processor postfader: fill-->
+    <Color name="neutral:background2" value="555555ff"/>  <!--range marker bar,  covered region,  tempo bar,  midi frame base-->
+    <Color name="neutral:midground" value="7f7f7fff"/>  <!--grid line minor,  grid line micro,  mono panner bg,  processor prefader: fill,  stereo panner mono bg,  ruler text-->
+    <Color name="neutral:foreground2" value="b5b5b5ff"/>  <!--marker track,  gtk_light_text_on_dark,  piano roll white,  secondary clock: text-->
+    <Color name="neutral:foreground" value="e5e5e5ff"/>  <!--gtk_foreground,  gtk_texts,  location loop,  selection rect,  transport loop rect-->
+    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major,  control point selected outline,  gtk_lightest,  midi note selected outline-->
+    <Color name="widget:bg" value="3a3a3aff"/>    <!--generic button: fill,  audio bus base,  gtk_audio_bus,  comment button: fill,  lua action button: fill-->
+    <Color name="widget:blue" value="3044c6ff"/>  <!--processor fader: fill active,  gtk_contrasting_indicator,  send alert button: fill,  tempo curve-->
+    <Color name="widget:blue darker" value="161931ff"/>
+    <Color name="widget:gray" value="4c4c4cff"/>  <!--gtk_processor_fader,  gtk_audio_track,  processor fader: fill,  time stretch outline-->
+    <Color name="widget:green" value="617552ff"/>  <!--gtk_processor_postfader-->
+    <Color name="widget:green darker" value="7d7d7dff"/>  <!--midi track base,  gtk_midi_track,  midi automation track fill,  -->
+    <Color name="widget:orange" value="904010ff"/>  <!--tempo marker,  processor postfader: fill active,  stereo panner mono fill-->
+    <Color name="widget:ruddy" value="5c0707ff"/>  <!--control point outline,  gtk_processor_prefader,  stereo panner inverted fill-->
+    <Color name="meter color0" value="05a305ff"/>
+    <Color name="meter color1" value="76ff00ff"/>
+    <Color name="meter color2" value="92ff00ff"/>
+    <Color name="meter color3" value="d1ff00ff"/>
+    <Color name="meter color4" value="ffdd00ff"/>
+    <Color name="meter color5" value="ffb300ff"/>
+    <Color name="meter color6" value="ff8600ff"/>
+    <Color name="meter color7" value="ff5600ff"/>
+    <Color name="meter color8" value="ff2e00ff"/>
+    <Color name="meter color9" value="ff000eff"/>
+    <Color name="midi meter 52" value="ff6670ff"/>
+    <Color name="midi meter 53" value="ed3c48ff"/>
+    <Color name="midi meter 54" value="d40310ff"/>
+    <Color name="midi meter 55" value="9d000aff"/>
+    <Color name="midi meter 56" value="4b2414ff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="neutral:foreground"/>
     <ColorAlias name="arrange base" alias="theme:bg"/>
     <ColorAlias name="audio automation track fill" alias="theme:bg"/>
-    <ColorAlias name="audio bus base" alias="widget:blue darker"/>
+    <ColorAlias name="audio bus base" alias="widget:bg"/>
     <ColorAlias name="audio master bus base" alias="neutral:backgroundest"/>
     <ColorAlias name="audio track base" alias="neutral:background"/>
-    <ColorAlias name="automation line" alias="alert:green"/>
+    <ColorAlias name="automation line" alias="theme:contrasting"/>
     <ColorAlias name="automation track outline" alias="theme:bg1"/>
     <ColorAlias name="big clock active: background" alias="neutral:backgroundest"/>
     <ColorAlias name="big clock active: cursor" alias="theme:contrasting clock"/>
@@ -73,10 +73,10 @@
     <ColorAlias name="clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="comment button: fill" alias="widget:bg"/>
-    <ColorAlias name="control point fill" alias="alert:green"/>
-    <ColorAlias name="control point outline" alias="alert:green"/>
-    <ColorAlias name="control point selected fill" alias="alert:orange"/>
-    <ColorAlias name="control point selected outline" alias="alert:red"/>
+    <ColorAlias name="control point fill" alias="theme:contrasting clock"/>
+    <ColorAlias name="control point outline" alias="widget:ruddy"/>
+    <ColorAlias name="control point selected fill" alias="widget:ruddy"/>
+    <ColorAlias name="control point selected outline" alias="neutral:foregroundest"/>
     <ColorAlias name="covered region" alias="neutral:background2"/>
     <ColorAlias name="crossfade editor base" alias="neutral:foreground2"/>
     <ColorAlias name="crossfade editor line" alias="neutral:backgroundest"/>
@@ -89,14 +89,14 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>
-    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: led active" alias="alert:red"/>
     <ColorAlias name="foldback knob" alias="widget:bg"/>
+    <ColorAlias name="foldback knob: arc end" alias="theme:contrasting"/>
+    <ColorAlias name="foldback knob: arc start" alias="theme:contrasting"/>
     <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
-    <ColorAlias name="foldback knob: arc end" alias="widget:blue"/>
-    <ColorAlias name="foldback knob: arc start" alias="widget:blue"/>
     <ColorAlias name="frame handle" alias="theme:bg1"/>
     <ColorAlias name="gain line" alias="alert:green"/>
     <ColorAlias name="gain line inactive" alias="theme:bg1"/>
@@ -113,24 +113,24 @@
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
     <ColorAlias name="grid line minor" alias="neutral:midground"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
-    <ColorAlias name="gtk_audio_bus" alias="widget:blue darker"/>
-    <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>
+    <ColorAlias name="gtk_audio_bus" alias="widget:bg"/>
+    <ColorAlias name="gtk_audio_track" alias="widget:gray"/>
     <ColorAlias name="gtk_automation_track_header" alias="theme:bg"/>
     <ColorAlias name="gtk_background" alias="theme:bg"/>
     <ColorAlias name="gtk_bases" alias="theme:bg2"/>
-    <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
-    <ColorAlias name="gtk_bg_tooltip" alias="theme:contrasting less"/>
-    <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
+    <ColorAlias name="gtk_bg_selected" alias="neutral:midground"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="theme:contrasting alt"/>
+    <ColorAlias name="gtk_bright_color" alias="theme:contrasting"/>
     <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
-    <ColorAlias name="gtk_contrasting_indicator" alias="alert:green"/>
+    <ColorAlias name="gtk_contrasting_indicator" alias="widget:blue"/>
     <ColorAlias name="gtk_control_master" alias="theme:bg1"/>
     <ColorAlias name="gtk_control_text" alias="neutral:foreground"/>
     <ColorAlias name="gtk_control_text2" alias="alert:ruddy"/>
     <ColorAlias name="gtk_darkest" alias="theme:bg2"/>
     <ColorAlias name="gtk_entry_cursor" alias="alert:red"/>
     <ColorAlias name="gtk_fg_selected" alias="theme:bg2"/>
-    <ColorAlias name="gtk_fg_tooltip" alias="neutral:backgroundest"/>
+    <ColorAlias name="gtk_fg_tooltip" alias="neutral:background"/>
     <ColorAlias name="gtk_foldback_bg" alias="theme:bg1"/>
     <ColorAlias name="gtk_foreground" alias="neutral:foreground"/>
     <ColorAlias name="gtk_light_text_on_dark" alias="neutral:foreground2"/>
@@ -154,7 +154,7 @@
     <ColorAlias name="gtk_somewhat_bright_indicator" alias="theme:contrasting alt"/>
     <ColorAlias name="gtk_texts" alias="neutral:foreground"/>
     <ColorAlias name="gtk_track_header_inactive" alias="theme:bg"/>
-    <ColorAlias name="gtk_track_header_selected" alias="widget:ruddy"/>
+    <ColorAlias name="gtk_track_header_selected" alias="neutral:foreground2"/>
     <ColorAlias name="image track" alias="neutral:foreground2"/>
     <ColorAlias name="inactive crossfade" alias="theme:contrasting"/>
     <ColorAlias name="inactive fade handle" alias="neutral:foreground2"/>
@@ -168,13 +168,12 @@
     <ColorAlias name="layered button: fill" alias="widget:bg"/>
     <ColorAlias name="layered button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="location cd marker" alias="alert:cyan"/>
-    <ColorAlias name="location loop" alias="alert:green"/>
-    <ColorAlias name="location marker" alias="theme:contrasting clock"/>
+    <ColorAlias name="location loop" alias="neutral:foreground"/>
+    <ColorAlias name="location marker" alias="theme:contrasting alt"/>
     <ColorAlias name="location punch" alias="alert:ruddy"/>
     <ColorAlias name="location range" alias="alert:green"/>
     <ColorAlias name="lock button: fill active" alias="widget:bg"/>
     <ColorAlias name="lock button: led active" alias="alert:red"/>
-    <ColorAlias name="lua action button: fill" alias="theme:bg"/>
     <ColorAlias name="lua action button: fill" alias="widget:bg"/>
     <ColorAlias name="marker bar" alias="neutral:background2"/>
     <ColorAlias name="marker bar separator" alias="theme:bg2"/>
@@ -213,7 +212,7 @@
     <ColorAlias name="midi device: fill active" alias="theme:bg"/>
     <ColorAlias name="midi device: led active" alias="alert:green"/>
     <ColorAlias name="midi frame base" alias="neutral:background2"/>
-    <ColorAlias name="midi input button: fill active" alias="alert:green"/>
+    <ColorAlias name="midi input button: fill active" alias="theme:contrasting alt"/>
     <ColorAlias name="midi input button: led active" alias="alert:red"/>
     <ColorAlias name="midi meter color0" alias="midi meter 52"/>
     <ColorAlias name="midi meter color1" alias="midi meter 53"/>
@@ -230,7 +229,7 @@
     <ColorAlias name="midi note mid" alias="alert:yellow"/>
     <ColorAlias name="midi note min" alias="alert:orange"/>
     <ColorAlias name="midi note selected" alias="widget:ruddy"/>
-    <ColorAlias name="midi note selected outline" alias="alert:red"/>
+    <ColorAlias name="midi note selected outline" alias="neutral:foregroundest"/>
     <ColorAlias name="midi note velocity text" alias="theme:contrasting"/>
     <ColorAlias name="midi patch change fill" alias="theme:contrasting selection"/>
     <ColorAlias name="midi patch change outline" alias="neutral:foreground"/>
@@ -249,30 +248,30 @@
     <ColorAlias name="monitor section button: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section dim: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section dim: fill active" alias="alert:orange"/>
-    <ColorAlias name="monitor section dim: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section dim: led active" alias="alert:orange"/>
     <ColorAlias name="monitor section knob" alias="widget:bg"/>
-    <ColorAlias name="monitor section knob: arc end" alias="widget:blue"/>
-    <ColorAlias name="monitor section knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="monitor section knob: arc end" alias="theme:contrasting"/>
+    <ColorAlias name="monitor section knob: arc start" alias="theme:contrasting"/>
     <ColorAlias name="monitor section mono: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section mono: fill active" alias="alert:blue"/>
-    <ColorAlias name="monitor section mono: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section mono: led active" alias="alert:orange"/>
     <ColorAlias name="monitor section processors present: fill" alias="alert:orange"/>
     <ColorAlias name="monitor section processors toggle: fill" alias="theme:bg"/>
     <ColorAlias name="monitor section processors toggle: fill active" alias="theme:bg"/>
     <ColorAlias name="monitor section solo model: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section solo model: fill active" alias="theme:bg"/>
-    <ColorAlias name="monitor section solo model: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section solo model: led active" alias="alert:orange"/>
     <ColorAlias name="monitor section solo option: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section solo option: fill active" alias="theme:bg"/>
-    <ColorAlias name="monitor section solo option: led active" alias="alert:green"/>
-    <ColorAlias name="mono panner bg" alias="theme:bg2"/>
-    <ColorAlias name="mono panner fill" alias="widget:blue"/>
-    <ColorAlias name="mono panner outline" alias="theme:bg"/>
-    <ColorAlias name="mono panner position fill" alias="theme:contrasting less"/>
+    <ColorAlias name="monitor section solo option: led active" alias="alert:orange"/>
+    <ColorAlias name="mono panner bg" alias="neutral:midground"/>
+    <ColorAlias name="mono panner fill" alias="theme:contrasting"/>
+    <ColorAlias name="mono panner outline" alias="neutral:background"/>
+    <ColorAlias name="mono panner position fill" alias="theme:contrasting"/>
     <ColorAlias name="mono panner position outline" alias="theme:bg"/>
     <ColorAlias name="mono panner text" alias="neutral:backgroundest"/>
     <ColorAlias name="mouse mode button: fill" alias="widget:bg"/>
-    <ColorAlias name="mouse mode button: fill active" alias="alert:greenish"/>
+    <ColorAlias name="mouse mode button: fill active" alias="theme:contrasting alt"/>
     <ColorAlias name="mouse mode button: led active" alias="alert:green"/>
     <ColorAlias name="mute button: fill" alias="widget:bg"/>
     <ColorAlias name="mute button: fill active" alias="alert:yellow"/>
@@ -285,13 +284,13 @@
     <ColorAlias name="nudge clock: background" alias="theme:bg2"/>
     <ColorAlias name="nudge clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="nudge clock: edited text" alias="theme:contrasting clock"/>
-    <ColorAlias name="nudge clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="nudge clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="page switch button: fill" alias="widget:bg"/>
-    <ColorAlias name="page switch button: fill active" alias="alert:green"/>
-    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
-    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
+    <ColorAlias name="page switch button: fill active" alias="theme:contrasting"/>
     <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
     <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
+    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
     <ColorAlias name="piano roll black" alias="theme:contrasting selection"/>
     <ColorAlias name="piano roll black outline" alias="neutral:foreground2"/>
     <ColorAlias name="piano roll white" alias="neutral:foreground2"/>
@@ -313,15 +312,15 @@
     <ColorAlias name="processor control knob" alias="theme:bg"/>
     <ColorAlias name="processor control knob: arc end" alias="widget:blue"/>
     <ColorAlias name="processor control knob: arc start" alias="widget:blue"/>
-    <ColorAlias name="processor fader: fill" alias="widget:blue"/>
+    <ColorAlias name="processor fader: fill" alias="widget:gray"/>
     <ColorAlias name="processor fader: fill active" alias="widget:blue"/>
-    <ColorAlias name="processor fader: led active" alias="alert:green"/>
-    <ColorAlias name="processor postfader: fill" alias="widget:green"/>
-    <ColorAlias name="processor postfader: fill active" alias="widget:green"/>
-    <ColorAlias name="processor postfader: led active" alias="alert:green"/>
-    <ColorAlias name="processor prefader: fill" alias="widget:ruddy"/>
-    <ColorAlias name="processor prefader: fill active" alias="widget:ruddy"/>
-    <ColorAlias name="processor prefader: led active" alias="alert:green"/>
+    <ColorAlias name="processor fader: led active" alias="alert:orange"/>
+    <ColorAlias name="processor postfader: fill" alias="neutral:backgroundest"/>
+    <ColorAlias name="processor postfader: fill active" alias="widget:orange"/>
+    <ColorAlias name="processor postfader: led active" alias="alert:orange"/>
+    <ColorAlias name="processor prefader: fill" alias="neutral:midground"/>
+    <ColorAlias name="processor prefader: fill active" alias="widget:gray"/>
+    <ColorAlias name="processor prefader: led active" alias="alert:orange"/>
     <ColorAlias name="processor sidechain: fill" alias="alert:orange"/>
     <ColorAlias name="processor sidechain: led active" alias="alert:green"/>
     <ColorAlias name="processor stub: fill" alias="neutral:background2"/>
@@ -364,13 +363,13 @@
     <ColorAlias name="secondary clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="secondary clock: edited text" alias="theme:contrasting clock"/>
-    <ColorAlias name="secondary clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="secondary clock: text" alias="neutral:foreground2"/>
     <ColorAlias name="secondary delta clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary delta clock: cursor" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="selected midi note frame" alias="alert:ruddy"/>
-    <ColorAlias name="selected region base" alias="alert:ruddy"/>
+    <ColorAlias name="selected region base" alias="theme:contrasting alt"/>
     <ColorAlias name="selected time axis frame" alias="alert:ruddy"/>
     <ColorAlias name="selected waveform fill" alias="alert:orange"/>
     <ColorAlias name="selected waveform outline" alias="theme:bg2"/>
@@ -378,10 +377,10 @@
     <ColorAlias name="selection clock: background" alias="theme:bg2"/>
     <ColorAlias name="selection clock: cursor" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: edited text" alias="alert:ruddy"/>
-    <ColorAlias name="selection clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="selection clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="selection rect" alias="neutral:foreground"/>
-    <ColorAlias name="send alert button: fill" alias="theme:contrasting selection"/>
-    <ColorAlias name="send alert button: fill active" alias="alert:cyan"/>
+    <ColorAlias name="send alert button: fill" alias="widget:blue"/>
+    <ColorAlias name="send alert button: fill active" alias="theme:contrasting alt"/>
     <ColorAlias name="send alert button: led active" alias="alert:red"/>
     <ColorAlias name="send bg" alias="neutral:backgroundest"/>
     <ColorAlias name="send pan" alias="theme:contrasting alt"/>
@@ -391,8 +390,8 @@
     <ColorAlias name="silence" alias="theme:contrasting alt"/>
     <ColorAlias name="silence text" alias="neutral:foreground"/>
     <ColorAlias name="solo button: fill" alias="widget:bg"/>
-    <ColorAlias name="solo button: fill active" alias="alert:green"/>
-    <ColorAlias name="solo button: led active" alias="alert:green"/>
+    <ColorAlias name="solo button: fill active" alias="alert:blue"/>
+    <ColorAlias name="solo button: led active" alias="alert:blue"/>
     <ColorAlias name="solo isolate: fill" alias="widget:bg"/>
     <ColorAlias name="solo isolate: fill active" alias="widget:bg"/>
     <ColorAlias name="solo isolate: led active" alias="alert:ruddy"/>
@@ -400,16 +399,16 @@
     <ColorAlias name="solo safe: fill active" alias="widget:bg"/>
     <ColorAlias name="solo safe: led active" alias="alert:ruddy"/>
     <ColorAlias name="stereo panner bg" alias="theme:bg2"/>
-    <ColorAlias name="stereo panner fill" alias="widget:blue"/>
-    <ColorAlias name="stereo panner inverted bg" alias="widget:blue darker"/>
-    <ColorAlias name="stereo panner inverted fill" alias="theme:contrasting less"/>
-    <ColorAlias name="stereo panner inverted outline" alias="alert:ruddy"/>
+    <ColorAlias name="stereo panner fill" alias="theme:contrasting"/>
+    <ColorAlias name="stereo panner inverted bg" alias="neutral:background"/>
+    <ColorAlias name="stereo panner inverted fill" alias="widget:ruddy"/>
+    <ColorAlias name="stereo panner inverted outline" alias="neutral:backgroundest"/>
     <ColorAlias name="stereo panner inverted text" alias="neutral:backgroundest"/>
-    <ColorAlias name="stereo panner mono bg" alias="theme:bg2"/>
-    <ColorAlias name="stereo panner mono fill" alias="theme:bg"/>
-    <ColorAlias name="stereo panner mono outline" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono bg" alias="neutral:midground"/>
+    <ColorAlias name="stereo panner mono fill" alias="widget:orange"/>
+    <ColorAlias name="stereo panner mono outline" alias="neutral:backgroundest"/>
     <ColorAlias name="stereo panner mono text" alias="neutral:backgroundest"/>
-    <ColorAlias name="stereo panner outline" alias="theme:bg"/>
+    <ColorAlias name="stereo panner outline" alias="neutral:background"/>
     <ColorAlias name="stereo panner rule" alias="theme:bg"/>
     <ColorAlias name="stereo panner text" alias="neutral:backgroundest"/>
     <ColorAlias name="stretch clock: background" alias="theme:bg2"/>
@@ -431,34 +430,34 @@
     <ColorAlias name="transport active option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport active option button: fill active" alias="alert:green"/>
     <ColorAlias name="transport active option button: led active" alias="alert:green"/>
-    <ColorAlias name="transport button: fill" alias="widget:yellow"/>
-    <ColorAlias name="transport button: fill active" alias="alert:green"/>
+    <ColorAlias name="transport button: fill" alias="widget:bg"/>
+    <ColorAlias name="transport button: fill active" alias="theme:contrasting alt"/>
     <ColorAlias name="transport button: led active" alias="alert:green"/>
     <ColorAlias name="transport clock: background" alias="theme:bg2"/>
     <ColorAlias name="transport clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="transport clock: edited text" alias="theme:contrasting clock"/>
-    <ColorAlias name="transport clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="transport clock: text" alias="alert:orange"/>
     <ColorAlias name="transport delta clock: background" alias="theme:bg2"/>
     <ColorAlias name="transport delta clock: cursor" alias="theme:contrasting alt"/>
     <ColorAlias name="transport delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport drag rect" alias="neutral:midground"/>
-    <ColorAlias name="transport loop rect" alias="alert:green"/>
+    <ColorAlias name="transport loop rect" alias="neutral:foreground"/>
     <ColorAlias name="transport marker bar" alias="widget:bg"/>
-    <ColorAlias name="transport option button: fill" alias="widget:yellow"/>
+    <ColorAlias name="transport option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill active" alias="widget:bg"/>
-    <ColorAlias name="transport option button: led active" alias="alert:green"/>
-    <ColorAlias name="transport punch rect" alias="widget:ruddy"/>
+    <ColorAlias name="transport option button: led active" alias="alert:orange"/>
+    <ColorAlias name="transport punch rect" alias="theme:contrasting clock"/>
     <ColorAlias name="transport recenable button: fill" alias="widget:bg"/>
     <ColorAlias name="transport recenable button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="transport recenable button: led active" alias="alert:red"/>
     <ColorAlias name="trim handle" alias="alert:blue"/>
     <ColorAlias name="trim handle locked" alias="alert:ruddy"/>
     <ColorAlias name="trim knob" alias="widget:bg"/>
-    <ColorAlias name="trim knob: arc end" alias="widget:blue"/>
-    <ColorAlias name="trim knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="trim knob: arc end" alias="theme:contrasting"/>
+    <ColorAlias name="trim knob: arc start" alias="theme:contrasting"/>
     <ColorAlias name="vca assign button: fill" alias="widget:bg"/>
-    <ColorAlias name="verbose canvas cursor" alias="theme:contrasting clock"/>
+    <ColorAlias name="verbose canvas cursor" alias="neutral:backgroundest"/>
     <ColorAlias name="video timeline bar" alias="neutral:background2"/>
     <ColorAlias name="waveform fill" alias="neutral:foregroundest"/>
     <ColorAlias name="waveform outline" alias="neutral:backgroundest"/>
@@ -474,7 +473,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.7"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.9"/>
-    <Modifier name="editable region" modifier="= alpha:0.25"/>
+    <Modifier name="editable region" modifier="= alpha:0.15"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>
@@ -482,7 +481,7 @@
     <Modifier name="loop rectangle" modifier="= alpha:0.5"/>
     <Modifier name="marker bar" modifier="= alpha:0.5"/>
     <Modifier name="grid line" modifier="= alpha:1.0"/>
-    <Modifier name="midi frame base" modifier="= alpha:0.4"/>
+    <Modifier name="midi frame base" modifier="= alpha:0.85"/>
     <Modifier name="midi note" modifier="= alpha:0.8"/>
     <Modifier name="midi note velocity text" modifier="= alpha:0.4666"/>
     <Modifier name="midi patch change fill" modifier="= alpha:0.6274"/>


### PR DESCRIPTION
++more contrasting&bright (compared with existing theme). Added comments to < Color > section.

In the original file there was an excess line (177) - deleted in new version:
```
177   <ColorAlias name="lua action button: fill" alias="theme:bg"/>
178    <ColorAlias name="lua action button: fill" alias="widget:bg"/>
```

2min video:
https://vimeo.com/416959800