### PR TITLE
Update cubasish-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Ardour theme-name="Cubasish">
   <Colors>
-    <Color name="alert:blue" value="0x6024d1ff"/>
-    <Color name="alert:cyan" value="20b2b2ff"/>
-    <Color name="alert:green" value="3dcc4cff"/>
-    <Color name="alert:greenish" value="459952ff"/>
-    <Color name="alert:orange" value="e58b05ff"/>
-    <Color name="alert:red" value="f10000ff"/>
-    <Color name="alert:ruddy" value="bb2828ff"/>
-    <Color name="alert:yellow" value="bba900ff"/>
-    <Color name="theme:bg" value="0x282b30ff"/>  <!--gtk_background-->
-    <Color name="theme:bg1" value="0x2f3841ff"/>  <!--gtk_audio_track-->
-    <Color name="theme:bg2" value="0x121212ff"/>  <!--ruler base-->
-    <Color name="theme:contrasting" value="0xffffffff"/>  <!--play head-->
-    <Color name="theme:contrasting clock" value="0xf0f0f0ff"/>  <!--big clock: text-->
-    <Color name="theme:contrasting less" value="0xbba34cff"/>  <!--gtk_bg_tooltip-->
-    <Color name="theme:contrasting selection" value="0xacb3b9ff"/>  <!--gtk_bg_selected-->
-    <Color name="theme:contrasting alt" value="0x8cd8f8ff"/>  <!--secondary delta clock: text-->
-    <Color name="neutral:backgroundest" value="000000ff"/>  <!--border color-->
-    <Color name="neutral:background" value="0x7aadf9ff"/>  <!--audio track base-->
-    <Color name="neutral:background2" value="0xcbd6daff"/>  <!--range marker bar-->
-    <Color name="neutral:midground" value="7f7f7fff"/>  <!--grid line minor-->
-    <Color name="neutral:foreground2" value="0xddddd8ff"/>  <!--marker track-->
-    <Color name="neutral:foreground" value="0xeeeeecff"/>  <!--gtk_foreground-->
-    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major-->
-    <Color name="widget:bg" value="0xc0c4c9ff"/>    <!--generic button-->
-    <Color name="widget:blue" value="0xdde1e4ff"/>  <!--processor fader: fill-->
-    <Color name="widget:blue darker" value="0x20242aff"/>  <!--gtk_audio_bus-->
-    <Color name="widget:gray" value="0x636363ff"/>  <!--gtk_processor_fader-->
-    <Color name="widget:green" value="0x2f3841ff"/>  <!--gtk processor postfader,  gtk_midi_track-->
-    <Color name="widget:green darker" value="0xcececeff"/>  <!--midi track base-->
-    <Color name="widget:orange" value="0xdd6363ff"/>  <!--tempo marker-->
-    <Color name="widget:ruddy" value="0xacb3b9ff"/>  <!--processor prefader-->
-    <Color name="meter color0" value="008800ff"/>
-    <Color name="meter color1" value="00aa00ff"/>
-    <Color name="meter color2" value="00ff00ff"/>
-    <Color name="meter color3" value="00ff00ff"/>
-    <Color name="meter color4" value="fff000ff"/>
-    <Color name="meter color5" value="fff000ff"/>
-    <Color name="meter color6" value="ff8800ff"/>
-    <Color name="meter color7" value="ff8800ff"/>
-    <Color name="meter color8" value="ff0000ff"/>
+    <Color name="alert:blue" value="5e00d1ff"/>  <!--monitor section mono: fill active,  transport button: fill active,  trim handle-->
+    <Color name="alert:cyan" value="6ddfffff"/>  <!--location cd marker,  midi select rect outline,  page switch button: fill active,  send alert button: fill active-->
+    <Color name="alert:green" value="3dcc4cff"/>  <!--gtk_solo,  location range,  solo button: fill active-->
+    <Color name="alert:greenish" value="200095ff"/>  <!--not green but blue-->  <!--automation line--> 
+    <Color name="alert:orange" value="ee6533ff"/>  <!--gtk_monitor,  monitor button: fill active,  plugin automation state button: fill active,  stereo panner mono fill-->
+    <Color name="alert:red" value="f1001fff"/>  <!--clipped waveform,  gtk_arm,  gtk_clip_indicator,  punch button: led active-->
+    <Color name="alert:ruddy" value="8a011eff"/>  <!--control point selected outline,  feedback alert: alt active,  location punch,  rude solo: fill active,  stereo panner inverted outline-->
+    <Color name="alert:yellow" value="f0ca65ff"/>  <!--gtk_mute,  mute button: fill active-->
+    <Color name="theme:bg" value="2d2e33ff"/>  <!--gtk_background,  gtk_automation_track_header,  stereo panner outline-->
+    <Color name="theme:bg1" value="383e46ff"/>  <!--gtk_audio_track, stereo panner mono outline-->
+    <Color name="theme:bg2" value="191c1fff"/>  <!--ruler base,  big clock: background,  clock: background,  selected waveform outline,  transport clock: background-->
+    <Color name="theme:contrasting" value="b97f84ff"/>  <!--stereo panner inverted fill-->
+    <Color name="theme:contrasting clock" value="ffffffff"/>  <!--play head,  big clock: text,  midi note selected outline,  mouse mode button: fill active,  processor fader: led active-->
+    <Color name="theme:contrasting less" value="aeb0b6ff"/>  <!--gtk_bg_tooltip,  time stretch fill-->
+    <Color name="theme:contrasting selection" value="9a9ca1ff"/>  <!--gtk_bg_selected,  piano roll black,  send alert button: fill-->
+    <Color name="theme:contrasting alt" value="cca336ff"/>  <!--secondary delta clock: text,  rude isolate: fill active-->
+    <Color name="neutral:backgroundest" value="000000ff"/>  <!--border color,  location loop,  mono panner text,  range marker bar,  selection rect-->
+    <Color name="neutral:background" value="202020ff"/>  <!--audio track base,  gtk_fg_tooltip,  processor control button: fil-->
+    <Color name="neutral:background2" value="555555ff"/>  <!--midi frame base,  recording waveform outline,  transport marker bar,  video timeline bar-->
+    <Color name="neutral:midground" value="7f7f7fff"/>  <!--grid line minor,  gtk_processor_fader_frame,  range drag bar rect,  ruler text-->
+    <Color name="neutral:foreground2" value="ccccccff"/>  <!--marker track,  marker bar-->
+    <Color name="neutral:foreground" value="e5e5e5ff"/>  <!--gtk_foreground,  arrange base,  gtk_texts,  -->
+    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major,  recording waveform fill,  waveform fill-->
+    <Color name="widget:bg" value="b3b4bbff"/>    <!--generic button,  mouse mode button: fill,  transport button: fill-->
+    <Color name="widget:blue" value="8193cbff"/>  <!--gtk_bright_color,  midi input button: fill activ,  selected time axis frame-->
+    <Color name="widget:blue darker" value="191c1fff"/>  <!--gtk_audio_bus,  audio bus base,  stereo panner inverted bg-->
+    <Color name="widget:gray" value="e0e0e0ff"/>  <!--gtk_processor_fader,  processor fader: fill,  time stretch outline-->
+    <Color name="widget:green" value="606773ff"/>  <!--gtk processor postfader,  gtk_midi_track,  processor postfader: fill-->
+    <Color name="widget:green darker" value="2c313cff"/>  <!--gtk_midi_track,  midi automation track fill,  mono panner outline-->
+    <Color name="widget:orange" value="c5baffff"/>  <!--tempo marker,  meter marker-->
+    <Color name="widget:ruddy" value="abb1b8ff"/>  <!--gtk_track_header_selected,  gtk_processor_prefader-->
+    <Color name="meter color0" value="3dd8fdff"/>
+    <Color name="meter color1" value="12f0d1ff"/>
+    <Color name="meter color2" value="00fdb6ff"/>
+    <Color name="meter color3" value="00fd26ff"/>
+    <Color name="meter color4" value="81fd00ff"/>
+    <Color name="meter color5" value="d0fd00ff"/>
+    <Color name="meter color6" value="ffe700ff"/>
+    <Color name="meter color7" value="ffcc00ff"/>
+    <Color name="meter color8" value="ffaa00ff"/>
     <Color name="meter color9" value="ff0000ff"/>
-    <Color name="midi meter 52" value="e8faa1ff"/>
-    <Color name="midi meter 53" value="f2c37dff"/>
-    <Color name="midi meter 54" value="ffac44ff"/>
-    <Color name="midi meter 55" value="f48352ff"/>
-    <Color name="midi meter 56" value="f85813ff"/>
+    <Color name="midi meter 52" value="221f70ff"/>
+    <Color name="midi meter 53" value="421d7aff"/>
+    <Color name="midi meter 54" value="7610baff"/>
+    <Color name="midi meter 55" value="b22353ff"/>
+    <Color name="midi meter 56" value="ea0508ff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="neutral:foreground"/>
-    <ColorAlias name="arrange base" alias="theme:bg"/>
-    <ColorAlias name="audio automation track fill" alias="theme:bg"/>
+    <ColorAlias name="arrange base" alias="neutral:foreground"/>
+    <ColorAlias name="audio automation track fill" alias="theme:contrasting clock"/>
     <ColorAlias name="audio bus base" alias="widget:blue darker"/>
     <ColorAlias name="audio master bus base" alias="neutral:backgroundest"/>
     <ColorAlias name="audio track base" alias="neutral:background"/>
-    <ColorAlias name="automation line" alias="alert:green"/>
+    <ColorAlias name="automation line" alias="alert:greenish"/>
     <ColorAlias name="automation track outline" alias="theme:bg1"/>
     <ColorAlias name="big clock active: background" alias="neutral:backgroundest"/>
     <ColorAlias name="big clock active: cursor" alias="theme:contrasting clock"/>
@@ -66,17 +66,17 @@
     <ColorAlias name="big clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="big clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="border color" alias="neutral:backgroundest"/>
-    <ColorAlias name="cd marker bar" alias="neutral:background2"/>
+    <ColorAlias name="cd marker bar" alias="neutral:backgroundest"/>
     <ColorAlias name="clipped waveform" alias="alert:red"/>
     <ColorAlias name="clock: background" alias="theme:bg2"/>
     <ColorAlias name="clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="comment button: fill" alias="widget:bg"/>
-    <ColorAlias name="control point fill" alias="alert:green"/>
-    <ColorAlias name="control point outline" alias="alert:green"/>
-    <ColorAlias name="control point selected fill" alias="alert:orange"/>
-    <ColorAlias name="control point selected outline" alias="alert:red"/>
+    <ColorAlias name="control point fill" alias="neutral:backgroundest"/>
+    <ColorAlias name="control point outline" alias="neutral:backgroundest"/>
+    <ColorAlias name="control point selected fill" alias="alert:red"/>
+    <ColorAlias name="control point selected outline" alias="alert:ruddy"/>
     <ColorAlias name="covered region" alias="neutral:background2"/>
     <ColorAlias name="crossfade editor base" alias="neutral:foreground2"/>
     <ColorAlias name="crossfade editor line" alias="neutral:backgroundest"/>
@@ -89,20 +89,20 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>
-    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: led active" alias="alert:red"/>
     <ColorAlias name="foldback knob" alias="widget:bg"/>
-    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
     <ColorAlias name="foldback knob: arc end" alias="widget:blue"/>
     <ColorAlias name="foldback knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
     <ColorAlias name="frame handle" alias="theme:bg1"/>
     <ColorAlias name="gain line" alias="alert:green"/>
     <ColorAlias name="gain line inactive" alias="theme:bg1"/>
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
-    <ColorAlias name="generic button: led active" alias="alert:blue"/>
+    <ColorAlias name="generic button: led active" alias="alert:green"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>
@@ -119,9 +119,9 @@
     <ColorAlias name="gtk_background" alias="theme:bg"/>
     <ColorAlias name="gtk_bases" alias="theme:bg2"/>
     <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
-    <ColorAlias name="gtk_bg_tooltip" alias="neutral:backgroundest"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="theme:contrasting less"/>
     <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
-    <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
+    <ColorAlias name="gtk_bright_indicator" alias="neutral:foregroundest"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_contrasting_indicator" alias="alert:green"/>
     <ColorAlias name="gtk_control_master" alias="theme:bg1"/>
@@ -133,7 +133,7 @@
     <ColorAlias name="gtk_fg_tooltip" alias="neutral:background"/>
     <ColorAlias name="gtk_foldback_bg" alias="theme:bg1"/>
     <ColorAlias name="gtk_foreground" alias="neutral:foreground"/>
-    <ColorAlias name="gtk_light_text_on_dark" alias="neutral:foreground2"/>
+    <ColorAlias name="gtk_light_text_on_dark" alias="neutral:midground"/>
     <ColorAlias name="gtk_lightest" alias="neutral:foregroundest"/>
     <ColorAlias name="gtk_midi_channel_selector" alias="widget:blue"/>
     <ColorAlias name="gtk_midi_track" alias="widget:green darker"/>
@@ -161,22 +161,21 @@
     <ColorAlias name="inactive group tab" alias="theme:bg"/>
     <ColorAlias name="invert button: fill" alias="widget:bg"/>
     <ColorAlias name="invert button: fill active" alias="alert:blue"/>
-    <ColorAlias name="invert button: led active" alias="alert:blue"/>
+    <ColorAlias name="invert button: led active" alias="alert:green"/>
     <ColorAlias name="latency button: fill" alias="widget:bg"/>
     <ColorAlias name="latency button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="latency button: led active" alias="alert:ruddy"/>
     <ColorAlias name="layered button: fill" alias="widget:bg"/>
     <ColorAlias name="layered button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="location cd marker" alias="alert:cyan"/>
-    <ColorAlias name="location loop" alias="alert:green"/>
-    <ColorAlias name="location marker" alias="theme:contrasting clock"/>
+    <ColorAlias name="location loop" alias="neutral:backgroundest"/>
+    <ColorAlias name="location marker" alias="widget:blue"/>
     <ColorAlias name="location punch" alias="alert:ruddy"/>
     <ColorAlias name="location range" alias="alert:green"/>
     <ColorAlias name="lock button: fill active" alias="widget:bg"/>
     <ColorAlias name="lock button: led active" alias="alert:red"/>
-    <ColorAlias name="lua action button: fill" alias="theme:bg"/>
     <ColorAlias name="lua action button: fill" alias="widget:bg"/>
-    <ColorAlias name="marker bar" alias="neutral:background2"/>
+    <ColorAlias name="marker bar" alias="neutral:foreground2"/>
     <ColorAlias name="marker bar separator" alias="theme:bg2"/>
     <ColorAlias name="marker drag line" alias="theme:contrasting clock"/>
     <ColorAlias name="marker label" alias="neutral:backgroundest"/>
@@ -186,9 +185,9 @@
     <ColorAlias name="master monitor section button normal: fill active" alias="widget:bg"/>
     <ColorAlias name="measure line bar" alias="neutral:foregroundest"/>
     <ColorAlias name="measure line beat" alias="widget:blue"/>
-    <ColorAlias name="meter background bottom" alias="neutral:background2"/>
-    <ColorAlias name="meter background top" alias="theme:bg"/>
-    <ColorAlias name="meter bar" alias="theme:bg1"/>
+    <ColorAlias name="meter background bottom" alias="neutral:backgroundest"/>
+    <ColorAlias name="meter background top" alias="neutral:backgroundest"/>
+    <ColorAlias name="meter bar" alias="neutral:backgroundest"/>
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
@@ -200,7 +199,7 @@
     <ColorAlias name="meterbridge peakindicator: fill active" alias="alert:red"/>
     <ColorAlias name="meterbridge peakindicator: led" alias="alert:red"/>
     <ColorAlias name="meterbridge peakindicator: led active" alias="alert:red"/>
-    <ColorAlias name="meterbridge peaklabel" alias="alert:red"/>
+    <ColorAlias name="meterbridge peaklabel" alias="theme:contrasting clock"/>
     <ColorAlias name="meterstrip dpm bg" alias="theme:bg2"/>
     <ColorAlias name="meterstrip dpm fg" alias="neutral:foreground2"/>
     <ColorAlias name="meterstrip ppm bg" alias="theme:bg2"/>
@@ -213,8 +212,8 @@
     <ColorAlias name="midi device: fill active" alias="theme:bg"/>
     <ColorAlias name="midi device: led active" alias="alert:green"/>
     <ColorAlias name="midi frame base" alias="neutral:background2"/>
-    <ColorAlias name="midi input button: fill active" alias="alert:green"/>
-    <ColorAlias name="midi input button: led active" alias="alert:red"/>
+    <ColorAlias name="midi input button: fill active" alias="widget:blue"/>
+    <ColorAlias name="midi input button: led active" alias="widget:blue"/>
     <ColorAlias name="midi meter color0" alias="midi meter 52"/>
     <ColorAlias name="midi meter color1" alias="midi meter 53"/>
     <ColorAlias name="midi meter color2" alias="midi meter 53"/>
@@ -230,50 +229,50 @@
     <ColorAlias name="midi note mid" alias="alert:yellow"/>
     <ColorAlias name="midi note min" alias="alert:orange"/>
     <ColorAlias name="midi note selected" alias="widget:ruddy"/>
-    <ColorAlias name="midi note selected outline" alias="alert:red"/>
+    <ColorAlias name="midi note selected outline" alias="theme:contrasting clock"/>
     <ColorAlias name="midi note velocity text" alias="theme:contrasting"/>
     <ColorAlias name="midi patch change fill" alias="theme:contrasting selection"/>
     <ColorAlias name="midi patch change outline" alias="neutral:foreground"/>
-    <ColorAlias name="midi select rect outline" alias="alert:red"/>
+    <ColorAlias name="midi select rect outline" alias="alert:cyan"/>
     <ColorAlias name="midi sysex fill" alias="theme:contrasting"/>
     <ColorAlias name="midi sysex outline" alias="theme:contrasting alt"/>
-    <ColorAlias name="midi track base" alias="widget:green darker"/>
+    <ColorAlias name="midi track base" alias="theme:contrasting clock"/>
     <ColorAlias name="mixer strip button: fill" alias="widget:bg"/>
     <ColorAlias name="mixer strip button: fill active" alias="theme:bg1"/>
-    <ColorAlias name="mixer strip button: led active" alias="alert:blue"/>
+    <ColorAlias name="mixer strip button: led active" alias="alert:green"/>
     <ColorAlias name="mixer strip name button: fill active" alias="theme:bg2"/>
-    <ColorAlias name="mixer strip name button: led active" alias="alert:blue"/>
+    <ColorAlias name="mixer strip name button: led active" alias="alert:green"/>
     <ColorAlias name="monitor button: fill" alias="widget:bg"/>
     <ColorAlias name="monitor button: fill active" alias="alert:orange"/>
     <ColorAlias name="monitor button: led active" alias="alert:ruddy"/>
     <ColorAlias name="monitor section button: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section dim: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section dim: fill active" alias="alert:orange"/>
-    <ColorAlias name="monitor section dim: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section dim: led active" alias="alert:cyan"/>
     <ColorAlias name="monitor section knob" alias="widget:bg"/>
-    <ColorAlias name="monitor section knob: arc end" alias="widget:blue"/>
-    <ColorAlias name="monitor section knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="monitor section knob: arc end" alias="theme:contrasting clock"/>
+    <ColorAlias name="monitor section knob: arc start" alias="theme:contrasting clock"/>
     <ColorAlias name="monitor section mono: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section mono: fill active" alias="alert:blue"/>
-    <ColorAlias name="monitor section mono: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section mono: led active" alias="alert:cyan"/>
     <ColorAlias name="monitor section processors present: fill" alias="alert:orange"/>
     <ColorAlias name="monitor section processors toggle: fill" alias="theme:bg"/>
     <ColorAlias name="monitor section processors toggle: fill active" alias="theme:bg"/>
     <ColorAlias name="monitor section solo model: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section solo model: fill active" alias="theme:bg"/>
-    <ColorAlias name="monitor section solo model: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section solo model: led active" alias="alert:cyan"/>
     <ColorAlias name="monitor section solo option: fill" alias="widget:bg"/>
     <ColorAlias name="monitor section solo option: fill active" alias="theme:bg"/>
-    <ColorAlias name="monitor section solo option: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section solo option: led active" alias="alert:cyan"/>
     <ColorAlias name="mono panner bg" alias="theme:bg2"/>
     <ColorAlias name="mono panner fill" alias="widget:blue"/>
-    <ColorAlias name="mono panner outline" alias="theme:bg"/>
-    <ColorAlias name="mono panner position fill" alias="theme:contrasting less"/>
-    <ColorAlias name="mono panner position outline" alias="theme:bg"/>
+    <ColorAlias name="mono panner outline" alias="widget:green darker"/>
+    <ColorAlias name="mono panner position fill" alias="widget:blue"/>
+    <ColorAlias name="mono panner position outline" alias="widget:green darker"/>
     <ColorAlias name="mono panner text" alias="neutral:backgroundest"/>
     <ColorAlias name="mouse mode button: fill" alias="widget:bg"/>
-    <ColorAlias name="mouse mode button: fill active" alias="alert:greenish"/>
-    <ColorAlias name="mouse mode button: led active" alias="alert:blue"/>
+    <ColorAlias name="mouse mode button: fill active" alias="theme:contrasting clock"/>
+    <ColorAlias name="mouse mode button: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="mute button: fill" alias="widget:bg"/>
     <ColorAlias name="mute button: fill active" alias="alert:yellow"/>
     <ColorAlias name="mute button: led active" alias="alert:yellow"/>
@@ -281,23 +280,23 @@
     <ColorAlias name="name highlight outline" alias="theme:bg1"/>
     <ColorAlias name="nudge button: fill" alias="widget:bg"/>
     <ColorAlias name="nudge button: fill active" alias="widget:bg"/>
-    <ColorAlias name="nudge button: led active" alias="alert:blue"/>
+    <ColorAlias name="nudge button: led active" alias="alert:green"/>
     <ColorAlias name="nudge clock: background" alias="theme:bg2"/>
     <ColorAlias name="nudge clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="nudge clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="nudge clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="page switch button: fill" alias="widget:bg"/>
-    <ColorAlias name="page switch button: fill active" alias="alert:blue"/>
-    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
-    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
+    <ColorAlias name="page switch button: fill active" alias="alert:cyan"/>
     <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
     <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
+    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
     <ColorAlias name="piano roll black" alias="theme:contrasting selection"/>
-    <ColorAlias name="piano roll black outline" alias="neutral:foreground2"/>
-    <ColorAlias name="piano roll white" alias="neutral:foreground2"/>
+    <ColorAlias name="piano roll black outline" alias="neutral:backgroundest"/>
+    <ColorAlias name="piano roll white" alias="theme:contrasting clock"/>
     <ColorAlias name="pinrouting custom: led active" alias="alert:ruddy"/>
     <ColorAlias name="pinrouting sidechain: led active" alias="alert:green"/>
-    <ColorAlias name="play head" alias="theme:contrasting"/>
+    <ColorAlias name="play head" alias="theme:contrasting clock"/>
     <ColorAlias name="plugin automation state button: fill active" alias="alert:orange"/>
     <ColorAlias name="plugin bypass button: led active" alias="alert:red"/>
     <ColorAlias name="pluginlist filter button: fill active" alias="widget:bg"/>
@@ -313,15 +312,15 @@
     <ColorAlias name="processor control knob" alias="theme:bg"/>
     <ColorAlias name="processor control knob: arc end" alias="widget:blue"/>
     <ColorAlias name="processor control knob: arc start" alias="widget:blue"/>
-    <ColorAlias name="processor fader: fill" alias="widget:blue"/>
-    <ColorAlias name="processor fader: fill active" alias="widget:blue"/>
-    <ColorAlias name="processor fader: led active" alias="alert:green"/>
+    <ColorAlias name="processor fader: fill" alias="widget:gray"/>
+    <ColorAlias name="processor fader: fill active" alias="widget:gray"/>
+    <ColorAlias name="processor fader: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="processor postfader: fill" alias="widget:green"/>
     <ColorAlias name="processor postfader: fill active" alias="widget:green"/>
-    <ColorAlias name="processor postfader: led active" alias="alert:green"/>
-    <ColorAlias name="processor prefader: fill" alias="widget:ruddy"/>
-    <ColorAlias name="processor prefader: fill active" alias="widget:ruddy"/>
-    <ColorAlias name="processor prefader: led active" alias="alert:green"/>
+    <ColorAlias name="processor postfader: led active" alias="theme:contrasting clock"/>
+    <ColorAlias name="processor prefader: fill" alias="widget:green"/>
+    <ColorAlias name="processor prefader: fill active" alias="widget:green"/>
+    <ColorAlias name="processor prefader: led active" alias="theme:contrasting clock"/>
     <ColorAlias name="processor sidechain: fill" alias="alert:orange"/>
     <ColorAlias name="processor sidechain: led active" alias="alert:green"/>
     <ColorAlias name="processor stub: fill" alias="neutral:background2"/>
@@ -336,7 +335,7 @@
     <ColorAlias name="punch line" alias="alert:ruddy"/>
     <ColorAlias name="range drag bar rect" alias="neutral:midground"/>
     <ColorAlias name="range drag rect" alias="alert:ruddy"/>
-    <ColorAlias name="range marker bar" alias="neutral:background2"/>
+    <ColorAlias name="range marker bar" alias="neutral:backgroundest"/>
     <ColorAlias name="record enable button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="record enable button: led active" alias="alert:red"/>
     <ColorAlias name="recording rect" alias="alert:ruddy"/>
@@ -347,7 +346,7 @@
     <ColorAlias name="region list whole file" alias="neutral:foreground"/>
     <ColorAlias name="route button: fill" alias="widget:bg"/>
     <ColorAlias name="route button: fill active" alias="theme:bg2"/>
-    <ColorAlias name="route button: led active" alias="alert:blue"/>
+    <ColorAlias name="route button: led active" alias="alert:green"/>
     <ColorAlias name="route rec button: led active" alias="alert:red"/>
     <ColorAlias name="rubber band rect" alias="neutral:foreground2"/>
     <ColorAlias name="rude audition: fill" alias="widget:bg"/>
@@ -364,22 +363,22 @@
     <ColorAlias name="secondary clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="secondary clock: edited text" alias="theme:contrasting clock"/>
-    <ColorAlias name="secondary clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="secondary clock: text" alias="neutral:midground"/>
     <ColorAlias name="secondary delta clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary delta clock: cursor" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: text" alias="theme:contrasting alt"/>
-    <ColorAlias name="selected midi note frame" alias="alert:ruddy"/>
-    <ColorAlias name="selected region base" alias="alert:ruddy"/>
-    <ColorAlias name="selected time axis frame" alias="alert:ruddy"/>
-    <ColorAlias name="selected waveform fill" alias="alert:orange"/>
+    <ColorAlias name="selected midi note frame" alias="alert:cyan"/>
+    <ColorAlias name="selected region base" alias="theme:contrasting clock"/>
+    <ColorAlias name="selected time axis frame" alias="widget:blue"/>
+    <ColorAlias name="selected waveform fill" alias="neutral:backgroundest"/>
     <ColorAlias name="selected waveform outline" alias="theme:bg2"/>
-    <ColorAlias name="selection" alias="alert:red"/>
+    <ColorAlias name="selection" alias="widget:blue"/>
     <ColorAlias name="selection clock: background" alias="theme:bg2"/>
     <ColorAlias name="selection clock: cursor" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: edited text" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: text" alias="theme:contrasting clock"/>
-    <ColorAlias name="selection rect" alias="neutral:foreground"/>
+    <ColorAlias name="selection rect" alias="neutral:backgroundest"/>
     <ColorAlias name="send alert button: fill" alias="theme:contrasting selection"/>
     <ColorAlias name="send alert button: fill active" alias="alert:cyan"/>
     <ColorAlias name="send alert button: led active" alias="alert:red"/>
@@ -392,22 +391,22 @@
     <ColorAlias name="silence text" alias="neutral:foreground"/>
     <ColorAlias name="solo button: fill" alias="widget:bg"/>
     <ColorAlias name="solo button: fill active" alias="alert:green"/>
-    <ColorAlias name="solo button: led active" alias="alert:blue"/>
+    <ColorAlias name="solo button: led active" alias="alert:green"/>
     <ColorAlias name="solo isolate: fill" alias="widget:bg"/>
     <ColorAlias name="solo isolate: fill active" alias="widget:bg"/>
-    <ColorAlias name="solo isolate: led active" alias="alert:ruddy"/>
+    <ColorAlias name="solo isolate: led active" alias="alert:red"/>
     <ColorAlias name="solo safe: fill" alias="widget:bg"/>
     <ColorAlias name="solo safe: fill active" alias="widget:bg"/>
-    <ColorAlias name="solo safe: led active" alias="alert:ruddy"/>
+    <ColorAlias name="solo safe: led active" alias="alert:red"/>
     <ColorAlias name="stereo panner bg" alias="theme:bg2"/>
     <ColorAlias name="stereo panner fill" alias="widget:blue"/>
     <ColorAlias name="stereo panner inverted bg" alias="widget:blue darker"/>
-    <ColorAlias name="stereo panner inverted fill" alias="theme:contrasting less"/>
+    <ColorAlias name="stereo panner inverted fill" alias="theme:contrasting"/>
     <ColorAlias name="stereo panner inverted outline" alias="alert:ruddy"/>
     <ColorAlias name="stereo panner inverted text" alias="neutral:backgroundest"/>
     <ColorAlias name="stereo panner mono bg" alias="theme:bg2"/>
-    <ColorAlias name="stereo panner mono fill" alias="theme:bg"/>
-    <ColorAlias name="stereo panner mono outline" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono fill" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono outline" alias="theme:bg1"/>
     <ColorAlias name="stereo panner mono text" alias="neutral:backgroundest"/>
     <ColorAlias name="stereo panner outline" alias="theme:bg"/>
     <ColorAlias name="stereo panner rule" alias="theme:bg"/>
@@ -417,7 +416,7 @@
     <ColorAlias name="stretch clock: edited text" alias="theme:contrasting clock"/>
     <ColorAlias name="stretch clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="sync mark" alias="theme:contrasting clock"/>
-    <ColorAlias name="tempo bar" alias="neutral:background2"/>
+    <ColorAlias name="tempo bar" alias="neutral:backgroundest"/>
     <ColorAlias name="tempo curve" alias="widget:blue"/>
     <ColorAlias name="tempo marker" alias="widget:orange"/>
     <ColorAlias name="tempo marker music" alias="widget:orange"/>
@@ -430,7 +429,7 @@
     <ColorAlias name="tracknumber label: led active" alias="alert:red"/>
     <ColorAlias name="transport active option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport active option button: fill active" alias="alert:green"/>
-    <ColorAlias name="transport active option button: led active" alias="alert:blue"/>
+    <ColorAlias name="transport active option button: led active" alias="alert:green"/>
     <ColorAlias name="transport button: fill" alias="widget:bg"/>
     <ColorAlias name="transport button: fill active" alias="alert:blue"/>
     <ColorAlias name="transport button: led active" alias="alert:blue"/>
@@ -443,12 +442,12 @@
     <ColorAlias name="transport delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport drag rect" alias="neutral:midground"/>
-    <ColorAlias name="transport loop rect" alias="alert:green"/>
-    <ColorAlias name="transport marker bar" alias="widget:bg"/>
+    <ColorAlias name="transport loop rect" alias="neutral:backgroundest"/>
+    <ColorAlias name="transport marker bar" alias="neutral:background2"/>
     <ColorAlias name="transport option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill active" alias="widget:bg"/>
-    <ColorAlias name="transport option button: led active" alias="alert:blue"/>
-    <ColorAlias name="transport punch rect" alias="widget:ruddy"/>
+    <ColorAlias name="transport option button: led active" alias="theme:contrasting clock"/>
+    <ColorAlias name="transport punch rect" alias="alert:red"/>
     <ColorAlias name="transport recenable button: fill" alias="widget:bg"/>
     <ColorAlias name="transport recenable button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="transport recenable button: led active" alias="alert:red"/>
@@ -465,7 +464,7 @@
     <ColorAlias name="zero line" alias="neutral:midground"/>
     <ColorAlias name="zoom button: fill" alias="widget:bg"/>
     <ColorAlias name="zoom button: fill active" alias="alert:green"/>
-    <ColorAlias name="zoom button: led active" alias="alert:blue"/>  </ColorAliases>
+    <ColorAlias name="zoom button: led active" alias="alert:green"/>  </ColorAliases>
   <Modifiers>
     <Modifier name="audio bus base" modifier="= alpha:0.3"/>
     <Modifier name="audio track base" modifier="= alpha:0.3"/>
@@ -474,7 +473,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.7"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.9"/>
-    <Modifier name="editable region" modifier="= alpha:0.25"/>
+    <Modifier name="editable region" modifier="= alpha:0.15"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>
@@ -482,7 +481,7 @@
     <Modifier name="loop rectangle" modifier="= alpha:0.5"/>
     <Modifier name="marker bar" modifier="= alpha:0.5"/>
     <Modifier name="grid line" modifier="= alpha:1.0"/>
-    <Modifier name="midi frame base" modifier="= alpha:0.4"/>
+    <Modifier name="midi frame base" modifier="= alpha:0.85"/>
     <Modifier name="midi note" modifier="= alpha:0.8"/>
     <Modifier name="midi note velocity text" modifier="= alpha:0.4666"/>
     <Modifier name="midi patch change fill" modifier="= alpha:0.6274"/>


### PR DESCRIPTION
Corrected colors closer to a5.12 version (compared with existing a6 theme). Added comments to < Color > section.

In the original file there was an excess line (177) - deleted in new version:
```

177 <ColorAlias name="lua action button: fill" alias="theme:bg"/>
178<ColorAlias name="lua action button: fill" alias="widget:bg"/>
```

video:
https://vimeo.com/419410940