### PR TITLE
Update clear_gray-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Ardour theme-name="Clear Gray">
   <Colors>
-    <Color name="alert:blue" value="2E41E6ff"/>
-    <Color name="alert:cyan" value="20b2b2ff"/>
-    <Color name="alert:green" value="3dcc4cff"/>
-    <Color name="alert:greenish" value="459952ff"/>
-    <Color name="alert:orange" value="e58b05ff"/>
-    <Color name="alert:red" value="f10000ff"/>
-    <Color name="alert:ruddy" value="bb2828ff"/>
-    <Color name="alert:yellow" value="bba900ff"/>
-    <Color name="theme:bg" value="0x505050ff"/>  <!--gtk_background-->
-    <Color name="theme:bg1" value="0x505050ff"/>  <!--gtk_audio_track-->
-    <Color name="theme:bg2" value="0x333333ff"/>  <!--ruler base-->
-    <Color name="theme:contrasting" value="0xffffffff"/>  <!--play head-->
-    <Color name="theme:contrasting clock" value="0xf0f0f0ff"/>  <!--big clock: text-->
-    <Color name="theme:contrasting less" value="0xffffffff"/>  <!--gtk_bg_tooltip-->
-    <Color name="theme:contrasting selection" value="0xa5a5a5ff"/>  <!--gtk_bg_selected-->
-    <Color name="theme:contrasting alt" value="0x8cd8f8ff"/>  <!--secondary delta clock: text-->
-    <Color name="neutral:backgroundest" value="000000ff"/>  <!--border color-->
-    <Color name="neutral:background" value="0xf0f0f0ff"/>  <!--audio track base-->
-    <Color name="neutral:background2" value="0x8d8d8dff"/>  <!--range marker bar-->
-    <Color name="neutral:midground" value="0xffa500ff"/>  <!--grid line minor-->
-    <Color name="neutral:foreground2" value="0xddddd8ff"/>  <!--marker track-->
-    <Color name="neutral:foreground" value="0xffffffff"/>  <!--gtk_foreground-->
-    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major-->
-    <Color name="widget:bg" value="0x9e9e9eff"/>    <!--generic button-->
-    <Color name="widget:blue" value="0x5550A0ff"/>  <!--processor fader: fill-->
-    <Color name="widget:blue darker" value="0x202020ff"/>  <!--gtk_audio_bus-->
-    <Color name="widget:gray" value="0x636363ff"/>  <!--gtk_processor_fader-->
-    <Color name="widget:green" value="0x969696ff"/>  <!--gtk_processor_postfader,  gtk_midi_track-->
-    <Color name="widget:green darker" value="0xffffffff"/>  <!--midi track base-->
-    <Color name="widget:orange" value="0xff0000ff"/>  <!--tempo marker-->
-    <Color name="widget:ruddy" value="0xb5b2b1ff"/>  <!--processor prefader-->
-    <Color name="meter color0" value="008800ff"/>
-    <Color name="meter color1" value="00aa00ff"/>
-    <Color name="meter color2" value="00ff00ff"/>
-    <Color name="meter color3" value="00ff00ff"/>
-    <Color name="meter color4" value="fff000ff"/>
-    <Color name="meter color5" value="fff000ff"/>
-    <Color name="meter color6" value="ff8800ff"/>
-    <Color name="meter color7" value="ff8800ff"/>
-    <Color name="meter color8" value="ff0000ff"/>
+   <Color name="alert:blue" value="2e41e6ff"/>  <!--monitor section mono: fill active,  send alert button: fill active,  trim handle-->
+    <Color name="alert:cyan" value="54a5ffff"/>  <!--location loop,  monitor button: fill active,  pluginlist hide button: led active-->
+    <Color name="alert:green" value="1c7c52ff"/>  <!--rude solo: fill active,  solo button: fill active-->
+    <Color name="alert:greenish" value="459952ff"/>  <!--no any-->
+    <Color name="alert:orange" value="e53b05ff"/>  <!--monitor section dim: fill active,  page switch button: fill active-->
+    <Color name="alert:red" value="fd0325ff"/>  <!--clipped waveform,  feedback alert: fill active,  gtk_bright_indicator,  midi note selected outline, transport punch rect-->
+    <Color name="alert:ruddy" value="bb2828ff"/>  <!--gtk_control_text2,  range drag rect,  selected midi note frame,  recording rect,  record enable button: fill active-->
+    <Color name="alert:yellow" value="edc67dff"/>  <!--mute button: fill active-->
+    <Color name="theme:bg" value="515151ff"/>  <!--gtk_background,  gtk_automation_track_header,  piano roll black,  stereo panner outline-->
+    <Color name="theme:bg1" value="515151ff"/>  <!--gtk_audio_track,  meter bar-->
+    <Color name="theme:bg2" value="191919ff"/>  <!--ruler base,  big clock: background,  gtk_darkest,  clock: background,  selected waveform outline-->
+    <Color name="theme:contrasting" value="f16b00ff"/>  <!--mono panner position fill-->
+    <Color name="theme:contrasting clock" value="ffffffff"/>  <!--big clock: text,  play head,  clock: text,  stereo panner fill,  processor fader: led active-->
+    <Color name="theme:contrasting less" value="ff616cff"/>  <!--stereo panner inverted fill,  time stretch fill-->
+    <Color name="theme:contrasting selection" value="92d5f7ff"/>  <!--midi patch change fill-->
+    <Color name="theme:contrasting alt" value="aa8e39ff"/>  <!--gtk_somewhat_bright_indicator,  rude isolate: fill active,  secondary delta clock: text-->
+    <Color name="neutral:backgroundest" value="000000ff"/>  <!--border color,  automation line,  control point fill,  grid line major,  waveform outline-->
+    <Color name="neutral:background" value="202020ff"/>  <!--audio track base,  processor control button: fill-->
+    <Color name="neutral:background2" value="555555ff"/>  <!--range marker bar,  covered region,  midi frame base,  recording waveform outline,  tempo bar-->
+    <Color name="neutral:midground" value="7f7f7fff"/>  <!--grid line minor,  ruler text-->
+    <Color name="neutral:foreground2" value="ccccccff"/>  <!--marker track,  gtk_light_text_on_dark,  piano roll white,  secondary clock: text-->
+    <Color name="neutral:foreground" value="e5e5e5ff"/>  <!--gtk_foreground,  gtk_bg_tooltip,  gtk_texts-->
+    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--gtk_lightest,  recording waveform fill,  waveform fill-->
+    <Color name="widget:bg" value="959595ff"/>    <!--generic button,  mixer strip button: fill,  mouse mode button: fill,  transport button: fill-->
+    <Color name="widget:blue" value="b1b1b1ff"/>  <!--processor fader: fill,  tempo curve-->
+    <Color name="widget:blue darker" value="252525ff"/>  <!--gtk_audio_bus,  audio bus base-->
+    <Color name="widget:gray" value="595755ff"/>  <!--gtk_processor_fader,  piano roll black outline,  time stretch outline,  stereo panner mono outline-->
+    <Color name="widget:green" value="484947ff"/>  <!--gtk_processor_postfader,  processor postfader: fill-->
+    <Color name="widget:green darker" value="959595ff"/>  <!--gtk_midi_track,  midi track base,  midi automation track fill-->
+    <Color name="widget:orange" value="904010ff"/>  <!--tempo marker,  meter marker-->
+    <Color name="widget:ruddy" value="cacacaff"/>  <!--processor prefader,  gtk_track_header_selected-->
+    <Color name="meter color0" value="00ff6bff"/>
+    <Color name="meter color1" value="00fb14ff"/>
+    <Color name="meter color2" value="00fe00ff"/>
+    <Color name="meter color3" value="b6ff00ff"/>
+    <Color name="meter color4" value="d7ff00ff"/>
+    <Color name="meter color5" value="ffbd00ff"/>
+    <Color name="meter color6" value="ffa700ff"/>
+    <Color name="meter color7" value="ff6900ff"/>
+    <Color name="meter color8" value="ff3700ff"/>
     <Color name="meter color9" value="ff0000ff"/>
-    <Color name="midi meter 52" value="e8faa1ff"/>
-    <Color name="midi meter 53" value="f2c37dff"/>
-    <Color name="midi meter 54" value="ffac44ff"/>
-    <Color name="midi meter 55" value="f48352ff"/>
-    <Color name="midi meter 56" value="f85813ff"/>
+    <Color name="midi meter 52" value="ffffffff"/>
+    <Color name="midi meter 53" value="acacacff"/>
+    <Color name="midi meter 54" value="646464ff"/>
+    <Color name="midi meter 55" value="535353ff"/>
+    <Color name="midi meter 56" value="2e2e2eff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="neutral:foreground"/>
-    <ColorAlias name="arrange base" alias="theme:bg"/>
+    <ColorAlias name="arrange base" alias="neutral:foreground2"/>
     <ColorAlias name="audio automation track fill" alias="theme:bg"/>
     <ColorAlias name="audio bus base" alias="widget:blue darker"/>
     <ColorAlias name="audio master bus base" alias="neutral:backgroundest"/>
     <ColorAlias name="audio track base" alias="neutral:background"/>
-    <ColorAlias name="automation line" alias="alert:green"/>
+    <ColorAlias name="automation line" alias="neutral:backgroundest"/>
     <ColorAlias name="automation track outline" alias="theme:bg1"/>
     <ColorAlias name="big clock active: background" alias="neutral:backgroundest"/>
     <ColorAlias name="big clock active: cursor" alias="theme:contrasting clock"/>
@@ -73,9 +73,9 @@
     <ColorAlias name="clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="comment button: fill" alias="widget:bg"/>
-    <ColorAlias name="control point fill" alias="alert:green"/>
-    <ColorAlias name="control point outline" alias="alert:green"/>
-    <ColorAlias name="control point selected fill" alias="alert:orange"/>
+    <ColorAlias name="control point fill" alias="neutral:backgroundest"/>
+    <ColorAlias name="control point outline" alias="neutral:backgroundest"/>
+    <ColorAlias name="control point selected fill" alias="theme:contrasting clock"/>
     <ColorAlias name="control point selected outline" alias="alert:red"/>
     <ColorAlias name="covered region" alias="neutral:background2"/>
     <ColorAlias name="crossfade editor base" alias="neutral:foreground2"/>
@@ -89,14 +89,14 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>
-    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: led active" alias="alert:red"/>
     <ColorAlias name="foldback knob" alias="widget:bg"/>
-    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
     <ColorAlias name="foldback knob: arc end" alias="widget:blue"/>
     <ColorAlias name="foldback knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
     <ColorAlias name="frame handle" alias="theme:bg1"/>
     <ColorAlias name="gain line" alias="alert:green"/>
     <ColorAlias name="gain line inactive" alias="theme:bg1"/>
@@ -109,7 +109,7 @@
     <ColorAlias name="ghost track wave clip" alias="neutral:background"/>
     <ColorAlias name="ghost track wave fill" alias="neutral:foregroundest"/>
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
-    <ColorAlias name="grid line major" alias="neutral:foregroundest"/>
+    <ColorAlias name="grid line major" alias="neutral:backgroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
     <ColorAlias name="grid line minor" alias="neutral:midground"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
@@ -118,9 +118,9 @@
     <ColorAlias name="gtk_automation_track_header" alias="theme:bg"/>
     <ColorAlias name="gtk_background" alias="theme:bg"/>
     <ColorAlias name="gtk_bases" alias="theme:bg2"/>
-    <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
-    <ColorAlias name="gtk_bg_tooltip" alias="theme:contrasting less"/>
-    <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
+    <ColorAlias name="gtk_bg_selected" alias="widget:bg"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_bright_color" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_contrasting_indicator" alias="alert:green"/>
@@ -168,13 +168,12 @@
     <ColorAlias name="layered button: fill" alias="widget:bg"/>
     <ColorAlias name="layered button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="location cd marker" alias="alert:cyan"/>
-    <ColorAlias name="location loop" alias="alert:green"/>
-    <ColorAlias name="location marker" alias="theme:contrasting clock"/>
+    <ColorAlias name="location loop" alias="alert:cyan"/>
+    <ColorAlias name="location marker" alias="theme:contrasting"/>
     <ColorAlias name="location punch" alias="alert:ruddy"/>
     <ColorAlias name="location range" alias="alert:green"/>
     <ColorAlias name="lock button: fill active" alias="widget:bg"/>
     <ColorAlias name="lock button: led active" alias="alert:red"/>
-    <ColorAlias name="lua action button: fill" alias="theme:bg"/>
     <ColorAlias name="lua action button: fill" alias="widget:bg"/>
     <ColorAlias name="marker bar" alias="neutral:background2"/>
     <ColorAlias name="marker bar separator" alias="theme:bg2"/>
@@ -186,8 +185,8 @@
     <ColorAlias name="master monitor section button normal: fill active" alias="widget:bg"/>
     <ColorAlias name="measure line bar" alias="neutral:foregroundest"/>
     <ColorAlias name="measure line beat" alias="widget:blue"/>
-    <ColorAlias name="meter background bottom" alias="neutral:background2"/>
-    <ColorAlias name="meter background top" alias="theme:bg"/>
+    <ColorAlias name="meter background bottom" alias="neutral:backgroundest"/>
+    <ColorAlias name="meter background top" alias="neutral:backgroundest"/>
     <ColorAlias name="meter bar" alias="theme:bg1"/>
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
@@ -213,7 +212,7 @@
     <ColorAlias name="midi device: fill active" alias="theme:bg"/>
     <ColorAlias name="midi device: led active" alias="alert:green"/>
     <ColorAlias name="midi frame base" alias="neutral:background2"/>
-    <ColorAlias name="midi input button: fill active" alias="alert:green"/>
+    <ColorAlias name="midi input button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="midi input button: led active" alias="alert:red"/>
     <ColorAlias name="midi meter color0" alias="midi meter 52"/>
     <ColorAlias name="midi meter color1" alias="midi meter 53"/>
@@ -239,41 +238,41 @@
     <ColorAlias name="midi sysex outline" alias="theme:contrasting alt"/>
     <ColorAlias name="midi track base" alias="widget:green darker"/>
     <ColorAlias name="mixer strip button: fill" alias="widget:bg"/>
-    <ColorAlias name="mixer strip button: fill active" alias="theme:bg1"/>
+    <ColorAlias name="mixer strip button: fill active" alias="theme:contrasting"/>
     <ColorAlias name="mixer strip button: led active" alias="alert:green"/>
     <ColorAlias name="mixer strip name button: fill active" alias="theme:bg2"/>
     <ColorAlias name="mixer strip name button: led active" alias="alert:green"/>
     <ColorAlias name="monitor button: fill" alias="widget:bg"/>
-    <ColorAlias name="monitor button: fill active" alias="alert:orange"/>
+    <ColorAlias name="monitor button: fill active" alias="alert:cyan"/>
     <ColorAlias name="monitor button: led active" alias="alert:ruddy"/>
     <ColorAlias name="monitor section button: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section dim: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section dim: fill active" alias="alert:orange"/>
-    <ColorAlias name="monitor section dim: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section dim: led active" alias="alert:red"/>
     <ColorAlias name="monitor section knob" alias="widget:bg"/>
-    <ColorAlias name="monitor section knob: arc end" alias="widget:blue"/>
-    <ColorAlias name="monitor section knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="monitor section knob: arc end" alias="theme:contrasting clock"/>
+    <ColorAlias name="monitor section knob: arc start" alias="theme:contrasting clock"/>
     <ColorAlias name="monitor section mono: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section mono: fill active" alias="alert:blue"/>
-    <ColorAlias name="monitor section mono: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section mono: led active" alias="alert:red"/>
     <ColorAlias name="monitor section processors present: fill" alias="alert:orange"/>
     <ColorAlias name="monitor section processors toggle: fill" alias="theme:bg"/>
     <ColorAlias name="monitor section processors toggle: fill active" alias="theme:bg"/>
     <ColorAlias name="monitor section solo model: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section solo model: fill active" alias="theme:bg"/>
-    <ColorAlias name="monitor section solo model: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section solo model: led active" alias="alert:red"/>
     <ColorAlias name="monitor section solo option: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section solo option: fill active" alias="theme:bg"/>
-    <ColorAlias name="monitor section solo option: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section solo option: led active" alias="alert:red"/>
     <ColorAlias name="mono panner bg" alias="theme:bg2"/>
-    <ColorAlias name="mono panner fill" alias="widget:blue"/>
+    <ColorAlias name="mono panner fill" alias="theme:contrasting clock"/>
     <ColorAlias name="mono panner outline" alias="theme:bg"/>
-    <ColorAlias name="mono panner position fill" alias="theme:contrasting less"/>
+    <ColorAlias name="mono panner position fill" alias="theme:contrasting"/>
     <ColorAlias name="mono panner position outline" alias="theme:bg"/>
     <ColorAlias name="mono panner text" alias="neutral:backgroundest"/>
     <ColorAlias name="mouse mode button: fill" alias="widget:bg"/>
-    <ColorAlias name="mouse mode button: fill active" alias="alert:greenish"/>
-    <ColorAlias name="mouse mode button: led active" alias="alert:green"/>
+    <ColorAlias name="mouse mode button: fill active" alias="theme:contrasting clock"/>
+    <ColorAlias name="mouse mode button: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="mute button: fill" alias="widget:bg"/>
     <ColorAlias name="mute button: fill active" alias="alert:yellow"/>
     <ColorAlias name="mute button: led active" alias="alert:yellow"/>
@@ -287,23 +286,23 @@
     <ColorAlias name="nudge clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="nudge clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="page switch button: fill" alias="widget:bg"/>
-    <ColorAlias name="page switch button: fill active" alias="alert:green"/>
-    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
-    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
+    <ColorAlias name="page switch button: fill active" alias="alert:orange"/>
     <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
     <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
-    <ColorAlias name="piano roll black" alias="theme:contrasting selection"/>
-    <ColorAlias name="piano roll black outline" alias="neutral:foreground2"/>
+    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
+    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
+    <ColorAlias name="piano roll black" alias="theme:bg"/>
+    <ColorAlias name="piano roll black outline" alias="widget:gray"/>
     <ColorAlias name="piano roll white" alias="neutral:foreground2"/>
     <ColorAlias name="pinrouting custom: led active" alias="alert:ruddy"/>
     <ColorAlias name="pinrouting sidechain: led active" alias="alert:green"/>
-    <ColorAlias name="play head" alias="theme:contrasting"/>
+    <ColorAlias name="play head" alias="theme:contrasting clock"/>
     <ColorAlias name="plugin automation state button: fill active" alias="alert:orange"/>
     <ColorAlias name="plugin bypass button: led active" alias="alert:red"/>
     <ColorAlias name="pluginlist filter button: fill active" alias="widget:bg"/>
     <ColorAlias name="pluginlist hide button: led active" alias="alert:cyan"/>
     <ColorAlias name="pluginui toggle: fill" alias="widget:bg"/>
-    <ColorAlias name="pluginui toggle: fill active" alias="widget:blue"/>
+    <ColorAlias name="pluginui toggle: fill active" alias="alert:red"/>
     <ColorAlias name="processor automation line" alias="theme:bg1"/>
     <ColorAlias name="processor auxfeedback: fill" alias="theme:contrasting alt"/>
     <ColorAlias name="processor auxfeedback: led active" alias="alert:green"/>
@@ -315,13 +314,13 @@
     <ColorAlias name="processor control knob: arc start" alias="widget:blue"/>
     <ColorAlias name="processor fader: fill" alias="widget:blue"/>
     <ColorAlias name="processor fader: fill active" alias="widget:blue"/>
-    <ColorAlias name="processor fader: led active" alias="alert:green"/>
+    <ColorAlias name="processor fader: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="processor postfader: fill" alias="widget:green"/>
     <ColorAlias name="processor postfader: fill active" alias="widget:green"/>
-    <ColorAlias name="processor postfader: led active" alias="alert:green"/>
+    <ColorAlias name="processor postfader: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="processor prefader: fill" alias="widget:ruddy"/>
     <ColorAlias name="processor prefader: fill active" alias="widget:ruddy"/>
-    <ColorAlias name="processor prefader: led active" alias="alert:green"/>
+    <ColorAlias name="processor prefader: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="processor sidechain: fill" alias="alert:orange"/>
     <ColorAlias name="processor sidechain: led active" alias="alert:green"/>
     <ColorAlias name="processor stub: fill" alias="neutral:background2"/>
@@ -357,14 +356,14 @@
     <ColorAlias name="rude isolate: fill active" alias="theme:contrasting alt"/>
     <ColorAlias name="rude isolate: led active" alias="alert:red"/>
     <ColorAlias name="rude solo: fill" alias="widget:bg"/>
-    <ColorAlias name="rude solo: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="rude solo: fill active" alias="alert:green"/>
     <ColorAlias name="rude solo: led active" alias="alert:red"/>
     <ColorAlias name="ruler base" alias="theme:bg2"/>
     <ColorAlias name="ruler text" alias="neutral:midground"/>
     <ColorAlias name="secondary clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="secondary clock: edited text" alias="theme:contrasting clock"/>
-    <ColorAlias name="secondary clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="secondary clock: text" alias="neutral:foreground2"/>
     <ColorAlias name="secondary delta clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary delta clock: cursor" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: edited text" alias="theme:contrasting alt"/>
@@ -372,16 +371,16 @@
     <ColorAlias name="selected midi note frame" alias="alert:ruddy"/>
     <ColorAlias name="selected region base" alias="alert:ruddy"/>
     <ColorAlias name="selected time axis frame" alias="alert:ruddy"/>
-    <ColorAlias name="selected waveform fill" alias="alert:orange"/>
+    <ColorAlias name="selected waveform fill" alias="neutral:backgroundest"/>
     <ColorAlias name="selected waveform outline" alias="theme:bg2"/>
     <ColorAlias name="selection" alias="alert:red"/>
     <ColorAlias name="selection clock: background" alias="theme:bg2"/>
     <ColorAlias name="selection clock: cursor" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: edited text" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: text" alias="theme:contrasting clock"/>
-    <ColorAlias name="selection rect" alias="neutral:foreground"/>
-    <ColorAlias name="send alert button: fill" alias="theme:contrasting selection"/>
-    <ColorAlias name="send alert button: fill active" alias="alert:cyan"/>
+    <ColorAlias name="selection rect" alias="neutral:backgroundest"/>
+    <ColorAlias name="send alert button: fill" alias="alert:cyan"/>
+    <ColorAlias name="send alert button: fill active" alias="alert:blue"/>
     <ColorAlias name="send alert button: led active" alias="alert:red"/>
     <ColorAlias name="send bg" alias="neutral:backgroundest"/>
     <ColorAlias name="send pan" alias="theme:contrasting alt"/>
@@ -400,14 +399,14 @@
     <ColorAlias name="solo safe: fill active" alias="widget:bg"/>
     <ColorAlias name="solo safe: led active" alias="alert:ruddy"/>
     <ColorAlias name="stereo panner bg" alias="theme:bg2"/>
-    <ColorAlias name="stereo panner fill" alias="widget:blue"/>
+    <ColorAlias name="stereo panner fill" alias="theme:contrasting clock"/>
     <ColorAlias name="stereo panner inverted bg" alias="widget:blue darker"/>
     <ColorAlias name="stereo panner inverted fill" alias="theme:contrasting less"/>
-    <ColorAlias name="stereo panner inverted outline" alias="alert:ruddy"/>
+    <ColorAlias name="stereo panner inverted outline" alias="alert:red"/>
     <ColorAlias name="stereo panner inverted text" alias="neutral:backgroundest"/>
     <ColorAlias name="stereo panner mono bg" alias="theme:bg2"/>
-    <ColorAlias name="stereo panner mono fill" alias="theme:bg"/>
-    <ColorAlias name="stereo panner mono outline" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono fill" alias="theme:contrasting"/>
+    <ColorAlias name="stereo panner mono outline" alias="widget:gray"/>
     <ColorAlias name="stereo panner mono text" alias="neutral:backgroundest"/>
     <ColorAlias name="stereo panner outline" alias="theme:bg"/>
     <ColorAlias name="stereo panner rule" alias="theme:bg"/>
@@ -415,7 +414,7 @@
     <ColorAlias name="stretch clock: background" alias="theme:bg2"/>
     <ColorAlias name="stretch clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="stretch clock: edited text" alias="theme:contrasting clock"/>
-    <ColorAlias name="stretch clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="stretch clock: text" alias="alert:red"/>
     <ColorAlias name="sync mark" alias="theme:contrasting clock"/>
     <ColorAlias name="tempo bar" alias="neutral:background2"/>
     <ColorAlias name="tempo curve" alias="widget:blue"/>
@@ -432,8 +431,8 @@
     <ColorAlias name="transport active option button: fill active" alias="alert:green"/>
     <ColorAlias name="transport active option button: led active" alias="alert:green"/>
     <ColorAlias name="transport button: fill" alias="widget:bg"/>
-    <ColorAlias name="transport button: fill active" alias="alert:green"/>
-    <ColorAlias name="transport button: led active" alias="alert:green"/>
+    <ColorAlias name="transport button: fill active" alias="theme:contrasting clock"/>
+    <ColorAlias name="transport button: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="transport clock: background" alias="theme:bg2"/>
     <ColorAlias name="transport clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="transport clock: edited text" alias="theme:contrasting clock"/>
@@ -443,12 +442,12 @@
     <ColorAlias name="transport delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport drag rect" alias="neutral:midground"/>
-    <ColorAlias name="transport loop rect" alias="alert:green"/>
+    <ColorAlias name="transport loop rect" alias="theme:contrasting clock"/>
     <ColorAlias name="transport marker bar" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill active" alias="widget:bg"/>
-    <ColorAlias name="transport option button: led active" alias="alert:green"/>
-    <ColorAlias name="transport punch rect" alias="widget:ruddy"/>
+    <ColorAlias name="transport option button: led active" alias="alert:red"/>
+    <ColorAlias name="transport punch rect" alias="alert:red"/>
     <ColorAlias name="transport recenable button: fill" alias="widget:bg"/>
     <ColorAlias name="transport recenable button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="transport recenable button: led active" alias="alert:red"/>
@@ -474,7 +473,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.7"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.9"/>
-    <Modifier name="editable region" modifier="= alpha:0.25"/>
+    <Modifier name="editable region" modifier="= alpha:0.15"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>
@@ -482,7 +481,7 @@
     <Modifier name="loop rectangle" modifier="= alpha:0.5"/>
     <Modifier name="marker bar" modifier="= alpha:0.5"/>
     <Modifier name="grid line" modifier="= alpha:1.0"/>
-    <Modifier name="midi frame base" modifier="= alpha:0.4"/>
+    <Modifier name="midi frame base" modifier="= alpha:0.85"/>
     <Modifier name="midi note" modifier="= alpha:0.8"/>
     <Modifier name="midi note velocity text" modifier="= alpha:0.4666"/>
     <Modifier name="midi patch change fill" modifier="= alpha:0.6274"/>
@@ -502,6 +501,6 @@
     <Modifier name="time axis view item base" modifier="= alpha:0.7"/>
     <Modifier name="transparent region base" modifier="= alpha:0.6"/>
    <Modifier name="time stretch fill" modifier="= alpha:0.5"/>
-    <Modifier name="verbose canvas cursor" modifier="= alpha:0.4666"/>
+    <Modifier name="verbose canvas cursor" modifier="= alpha:0.8"/>
   </Modifiers>
 </Ardour>


### PR DESCRIPTION
++more contrasting&bright (compared with existing theme). Added comments to < Color > section.

In the original file there was an excess line (177) - deleted in new version:
```
 177 <ColorAlias name="lua action button: fill" alias="theme:bg"/>
 178<ColorAlias name="lua action button: fill" alias="widget:bg"/>
```

video:
https://vimeo.com/419249079