### PR TITLE
Update unastudia-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Ardour theme-name="UnaStudia">
   <Colors>
-    <Color name="alert:blue" value="0x4e7e9cff"/>
-    <Color name="alert:cyan" value="20b2b2ff"/>
-    <Color name="alert:green" value="3dcc4cff"/>
-    <Color name="alert:orange" value="e58b05ff"/>
-    <Color name="alert:red" value="f10000ff"/>
-    <Color name="alert:ruddy" value="bb2828ff"/>
-    <Color name="alert:yellow" value="bba900ff"/>
-    <Color name="theme:bg" value="0x272a2eff"/>  <!--gtk_background-->
-    <Color name="theme:bg1" value="373737ff"/>  <!--gtk_audio_track-->
-    <Color name="theme:bg2" value="0x272a2eff"/>  <!--ruler base-->
-    <Color name="theme:contrasting" value="0xffffffff"/>  <!--play head-->
-    <Color name="theme:contrasting clock" value="0x4e7e9cff"/>  <!--big clock: text-->
-    <Color name="theme:contrasting less" value="5697B3FF"/>  <!--gtk_bg_tooltip-->
-    <Color name="theme:contrasting selection" value="0x4e7e9cff"/>  <!--gtk_bg_selected-->
-    <Color name="theme:contrasting alt" value="0x4e7e9cff"/>  <!--secondary delta clock: text-->
-    <Color name="neutral:backgroundest" value="0x272a2eff"/>  <!--border color-->
-    <Color name="neutral:background" value="202020ff"/>  <!--audio track base-->
-    <Color name="neutral:background2" value="505050ff"/>  <!--range marker bar-->
-    <Color name="neutral:midground" value="7f7f7fff"/>  <!--grid line minor-->
-    <Color name="neutral:foreground2" value="ccccccff"/>  <!--marker track-->
-    <Color name="neutral:foreground" value="e5e5e5ff"/>  <!--gtk_foreground-->
-    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major-->
-    <Color name="widget:bg" value="0x333940ff"/>    <!--generic button-->
-    <Color name="widget:blue" value="526d94ff"/>  <!--processor fader: fill-->
-    <Color name="widget:blue darker" value="20242aff"/>  <!--gtk_audio_bus-->
-    <Color name="widget:gray" value="595755ff"/>  <!--gtk_processor fader-->
-    <Color name="widget:green" value="617552ff"/>  <!--gtk processor postfader,  gtk_midi_track-->
-    <Color name="widget:green darker" value="3C403AFF"/>  <!--midi track base-->
-    <Color name="widget:orange" value="904010ff"/>  <!--tempo marker-->
-    <Color name="widget:ruddy" value="7c3a3aff"/>  <!--processor prefader-->
-    <Color name="meter color0" value="008800ff"/>
-    <Color name="meter color1" value="00aa00ff"/>
-    <Color name="meter color2" value="00ff00ff"/>
-    <Color name="meter color3" value="00ff00ff"/>
-    <Color name="meter color4" value="fff000ff"/>
-    <Color name="meter color5" value="fff000ff"/>
-    <Color name="meter color6" value="ff8800ff"/>
-    <Color name="meter color7" value="ff8800ff"/>
+    <Color name="alert:blue" value="4e7e9cff"/>  <!--control point fill,  location range,  page switch button: fill active-->
+    <Color name="alert:cyan" value="81d3f8ff"/>  <!--location cd marker,  pluginlist hide button: led active-->
+    <Color name="alert:green" value="3dcc4cff"/>  <!--no-->
+    <Color name="alert:orange" value="f68b17ff"/>  <!--midi note selected outline,  stereo panner mono fill,  monitor button: fill active-->
+    <Color name="alert:red" value="f10000ff"/>  <!--clipped waveform,  feedback alert: fill active,  plugin bypass button: led active-->
+    <Color name="alert:ruddy" value="bb2828ff"/>  <!--location punch,  monitor button: led active,  record enable button: fill active-->
+    <Color name="alert:yellow" value="d5b549ff"/>  <!--solo button: fill active,  rude solo: fill active-->
+    <Color name="theme:bg" value="333138ff"/>  <!--gtk_background,  gtk_automation_track_header-->
+    <Color name="theme:bg1" value="646870ff"/>  <!--gtk_audio_track-->
+    <Color name="theme:bg2" value="2e2f35ff"/>  <!--ruler base,  big clock: background,  clock: background,  gtk_bases-->
+    <Color name="theme:contrasting" value="ffffffff"/>  <!--play head,  gtk_bright_indicator-->
+    <Color name="theme:contrasting clock" value="ffffffff"/>  <!--big clock: text,  clock: text,  location marker,  punch clock: text-->
+    <Color name="theme:contrasting less" value="5697b3ff"/>  <!--gtk_bg_tooltip-->
+    <Color name="theme:contrasting selection" value="5ba0ffff"/>  <!--gtk_bg_selected,  piano roll black-->
+    <Color name="theme:contrasting alt" value="94bef5ff"/>  <!--secondary delta clock: text,  rude isolate: fill active,  mono panner outline-->
+    <Color name="neutral:backgroundest" value="272a2eff"/>  <!--border color,  audio master bus base,  midi bus base-->
+    <Color name="neutral:background" value="202020ff"/>  <!--gtk_fg_tooltip,  processor control button: fill-->
+    <Color name="neutral:background2" value="27292dff"/>  <!--range marker bar,  arrange base,  recording waveform outline-->
+    <Color name="neutral:midground" value="7f7f7fff"/>  <!--grid line minor,  ruler text-->
+    <Color name="neutral:foreground2" value="ccccccff"/>  <!--marker track,  gtk_light_text_on_dark,  piano roll white-->
+    <Color name="neutral:foreground" value="e5e5e5ff"/>  <!--gtk_foreground,  active crossfade-->
+    <Color name="neutral:foregroundest" value="ffffffff"/>  <!--grid line major,  meterbridge peaklabel,  recording waveform fill-->
+    <Color name="widget:bg" value="676573ff"/>    <!--generic button,  solo button: fill,  mute button: fill,  mouse mode button: fill-->
+    <Color name="widget:blue" value="4778bdff"/>  <!--processor fader: fill,  mouse mode button: fill active-->
+    <Color name="widget:blue darker" value="20242aff"/>  <!--gtk_audio_bus,  stereo panner inverted bg-->
+    <Color name="widget:gray" value="595755ff"/>  <!--gtk_processor fader,  time stretch outline-->
+    <Color name="widget:green" value="838092ff"/>  <!--gtk processor postfader,  processor postfader: fill-->
+    <Color name="widget:green darker" value="3d4044ff"/>  <!--gtk_midi_track,  midi automation track fill-->
+    <Color name="widget:orange" value="af2f36ff"/>  <!--gtk_mute,  mute button: fill active-->
+    <Color name="widget:ruddy" value="cacacaff"/>  <!--processor prefader,  gtk_track_header_selected-->
+    <Color name="meter color0" value="5f90b8ff"/>
+    <Color name="meter color1" value="5f90b8ff"/>
+    <Color name="meter color2" value="5f90b8ff"/>
+    <Color name="meter color3" value="5f90b8ff"/>
+    <Color name="meter color4" value="5f90b8ff"/>
+    <Color name="meter color5" value="5f90b8ff"/>
+    <Color name="meter color6" value="5f90b8ff"/>
+    <Color name="meter color7" value="5f90b8ff"/>
     <Color name="meter color8" value="ff0000ff"/>
     <Color name="meter color9" value="ff0000ff"/>
-    <Color name="midi meter 52" value="e8faa1ff"/>
-    <Color name="midi meter 53" value="f2c37dff"/>
-    <Color name="midi meter 54" value="ffac44ff"/>
-    <Color name="midi meter 55" value="f48352ff"/>
-    <Color name="midi meter 56" value="f85813ff"/>
+    <Color name="midi meter 52" value="26525eff"/>
+    <Color name="midi meter 53" value="1c758eff"/>
+    <Color name="midi meter 54" value="60a6b9ff"/>
+    <Color name="midi meter 55" value="70c4daff"/>
+    <Color name="midi meter 56" value="8ee7ffff"/>
   </Colors>
   <ColorAliases>
     <ColorAlias name="active crossfade" alias="neutral:foreground"/>
-    <ColorAlias name="arrange base" alias="theme:bg"/>
+    <ColorAlias name="arrange base" alias="neutral:background2"/>
     <ColorAlias name="audio automation track fill" alias="theme:bg"/>
-    <ColorAlias name="audio bus base" alias="widget:blue darker"/>
+    <ColorAlias name="audio bus base" alias="neutral:background2"/>
     <ColorAlias name="audio master bus base" alias="neutral:backgroundest"/>
-    <ColorAlias name="audio track base" alias="neutral:background"/>
-    <ColorAlias name="automation line" alias="alert:blue"/>
+    <ColorAlias name="audio track base" alias="neutral:background2"/>
+    <ColorAlias name="automation line" alias="widget:blue"/>
     <ColorAlias name="automation track outline" alias="theme:bg1"/>
     <ColorAlias name="big clock active: background" alias="neutral:backgroundest"/>
     <ColorAlias name="big clock active: cursor" alias="theme:contrasting clock"/>
@@ -74,8 +74,8 @@
     <ColorAlias name="comment button: fill" alias="widget:bg"/>
     <ColorAlias name="control point fill" alias="alert:blue"/>
     <ColorAlias name="control point outline" alias="alert:blue"/>
-    <ColorAlias name="control point selected fill" alias="alert:orange"/>
-    <ColorAlias name="control point selected outline" alias="alert:red"/>
+    <ColorAlias name="control point selected fill" alias="theme:contrasting alt"/>
+    <ColorAlias name="control point selected outline" alias="theme:contrasting alt"/>
     <ColorAlias name="covered region" alias="neutral:background2"/>
     <ColorAlias name="crossfade editor base" alias="neutral:foreground2"/>
     <ColorAlias name="crossfade editor line" alias="neutral:backgroundest"/>
@@ -88,14 +88,14 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>
-    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: led active" alias="alert:red"/>
     <ColorAlias name="foldback knob" alias="widget:bg"/>
-    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
     <ColorAlias name="foldback knob: arc end" alias="widget:blue"/>
     <ColorAlias name="foldback knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
     <ColorAlias name="frame handle" alias="theme:bg1"/>
     <ColorAlias name="gain line" alias="alert:blue"/>
     <ColorAlias name="gain line inactive" alias="theme:bg1"/>
@@ -120,7 +120,7 @@
     <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
     <ColorAlias name="gtk_bg_tooltip" alias="theme:contrasting less"/>
     <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
-    <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
+    <ColorAlias name="gtk_bright_indicator" alias="theme:contrasting"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_contrasting_indicator" alias="alert:blue"/>
     <ColorAlias name="gtk_control_master" alias="theme:bg1"/>
@@ -138,7 +138,7 @@
     <ColorAlias name="gtk_midi_track" alias="widget:green darker"/>
     <ColorAlias name="gtk_monitor" alias="alert:orange"/>
     <ColorAlias name="gtk_mono" alias="neutral:foreground"/>
-    <ColorAlias name="gtk_mute" alias="alert:yellow"/>
+    <ColorAlias name="gtk_mute" alias="widget:orange"/>
     <ColorAlias name="gtk_not_so_bright_indicator" alias="theme:contrasting"/>
     <ColorAlias name="gtk_processor_fader" alias="widget:gray"/>
     <ColorAlias name="gtk_processor_fader_frame" alias="neutral:midground"/>
@@ -149,7 +149,7 @@
     <ColorAlias name="gtk_processor_prefader_frame" alias="widget:ruddy"/>
     <ColorAlias name="gtk_send_bg" alias="theme:bg1"/>
     <ColorAlias name="gtk_send_fg" alias="widget:blue"/>
-    <ColorAlias name="gtk_solo" alias="alert:blue"/>
+    <ColorAlias name="gtk_solo" alias="alert:yellow"/>
     <ColorAlias name="gtk_somewhat_bright_indicator" alias="theme:contrasting alt"/>
     <ColorAlias name="gtk_texts" alias="neutral:foreground"/>
     <ColorAlias name="gtk_track_header_inactive" alias="theme:bg"/>
@@ -167,13 +167,12 @@
     <ColorAlias name="layered button: fill" alias="widget:bg"/>
     <ColorAlias name="layered button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="location cd marker" alias="alert:cyan"/>
-    <ColorAlias name="location loop" alias="alert:blue"/>
+    <ColorAlias name="location loop" alias="widget:blue"/>
     <ColorAlias name="location marker" alias="theme:contrasting clock"/>
     <ColorAlias name="location punch" alias="alert:ruddy"/>
     <ColorAlias name="location range" alias="alert:blue"/>
     <ColorAlias name="lock button: fill active" alias="widget:bg"/>
     <ColorAlias name="lock button: led active" alias="alert:red"/>
-    <ColorAlias name="lua action button: fill" alias="theme:bg"/>
     <ColorAlias name="lua action button: fill" alias="widget:bg"/>
     <ColorAlias name="marker bar" alias="neutral:background2"/>
     <ColorAlias name="marker bar separator" alias="theme:bg2"/>
@@ -185,8 +184,8 @@
     <ColorAlias name="master monitor section button normal: fill active" alias="widget:bg"/>
     <ColorAlias name="measure line bar" alias="neutral:foregroundest"/>
     <ColorAlias name="measure line beat" alias="widget:blue"/>
-    <ColorAlias name="meter background bottom" alias="neutral:background2"/>
-    <ColorAlias name="meter background top" alias="theme:bg"/>
+    <ColorAlias name="meter background bottom" alias="neutral:backgroundest"/>
+    <ColorAlias name="meter background top" alias="neutral:backgroundest"/>
     <ColorAlias name="meter bar" alias="theme:bg1"/>
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
@@ -199,7 +198,7 @@
     <ColorAlias name="meterbridge peakindicator: fill active" alias="alert:red"/>
     <ColorAlias name="meterbridge peakindicator: led" alias="alert:red"/>
     <ColorAlias name="meterbridge peakindicator: led active" alias="alert:red"/>
-    <ColorAlias name="meterbridge peaklabel" alias="alert:red"/>
+    <ColorAlias name="meterbridge peaklabel" alias="neutral:foregroundest"/>
     <ColorAlias name="meterstrip dpm bg" alias="theme:bg2"/>
     <ColorAlias name="meterstrip dpm fg" alias="neutral:foreground2"/>
     <ColorAlias name="meterstrip ppm bg" alias="theme:bg2"/>
@@ -229,14 +228,14 @@
     <ColorAlias name="midi note mid" alias="alert:yellow"/>
     <ColorAlias name="midi note min" alias="alert:orange"/>
     <ColorAlias name="midi note selected" alias="widget:ruddy"/>
-    <ColorAlias name="midi note selected outline" alias="alert:red"/>
+    <ColorAlias name="midi note selected outline" alias="alert:orange"/>
     <ColorAlias name="midi note velocity text" alias="theme:contrasting"/>
     <ColorAlias name="midi patch change fill" alias="theme:contrasting selection"/>
     <ColorAlias name="midi patch change outline" alias="neutral:foreground"/>
     <ColorAlias name="midi select rect outline" alias="alert:red"/>
     <ColorAlias name="midi sysex fill" alias="theme:contrasting"/>
     <ColorAlias name="midi sysex outline" alias="theme:contrasting alt"/>
-    <ColorAlias name="midi track base" alias="widget:green darker"/>
+    <ColorAlias name="midi track base" alias="neutral:background2"/>
     <ColorAlias name="mixer strip button: fill" alias="widget:bg"/>
     <ColorAlias name="mixer strip button: fill active" alias="theme:bg1"/>
     <ColorAlias name="mixer strip button: led active" alias="alert:blue"/>
@@ -266,16 +265,16 @@
     <ColorAlias name="monitor section solo option: led active" alias="alert:blue"/>
     <ColorAlias name="mono panner bg" alias="theme:bg2"/>
     <ColorAlias name="mono panner fill" alias="widget:blue"/>
-    <ColorAlias name="mono panner outline" alias="theme:bg"/>
+    <ColorAlias name="mono panner outline" alias="theme:contrasting alt"/>
     <ColorAlias name="mono panner position fill" alias="theme:contrasting less"/>
-    <ColorAlias name="mono panner position outline" alias="theme:bg"/>
+    <ColorAlias name="mono panner position outline" alias="theme:contrasting alt"/>
     <ColorAlias name="mono panner text" alias="neutral:backgroundest"/>
     <ColorAlias name="mouse mode button: fill" alias="widget:bg"/>
-    <ColorAlias name="mouse mode button: fill active" alias="alert:blue"/>
-    <ColorAlias name="mouse mode button: led active" alias="alert:blue"/>
+    <ColorAlias name="mouse mode button: fill active" alias="widget:blue"/>
+    <ColorAlias name="mouse mode button: led active" alias="widget:blue"/>
     <ColorAlias name="mute button: fill" alias="widget:bg"/>
-    <ColorAlias name="mute button: fill active" alias="alert:yellow"/>
-    <ColorAlias name="mute button: led active" alias="alert:yellow"/>
+    <ColorAlias name="mute button: fill active" alias="widget:orange"/>
+    <ColorAlias name="mute button: led active" alias="widget:orange"/>
     <ColorAlias name="name highlight fill" alias="alert:blue"/>
     <ColorAlias name="name highlight outline" alias="theme:bg1"/>
     <ColorAlias name="nudge button: fill" alias="widget:bg"/>
@@ -287,10 +286,11 @@
     <ColorAlias name="nudge clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="page switch button: fill" alias="widget:bg"/>
     <ColorAlias name="page switch button: fill active" alias="alert:blue"/>
-    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
-    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
     <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
     <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
+    <ColorAlias name="patch change button: fill acpunch button: fill activetive" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
     <ColorAlias name="piano roll black" alias="theme:contrasting selection"/>
     <ColorAlias name="piano roll black outline" alias="neutral:foreground2"/>
     <ColorAlias name="piano roll white" alias="neutral:foreground2"/>
@@ -314,13 +314,13 @@
     <ColorAlias name="processor control knob: arc start" alias="widget:blue"/>
     <ColorAlias name="processor fader: fill" alias="widget:blue"/>
     <ColorAlias name="processor fader: fill active" alias="widget:blue"/>
-    <ColorAlias name="processor fader: led active" alias="alert:blue"/>
+    <ColorAlias name="processor fader: led active" alias="theme:contrasting alt"/>
     <ColorAlias name="processor postfader: fill" alias="widget:green"/>
     <ColorAlias name="processor postfader: fill active" alias="widget:green"/>
-    <ColorAlias name="processor postfader: led active" alias="alert:blue"/>
+    <ColorAlias name="processor postfader: led active" alias="theme:contrasting alt"/>
     <ColorAlias name="processor prefader: fill" alias="widget:ruddy"/>
     <ColorAlias name="processor prefader: fill active" alias="widget:ruddy"/>
-    <ColorAlias name="processor prefader: led active" alias="alert:blue"/>
+    <ColorAlias name="processor prefader: led active" alias="theme:contrasting alt"/>
     <ColorAlias name="processor sidechain: fill" alias="alert:orange"/>
     <ColorAlias name="processor sidechain: led active" alias="alert:blue"/>
     <ColorAlias name="processor stub: fill" alias="neutral:background2"/>
@@ -356,8 +356,8 @@
     <ColorAlias name="rude isolate: fill active" alias="theme:contrasting alt"/>
     <ColorAlias name="rude isolate: led active" alias="alert:red"/>
     <ColorAlias name="rude solo: fill" alias="widget:bg"/>
-    <ColorAlias name="rude solo: fill active" alias="alert:ruddy"/>
-    <ColorAlias name="rude solo: led active" alias="alert:red"/>
+    <ColorAlias name="rude solo: fill active" alias="alert:yellow"/>
+    <ColorAlias name="rude solo: led active" alias="alert:yellow"/>
     <ColorAlias name="ruler base" alias="theme:bg2"/>
     <ColorAlias name="ruler text" alias="neutral:midground"/>
     <ColorAlias name="secondary clock: background" alias="theme:bg2"/>
@@ -369,16 +369,16 @@
     <ColorAlias name="secondary delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="selected midi note frame" alias="alert:ruddy"/>
-    <ColorAlias name="selected region base" alias="alert:ruddy"/>
-    <ColorAlias name="selected time axis frame" alias="alert:ruddy"/>
-    <ColorAlias name="selected waveform fill" alias="alert:orange"/>
+    <ColorAlias name="selected region base" alias="neutral:foregroundest"/>
+    <ColorAlias name="selected time axis frame" alias="widget:blue"/>
+    <ColorAlias name="selected waveform fill" alias="neutral:backgroundest"/>
     <ColorAlias name="selected waveform outline" alias="theme:bg2"/>
-    <ColorAlias name="selection" alias="alert:red"/>
+    <ColorAlias name="selection" alias="widget:blue"/>
     <ColorAlias name="selection clock: background" alias="theme:bg2"/>
     <ColorAlias name="selection clock: cursor" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: edited text" alias="alert:ruddy"/>
     <ColorAlias name="selection clock: text" alias="theme:contrasting clock"/>
-    <ColorAlias name="selection rect" alias="neutral:foreground"/>
+    <ColorAlias name="selection rect" alias="theme:contrasting less"/>
     <ColorAlias name="send alert button: fill" alias="theme:contrasting selection"/>
     <ColorAlias name="send alert button: fill active" alias="alert:cyan"/>
     <ColorAlias name="send alert button: led active" alias="alert:red"/>
@@ -390,8 +390,8 @@
     <ColorAlias name="silence" alias="theme:contrasting alt"/>
     <ColorAlias name="silence text" alias="neutral:foreground"/>
     <ColorAlias name="solo button: fill" alias="widget:bg"/>
-    <ColorAlias name="solo button: fill active" alias="alert:blue"/>
-    <ColorAlias name="solo button: led active" alias="alert:blue"/>
+    <ColorAlias name="solo button: fill active" alias="alert:yellow"/>
+    <ColorAlias name="solo button: led active" alias="alert:yellow"/>
     <ColorAlias name="solo isolate: fill" alias="widget:bg"/>
     <ColorAlias name="solo isolate: fill active" alias="widget:bg"/>
     <ColorAlias name="solo isolate: led active" alias="alert:ruddy"/>
@@ -401,14 +401,14 @@
     <ColorAlias name="stereo panner bg" alias="theme:bg2"/>
     <ColorAlias name="stereo panner fill" alias="widget:blue"/>
     <ColorAlias name="stereo panner inverted bg" alias="widget:blue darker"/>
-    <ColorAlias name="stereo panner inverted fill" alias="theme:contrasting less"/>
-    <ColorAlias name="stereo panner inverted outline" alias="alert:ruddy"/>
-    <ColorAlias name="stereo panner inverted text" alias="neutral:backgroundest"/>
+    <ColorAlias name="stereo panner inverted fill" alias="neutral:backgroundest"/>
+    <ColorAlias name="stereo panner inverted outline" alias="theme:contrasting alt"/>
+    <ColorAlias name="stereo panner inverted text" alias="neutral:foregroundest"/>
     <ColorAlias name="stereo panner mono bg" alias="theme:bg2"/>
-    <ColorAlias name="stereo panner mono fill" alias="theme:bg"/>
-    <ColorAlias name="stereo panner mono outline" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono fill" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono outline" alias="widget:blue"/>
     <ColorAlias name="stereo panner mono text" alias="neutral:backgroundest"/>
-    <ColorAlias name="stereo panner outline" alias="theme:bg"/>
+    <ColorAlias name="stereo panner outline" alias="theme:contrasting alt"/>
     <ColorAlias name="stereo panner rule" alias="theme:bg"/>
     <ColorAlias name="stereo panner text" alias="neutral:backgroundest"/>
     <ColorAlias name="stretch clock: background" alias="theme:bg2"/>
@@ -431,8 +431,8 @@
     <ColorAlias name="transport active option button: fill active" alias="alert:blue"/>
     <ColorAlias name="transport active option button: led active" alias="alert:blue"/>
     <ColorAlias name="transport button: fill" alias="widget:bg"/>
-    <ColorAlias name="transport button: fill active" alias="alert:blue"/>
-    <ColorAlias name="transport button: led active" alias="alert:blue"/>
+    <ColorAlias name="transport button: fill active" alias="widget:blue"/>
+    <ColorAlias name="transport button: led active" alias="widget:blue"/>
     <ColorAlias name="transport clock: background" alias="theme:bg2"/>
     <ColorAlias name="transport clock: cursor" alias="theme:contrasting clock"/>
     <ColorAlias name="transport clock: edited text" alias="theme:contrasting clock"/>
@@ -442,12 +442,12 @@
     <ColorAlias name="transport delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport drag rect" alias="neutral:midground"/>
-    <ColorAlias name="transport loop rect" alias="alert:blue"/>
-    <ColorAlias name="transport marker bar" alias="widget:bg"/>
+    <ColorAlias name="transport loop rect" alias="alert:cyan"/>
+    <ColorAlias name="transport marker bar" alias="neutral:foregroundest"/>
     <ColorAlias name="transport option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill active" alias="widget:bg"/>
     <ColorAlias name="transport option button: led active" alias="alert:blue"/>
-    <ColorAlias name="transport punch rect" alias="widget:ruddy"/>
+    <ColorAlias name="transport punch rect" alias="alert:ruddy"/>
     <ColorAlias name="transport recenable button: fill" alias="widget:bg"/>
     <ColorAlias name="transport recenable button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="transport recenable button: led active" alias="alert:red"/>
@@ -473,7 +473,7 @@
     <Modifier name="covered region base" modifier="= alpha:0.7"/>
     <Modifier name="crossfade alpha" modifier="= alpha:0.1803"/>
     <Modifier name="dragging region" modifier="= alpha:0.9"/>
-    <Modifier name="editable region" modifier="= alpha:0.25"/>
+    <Modifier name="editable region" modifier="= alpha:0.15"/>
     <Modifier name="gain line inactive" modifier="= alpha:0.7725"/>
     <Modifier name="ghost track base" modifier="= alpha:0.640782"/>
     <Modifier name="ghost track midi fill" modifier="= alpha:0.3"/>
@@ -481,7 +481,7 @@
     <Modifier name="loop rectangle" modifier="= alpha:0.5"/>
     <Modifier name="marker bar" modifier="= alpha:0.5"/>
     <Modifier name="grid line" modifier="= alpha:1.0"/>
-    <Modifier name="midi frame base" modifier="= alpha:0.4"/>
+    <Modifier name="midi frame base" modifier="= alpha:0.85"/>
     <Modifier name="midi note" modifier="= alpha:0.8"/>
     <Modifier name="midi note velocity text" modifier="= alpha:0.4666"/>
     <Modifier name="midi patch change fill" modifier="= alpha:0.6274"/>


### PR DESCRIPTION
Actually I'm not an author of this theme. I've decided to try... if there is no objection. I have no much time unfortunately - so I could not notice some minor things.

I used this picture as a reference:
![Screenshot from 2020-05-17 20-33-08](https://user-images.githubusercontent.com/19673308/82186750-03b72d80-98f4-11ea-9442-4e9f2ec657a3.png)

the result screenshot:
![unastudia ARDOUR 6](https://user-images.githubusercontent.com/19673308/82186849-277a7380-98f4-11ea-9af7-423b0a9ed027.png)

Added comments to < Color > section.
In the original file there was an excess line (176) - deleted in new version:

```
176  <ColorAlias name="lua action button: fill" alias="theme:bg"/>
177 <ColorAlias name="lua action button: fill" alias="widget:bg"/>
```