### PR TITLE
Allow CD marker at session start #8029

### DIFF
--- a/gtk2_ardour/location_ui.cc
+++ b/gtk2_ardour/location_ui.cc
@@ -298,12 +298,6 @@ LocationEditRow::set_location (Location *loc)
 		cd_check_button.set_active (location->is_cd_marker());
 		cd_check_button.show();
 
-		if (location->start() == _session->current_start_sample()) {
-			cd_check_button.set_sensitive (false);
-		} else {
-			cd_check_button.set_sensitive (true);
-		}
-
 		hide_check_button.show();
 		lock_check_button.show();
 		glue_check_button.show();
@@ -533,18 +527,6 @@ LocationEditRow::cd_toggled ()
 		return;
 	}
 
-	//if (cd_check_button.get_active() == location->is_cd_marker()) {
-	//	return;
-	//}
-
-	if (cd_check_button.get_active()) {
-		if (location->start() <= _session->current_start_sample()) {
-			error << _("You cannot put a CD marker at the start of the session") << endmsg;
-			cd_check_button.set_active (false);
-			return;
-		}
-	}
-
 	location->set_cd (cd_check_button.get_active(), this);
 
 	if (location->is_cd_marker()) {
@@ -659,12 +641,6 @@ LocationEditRow::start_changed ()
 	i_am_the_modifier++;
 
 	start_clock.set (location->start());
-
-	if (location->start() == _session->current_start_sample()) {
-		cd_check_button.set_sensitive (false);
-	} else {
-		cd_check_button.set_sensitive (true);
-	}
 
 	i_am_the_modifier--;
 }

--- a/gtk2_ardour/po/cs.po
+++ b/gtk2_ardour/po/cs.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk-ardour 0.347.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-13 16:55+0200\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -971,7 +971,7 @@ msgstr "Přidat stopy/sběrnice"
 msgid "About"
 msgstr "O programu"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Polohy"
 
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Otázka"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2931,11 +2931,11 @@ msgstr ""
 "\n"
 "Od nynějška používejte záložní kopii se staršími verzemi %3"
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Vzorkovací kmitočet neodpovídá"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2945,15 +2945,15 @@ msgstr ""
 "%2 nyní běží na %3 Hz. Pokud toto sezení nahrajete,\n"
 "je možné, že zvuk bude přehráván při nesprávném vzorkovacím kmitočtu.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Sezení nenahrávat"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Sezení přesto nahrát"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2967,31 +2967,31 @@ msgstr ""
 "Zvukový stroj nastavte znovu\n"
 "v Nabídka → Okno → Zvuk/Nastavení MIDI"
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM: Inicializace selhala"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "Server NSM se neohlásil"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM: Neposkytnuto žádné ID klienta"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM: Nevytvořeno žádné sezení"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 je připraven pro použití"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -3006,9 +3006,17 @@ msgstr ""
 "Můžete se podívat na omezení pro paměť pomocí příkazu 'ulimit -l', a obvykle "
 "můžete toto nastavení změnit %2."
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Neukazovat toto okno s hlášením znovu"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3496,7 +3504,7 @@ msgstr "Čas"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Délka"
 
@@ -5933,7 +5941,7 @@ msgid "mark"
 msgstr "Značka"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "Přidat značku"
 
@@ -5953,7 +5961,7 @@ msgstr "Rozsah"
 msgid "new range marker"
 msgstr "Nová značka rozsahu"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "Odstranit značky"
 
@@ -6171,7 +6179,7 @@ msgstr "Postrčit o krok dozadu"
 msgid "sequence regions"
 msgstr "Řadit oblasti vedle sebe"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Nový rozsah"
 
@@ -8802,59 +8810,55 @@ msgstr "Skladatel:"
 msgid "Pre-Emphasis"
 msgstr "Předzdůraznění"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Odstranit tento rozsah"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Čas začátku - klepnutí prostředním tlačítkem myši pro postavení se sem"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Čas konce - klepnutí prostředním tlačítkem myši pro postavení se sem"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Nastavit začátek rozsahu z místa ukazatele polohy"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Nastavit konec rozsahu z místa ukazatele polohy"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Odstranit tuto značku"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Poloha - klepnutí prostředním tlačítkem myši pro postavení se sem"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Nastavit čas značky z místa ukazatele polohy"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Na začátku sezení nemůžete zřídit žádnou značku na CD"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Nová značka"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Rozsahy smyčky/přepsání</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Značky (včetně rejstříku CD)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Značky (včetně rozsahů stop CD)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "Přidat značku rozsahu"
 

--- a/gtk2_ardour/po/de.po
+++ b/gtk2_ardour/po/de.po
@@ -3,16 +3,16 @@
 # This file is distributed under the same license as the gtk-ardour package.
 #
 #
-#: audio_clock.cc:941 audio_clock.cc:942 session_dialog.cc:604
-#: session_dialog.cc:605
 # Karsten Petersen <kapet@kapet.de>, 2003.
 # Edgar Aichinger <edgar.aichinger@aon.at>, 2008, 2012, 2013, 2014, 2015, 2016, 2017, 2020.
 # Benjamin Scherrer <benjamin@wagnerbrutal.de>, 2015.
+#: audio_clock.cc:941 audio_clock.cc:942 session_dialog.cc:604
+#: session_dialog.cc:605
 msgid ""
 msgstr ""
 "Project-Id-Version: gtk-ardour 0.347.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-23 09:12+0200\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-23 09:21+0200\n"
 "Last-Translator: Edgar Aichinger <edgar.aichinger@aon.at>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -797,7 +797,7 @@ msgid "Manual Configuration"
 msgstr "Manuelle Konfiguration"
 
 #: add_route_dialog.cc:590 add_route_dialog.cc:756 ardour_ui.cc:1194
-#: ardour_ui_ed.cc:782 engine_dialog.cc:264 plugin_pin_dialog.cc:74
+#: ardour_ui_ed.cc:782 engine_dialog.cc:265 plugin_pin_dialog.cc:74
 #: rc_option_editor.cc:2975 rc_option_editor.cc:2977 rc_option_editor.cc:2979
 #: rc_option_editor.cc:2981 rc_option_editor.cc:3028 rc_option_editor.cc:3030
 #: rc_option_editor.cc:3032 rc_option_editor.cc:3040
@@ -805,7 +805,7 @@ msgid "Audio"
 msgstr "Audio"
 
 #: add_route_dialog.cc:593 add_route_dialog.cc:757 editor_actions.cc:145
-#: engine_dialog.cc:266 missing_file_dialog.cc:65 mixer_ui.cc:2417
+#: engine_dialog.cc:267 missing_file_dialog.cc:65 mixer_ui.cc:2417
 #: plugin_pin_dialog.cc:75 rc_option_editor.cc:3050 rc_option_editor.cc:3052
 #: rc_option_editor.cc:3061 rc_option_editor.cc:3063 rc_option_editor.cc:3071
 #: rc_option_editor.cc:3087 rc_option_editor.cc:3090 rc_option_editor.cc:3092
@@ -859,7 +859,7 @@ msgid "12 Channel"
 msgstr "12 Kanäle"
 
 #: add_route_dialog.cc:900 gain_meter.cc:810 mixer_strip.cc:2076
-#: mixer_strip.cc:2536 processor_box.cc:3928
+#: mixer_strip.cc:2536 processor_box.cc:3926
 msgid "Custom"
 msgstr "Benutzerdefiniert"
 
@@ -995,7 +995,7 @@ msgstr "Spuren/Busse hinzufügen"
 msgid "About"
 msgstr "Über..."
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Positionen"
 
@@ -2423,7 +2423,7 @@ msgstr "Zu nächstem Marker springen"
 #: ardour_ui_ed.cc:567 editor_audio_import.cc:356 luawindow.cc:100
 #: pt_import_selector.cc:43 session_import_dialog.cc:82
 #: session_import_dialog.cc:104 session_metadata_dialog.cc:465 sfdb_ui.cc:638
-#: template_dialog.cc:228 editor_videotimeline.cc:97
+#: template_dialog.cc:228 editor_videotimeline.cc:94
 msgid "Import"
 msgstr "Importieren"
 
@@ -2531,7 +2531,7 @@ msgstr "Alle sichtbaren Automationsspuren auswählen"
 msgid "Select All Tracks"
 msgstr "Alle Spuren auswählen"
 
-#: ardour_ui_ed.cc:654 export_timespan_selector.cc:66 processor_box.cc:3908
+#: ardour_ui_ed.cc:654 export_timespan_selector.cc:66 processor_box.cc:3906
 msgid "Deselect All"
 msgstr "Nichts auswählen"
 
@@ -3085,8 +3085,8 @@ msgstr ""
 #: ardour_ui_startup.cc:727
 msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
 msgstr ""
-"NSM: %1 kann nicht mit dem JACK Server verbinden. Starten Sie bitte zuerst"
-" JACK."
+"NSM: %1 kann nicht mit dem JACK Server verbinden. Starten Sie bitte zuerst "
+"JACK."
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3410,7 +3410,7 @@ msgstr "Bearbeiten"
 
 #: bundle_manager.cc:267 editor.cc:6205 editor.cc:6235 editor_actions.cc:386
 #: editor_actions.cc:387 luawindow.cc:102 plugin_ui.cc:468
-#: processor_box.cc:3892 processor_box.cc:3894
+#: processor_box.cc:3890 processor_box.cc:3892
 msgid "Delete"
 msgstr "Löschen"
 
@@ -3578,7 +3578,7 @@ msgstr "Zeitpunkt"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Länge"
 
@@ -4023,15 +4023,15 @@ msgstr "Wähle Bereich zwischen Positionszeiger und Arbeitspunkt aus"
 msgid "Select"
 msgstr "Auswahl"
 
-#: editor.cc:2034 editor.cc:2105 editor_actions.cc:385 processor_box.cc:3888
+#: editor.cc:2034 editor.cc:2105 editor_actions.cc:385 processor_box.cc:3886
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: editor.cc:2035 editor.cc:2106 editor_actions.cc:391 processor_box.cc:3890
+#: editor.cc:2035 editor.cc:2106 editor_actions.cc:391 processor_box.cc:3888
 msgid "Copy"
 msgstr "Kopieren"
 
-#: editor.cc:2036 editor.cc:2107 editor_actions.cc:392 processor_box.cc:3902
+#: editor.cc:2036 editor.cc:2107 editor_actions.cc:392 processor_box.cc:3900
 msgid "Paste"
 msgstr "Einfügen"
 
@@ -4361,8 +4361,8 @@ msgid "Keep Remaining"
 msgstr "Übrige behalten"
 
 #: editor.cc:4214 editor_audio_import.cc:674 editor_ops.cc:6964
-#: engine_dialog.cc:3151 sfdb_freesound_mootcher.cc:69 keyeditor.cc:80
-#: processor_box.cc:3648 processor_box.cc:3673 pt_import_selector.cc:44
+#: engine_dialog.cc:3162 sfdb_freesound_mootcher.cc:69 keyeditor.cc:80
+#: processor_box.cc:3646 processor_box.cc:3671 pt_import_selector.cc:44
 #: template_dialog.cc:525 transport_masters_dialog.cc:756 utils.cc:124
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -4384,7 +4384,7 @@ msgid "Please wait while %1 loads visual data."
 msgstr "Bitte warten Sie, während %1 die Daten zur Anzeige des Projekts lädt."
 
 #: editor.cc:6204 editor.cc:6239 editor_markers.cc:1030 editor_markers.cc:1052
-#: panner_ui.cc:417 processor_box.cc:3932
+#: panner_ui.cc:417 processor_box.cc:3930
 msgid "Edit..."
 msgstr "Bearbeiten..."
 
@@ -5697,7 +5697,7 @@ msgstr ""
 "Das Projekt enthält bereits eine Datei namens %1. Wollen Sie %2 als neue "
 "Quelle importieren, oder überspringen?"
 
-#: editor_audio_import.cc:356 editor_pt_import.cc:96 editor_videotimeline.cc:97
+#: editor_audio_import.cc:356 editor_pt_import.cc:96 editor_videotimeline.cc:94
 msgid "Cancel Import"
 msgstr "Importieren Abbrechen"
 
@@ -6024,7 +6024,7 @@ msgid "mark"
 msgstr "Marker"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "Marker hinzufügen"
 
@@ -6044,7 +6044,7 @@ msgstr "Bereich"
 msgid "new range marker"
 msgstr "Neuer Bereich"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "Marker entfernen"
 
@@ -6168,8 +6168,8 @@ msgstr "Marker umbenennen"
 msgid "Rename Range"
 msgstr "Bereich umbenennen"
 
-#: editor_markers.cc:1628 editor_mouse.cc:2493 processor_box.cc:3388
-#: processor_box.cc:3904 route_time_axis.cc:1072 route_ui.cc:1714
+#: editor_markers.cc:1628 editor_mouse.cc:2493 processor_box.cc:3386
+#: processor_box.cc:3902 route_time_axis.cc:1072 route_ui.cc:1714
 #: template_dialog.cc:226 vca_master_strip.cc:463
 msgid "Rename"
 msgstr "Umbenennen"
@@ -6261,7 +6261,7 @@ msgstr "Schritt nach hinten"
 msgid "sequence regions"
 msgstr "Regionen aneinanderreihen"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Neuer Bereich"
 
@@ -6325,7 +6325,7 @@ msgstr "Regionen ganz nach unten"
 msgid "Rename Region"
 msgstr "Region umbenennen"
 
-#: editor_ops.cc:2913 processor_box.cc:3386 route_ui.cc:1712
+#: editor_ops.cc:2913 processor_box.cc:3384 route_ui.cc:1712
 msgid "New name:"
 msgstr "Neuer Name:"
 
@@ -7302,7 +7302,7 @@ msgstr "Gepuffertes E/A benutzen"
 msgid "Autostart"
 msgstr "Autostart"
 
-#: engine_dialog.cc:103 engine_dialog.cc:3165
+#: engine_dialog.cc:103 engine_dialog.cc:3176
 msgid "Measure"
 msgstr "Messen"
 
@@ -7322,7 +7322,7 @@ msgstr "Audio kalibrieren"
 msgid "Back to settings"
 msgstr "Zurück zu Einstellungen"
 
-#: engine_dialog.cc:132
+#: engine_dialog.cc:133
 msgid ""
 "No audio/MIDI backends detected. %1 cannot run\n"
 "\n"
@@ -7332,11 +7332,11 @@ msgstr ""
 "\n"
 "(Das ist ein Kompilier-/Paket-/Systemfehler und sollte nie passieren.)"
 
-#: engine_dialog.cc:157
+#: engine_dialog.cc:158
 msgid "Latency Measurement Tool"
 msgstr "Latenzmesswerkzeug"
 
-#: engine_dialog.cc:169
+#: engine_dialog.cc:170
 msgid ""
 "<span weight=\"bold\">Turn down the volume on your audio equipment to a very "
 "low level.</span>"
@@ -7344,113 +7344,108 @@ msgstr ""
 "<span weight=\"bold\">Drehen Sie die Lautstärke Ihrer Audioanlage sehr leise."
 "</span>"
 
-#: engine_dialog.cc:178
+#: engine_dialog.cc:179
 msgid "Select two channels below and connect them using a cable."
 msgstr "Wählen Sie unten zwei Kanäle aus und verbinden sie mit einem Kabel."
 
-#: engine_dialog.cc:183
+#: engine_dialog.cc:184
 msgid "Output channel:"
 msgstr "Ausgangskanal:"
 
-#: engine_dialog.cc:195
+#: engine_dialog.cc:196
 msgid "Input channel:"
 msgstr "Eingangskanal:"
 
-#: engine_dialog.cc:233
+#: engine_dialog.cc:234
 msgid "Once the channels are connected, click the \"Measure\" button."
 msgstr "Wenn die Kanäle verbunden sind, klicken Sie den \"Messen\"-Knopf."
 
-#: engine_dialog.cc:240
+#: engine_dialog.cc:241
 msgid "When satisfied with the results, click the \"Use results\" button."
 msgstr ""
 "Wenn Sie mit dem Resultat zufrieden sind, klicken Sie den Knopf \"Benutze "
 "Ergebnisse\"."
 
-#: engine_dialog.cc:255 engine_dialog.cc:3359 engine_dialog.cc:3369
+#: engine_dialog.cc:256 engine_dialog.cc:3371 engine_dialog.cc:3381
 msgid "No measurement results yet"
 msgstr "Noch keine Messergebnisse"
 
-#: engine_dialog.cc:265
+#: engine_dialog.cc:266
 msgid "Latency"
 msgstr "Latenz"
 
-#: engine_dialog.cc:317
+#: engine_dialog.cc:318
 msgid ""
 "Always try these settings when starting %1, if the same device is available"
 msgstr ""
 "%1 immer mit diesen Einstellungen zu starten versuchen, falls das gleiche "
 "Gerät verfügbar ist"
 
-#: engine_dialog.cc:483
-msgid "Could not configure Audio/MIDI engine with given settings."
-msgstr ""
-"Konnte Audio/MIDI Engine mit den angegebenen Einstellungen nicht starten."
-
-#: engine_dialog.cc:513
+#: engine_dialog.cc:510
 msgid "Audio System:"
 msgstr "Audiosystem:"
 
-#: engine_dialog.cc:557
+#: engine_dialog.cc:554
 msgid "Driver:"
 msgstr "Treiber:"
 
-#: engine_dialog.cc:564
+#: engine_dialog.cc:561
 msgid "Input Device:"
 msgstr "Eingangsgerät:"
 
-#: engine_dialog.cc:568
+#: engine_dialog.cc:565
 msgid "Output Device:"
 msgstr "Ausgangsgerät:"
 
-#: engine_dialog.cc:575
+#: engine_dialog.cc:572
 msgid "Device:"
 msgstr "Gerät:"
 
-#: engine_dialog.cc:603 engine_dialog.cc:720 export_report.cc:165
+#: engine_dialog.cc:600 engine_dialog.cc:717 export_report.cc:165
 #: export_report.cc:337 sfdb_ui.cc:183 sfdb_ui.cc:412 sfdb_ui.cc:417
 msgid "Sample rate:"
 msgstr "Samplerate:"
 
-#: engine_dialog.cc:608 engine_dialog.cc:727
+#: engine_dialog.cc:605 engine_dialog.cc:724
 msgid "Buffer size:"
 msgstr "Puffergröße:"
 
-#: engine_dialog.cc:617
+#: engine_dialog.cc:614
 msgid "Periods:"
 msgstr "Perioden:"
 
-#: engine_dialog.cc:634
+#: engine_dialog.cc:631
 msgid "Input channels:"
 msgstr "Eingangskanäle:"
 
-#: engine_dialog.cc:647
+#: engine_dialog.cc:644
 msgid "Output channels:"
 msgstr "Ausgangskanäle:"
 
-#: engine_dialog.cc:666
+#: engine_dialog.cc:663
 msgid "Hardware input latency:"
 msgstr "Hardware Eingangslatenz (Samples)"
 
-#: engine_dialog.cc:669 engine_dialog.cc:682
+#: engine_dialog.cc:666 engine_dialog.cc:679
 msgid "samples"
 msgstr "Samples"
 
-#: engine_dialog.cc:679
+#: engine_dialog.cc:676
 msgid "Hardware output latency:"
 msgstr "Hardware Ausgangslatenz (Samples)"
 
-#: engine_dialog.cc:690
+#: engine_dialog.cc:687
 msgid "MIDI System:"
 msgstr "MIDI System:"
 
-#: engine_dialog.cc:712
+#: engine_dialog.cc:709
 msgid ""
 "%1 is already running. %2 will connect to it and use the existing settings."
 msgstr ""
 "%1 läuft bereits. %2 wird zu ihm verbinden und die existierenden "
 "Einstellungen übernehmen."
 
-#: engine_dialog.cc:766
+#: engine_dialog.cc:763
 msgid ""
 "Failed to start or connect to audio-engine.\n"
 "\n"
@@ -7460,7 +7455,7 @@ msgstr ""
 "\n"
 "Latenzkalibrierung erfordert ein funktionierendes Audio-Interface."
 
-#: engine_dialog.cc:772
+#: engine_dialog.cc:769
 msgid ""
 "Your selected audio configuration is playback- or capture-only.\n"
 "\n"
@@ -7472,111 +7467,111 @@ msgstr ""
 "Latenzkalibrierung verlangt Duplexbetrieb (gleichzeitig Aufnahme und "
 "Wiedergabe)"
 
-#: engine_dialog.cc:932
+#: engine_dialog.cc:929
 msgid "Engine|Stop"
 msgstr "Stop"
 
-#: engine_dialog.cc:936
+#: engine_dialog.cc:933
 msgid "Engine|Start"
 msgstr "Start"
 
-#: engine_dialog.cc:1022
+#: engine_dialog.cc:1019
 msgid "MIDI Devices"
 msgstr "MIDI Geräte"
 
-#: engine_dialog.cc:1028
+#: engine_dialog.cc:1025
 msgid "Device"
 msgstr "Gerät"
 
-#: engine_dialog.cc:1030
+#: engine_dialog.cc:1027
 msgid "Systemic Latency [samples]"
 msgstr "Systemlatenz (samples)"
 
-#: engine_dialog.cc:1033 gain_meter.cc:802 mixer_strip.cc:191
+#: engine_dialog.cc:1030 gain_meter.cc:802 mixer_strip.cc:191
 #: mixer_strip.cc:408 mixer_strip.cc:2532 plugin_eq_gui.cc:131
 #: rc_option_editor.cc:4000
 msgid "Input"
 msgstr "Eingang"
 
-#: engine_dialog.cc:1035 foldback_strip.cc:407 gain_meter.cc:808
+#: engine_dialog.cc:1032 foldback_strip.cc:407 gain_meter.cc:808
 #: mixer_strip.cc:195 mixer_strip.cc:412 mixer_strip.cc:2535
 #: monitor_section.cc:305 monitor_section.cc:309 plugin_eq_gui.cc:132
 #: rc_option_editor.cc:4004 vca_master_strip.cc:236
 msgid "Output"
 msgstr "Ausgang"
 
-#: engine_dialog.cc:1076
+#: engine_dialog.cc:1073
 msgid "Calibrate"
 msgstr "Kalibrieren"
 
-#: engine_dialog.cc:1181
+#: engine_dialog.cc:1178
 msgid "all available channels"
 msgstr "alle verfügbaren Kanäle"
 
-#: engine_dialog.cc:1711
+#: engine_dialog.cc:1708
 msgid "%1 sample"
 msgid_plural "%1 samples"
 msgstr[0] "%1 Sample"
 msgstr[1] "%1 Samples"
 
-#: engine_dialog.cc:1771
+#: engine_dialog.cc:1768
 #, c-format
 msgid "(%.1f ms)"
 msgstr "(%.1f ms)"
 
-#: engine_dialog.cc:2525
+#: engine_dialog.cc:2522
 msgid "Could not start backend engine %1"
 msgstr "Konnte Backend-Engine %1 nicht starten"
 
-#: engine_dialog.cc:2557
+#: engine_dialog.cc:2554
 msgid "Cannot set driver to %1"
 msgstr "Kann Treiber nicht auf %1 setzen"
 
-#: engine_dialog.cc:2562
+#: engine_dialog.cc:2559
 msgid "Cannot set input device name to %1"
 msgstr "Kann Namen des Eingangsgeräts nicht auf %1 setzen"
 
-#: engine_dialog.cc:2566
+#: engine_dialog.cc:2563
 msgid "Cannot set output device name to %1"
 msgstr "Kann Namen des Ausgangsgeräts nicht auf %1 setzen"
 
-#: engine_dialog.cc:2571
+#: engine_dialog.cc:2568
 msgid "Cannot set device name to %1"
 msgstr "Kann Gerät nicht auf %1 setzen"
 
-#: engine_dialog.cc:2576
+#: engine_dialog.cc:2573
 msgid "Cannot set sample rate to %1"
 msgstr "Kann Samplerate nicht auf %1 setzen"
 
-#: engine_dialog.cc:2580
+#: engine_dialog.cc:2577
 msgid "Cannot set buffer size to %1"
 msgstr "Kann Buffergröße nicht auf %1 setzen"
 
-#: engine_dialog.cc:2584
+#: engine_dialog.cc:2581
 msgid "Cannot set periods to %1"
 msgstr "Kann Perioden nicht auf %1 setzen"
 
-#: engine_dialog.cc:2590
+#: engine_dialog.cc:2587
 msgid "Cannot set input channels to %1"
 msgstr "Kann Eingangskanäle nicht auf %1 setzen"
 
-#: engine_dialog.cc:2594
+#: engine_dialog.cc:2591
 msgid "Cannot set output channels to %1"
 msgstr "Kann Ausgangskanäle nicht auf %1 setzen"
 
-#: engine_dialog.cc:2600
+#: engine_dialog.cc:2597
 msgid "Cannot set input latency to %1"
 msgstr "Kann Eingangslatenz nicht auf %1 setzen"
 
-#: engine_dialog.cc:2604
+#: engine_dialog.cc:2601
 msgid "Cannot set output latency to %1"
 msgstr "Kann Ausgangslatenz nicht auf %1 setzen"
 
-#: engine_dialog.cc:3016 engine_dialog.cc:3082
+#: engine_dialog.cc:3027 engine_dialog.cc:3093
 msgid "No signal detected "
 msgstr "Kein Signal erkannt "
 
-#: engine_dialog.cc:3023
+#: engine_dialog.cc:3034
 msgid ""
 "Input signal is > -3dBFS. Lower the signal level (output gain, input gain) "
 "on the audio-interface."
@@ -7584,64 +7579,64 @@ msgstr ""
 "Eingangssignal is > -3dBFS. Verringern Sie den Signalpegel (E/A-Lautstärken) "
 "am Audio Interface."
 
-#: engine_dialog.cc:3036 engine_dialog.cc:3090 port_insert_ui.cc:74
+#: engine_dialog.cc:3047 engine_dialog.cc:3101 port_insert_ui.cc:74
 #: port_insert_ui.cc:102
 msgid "Disconnected from audio engine"
 msgstr "Von Audioengine getrennt"
 
-#: engine_dialog.cc:3045 engine_dialog.cc:3098
+#: engine_dialog.cc:3056 engine_dialog.cc:3109
 msgid "Detected roundtrip latency: "
 msgstr "Entdeckte Roundtrip-Latenz: "
 
-#: engine_dialog.cc:3047 engine_dialog.cc:3100
+#: engine_dialog.cc:3058 engine_dialog.cc:3111
 msgid "Systemic latency: "
 msgstr "Systemische Latenz: "
 
-#: engine_dialog.cc:3054
+#: engine_dialog.cc:3065
 msgid "(signal detection error)"
 msgstr "(Fehler bei der Signalerkennung)"
 
-#: engine_dialog.cc:3060
+#: engine_dialog.cc:3071
 msgid "(inverted - bad wiring)"
 msgstr "(invertiert - schlechte Verkabelung)"
 
-#: engine_dialog.cc:3107
+#: engine_dialog.cc:3118
 msgid "(averaging)"
 msgstr "(durchschnittlich)"
 
-#: engine_dialog.cc:3113
+#: engine_dialog.cc:3124
 msgid "(too large jitter)"
 msgstr "(zu viel Jitter)"
 
-#: engine_dialog.cc:3117
+#: engine_dialog.cc:3128
 msgid "(large jitter)"
 msgstr "(viel Jitter)"
 
-#: engine_dialog.cc:3129
+#: engine_dialog.cc:3140
 msgid "Timeout - large MIDI jitter."
 msgstr "Timeout - viel MIDI Jitter."
 
-#: engine_dialog.cc:3145 port_insert_ui.cc:138
+#: engine_dialog.cc:3156 port_insert_ui.cc:138
 msgid "Detecting ..."
 msgstr "Messe..."
 
-#: engine_dialog.cc:3283
+#: engine_dialog.cc:3295
 msgid "Disconnect from %1"
 msgstr "Trenne von %1"
 
-#: engine_dialog.cc:3288
+#: engine_dialog.cc:3300
 msgid "Running"
 msgstr "Läuft"
 
-#: engine_dialog.cc:3290
+#: engine_dialog.cc:3302
 msgid "Connected"
 msgstr "Verbunden"
 
-#: engine_dialog.cc:3301
+#: engine_dialog.cc:3313
 msgid "Connect to %1"
 msgstr "Verbinde zu %1"
 
-#: engine_dialog.cc:3305
+#: engine_dialog.cc:3317
 msgid "Stopped"
 msgstr "Gestoppt"
 
@@ -8303,7 +8298,7 @@ msgstr "Zeitanzeige:"
 msgid "Realtime Export"
 msgstr "Echtzeit-Export"
 
-#: export_timespan_selector.cc:58 processor_box.cc:3906
+#: export_timespan_selector.cc:58 processor_box.cc:3904
 msgid "Select All"
 msgstr "Alles auswählen"
 
@@ -8545,7 +8540,7 @@ msgstr "Plugin Editor: konnte kein Kontrollelement für Eigenschaft %1 erzeugen"
 msgid "Switches"
 msgstr "Schalter"
 
-#: generic_pluginui.cc:507 generic_pluginui.cc:613 processor_box.cc:3876
+#: generic_pluginui.cc:507 generic_pluginui.cc:613 processor_box.cc:3874
 msgid "Controls"
 msgstr "Steuerelemente"
 
@@ -8917,59 +8912,55 @@ msgstr "Komponist:"
 msgid "Pre-Emphasis"
 msgstr "Präemphase"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Diesen Bereich entfernen"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Startzeit - Mittelklick, um hierher zu positionieren"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Endzeit - Mittelklick, um hierher zu positionieren"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Bereichsbeginn auf Positionszeiger setzen"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Bereichsende auf Positionszeiger setzen"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Diesen Marker entfernen"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Position - Mittelklick, um hierher zu positionieren"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Markerposition auf Positionszeiger setzen"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Sie können keinen CD-Marker am Anfang des Projekts erstellen"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Neuer Marker"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Schleifen/Punchbereiche</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Marker (auch CD-Index)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Bereiche (auch CD-Track-Bereichen)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "Bereich hinzufügen"
 
@@ -10023,7 +10014,7 @@ msgstr "Benutzerdefinierte Aufnahme- und Wiedergabe-Positionen"
 msgid "Disk I/O..."
 msgstr "Disk E/A..."
 
-#: mixer_strip.cc:1760 processor_box.cc:3921
+#: mixer_strip.cc:1760 processor_box.cc:3919
 msgid "Pin Connections..."
 msgstr "Pin-Verbindungen..."
 
@@ -11231,7 +11222,7 @@ msgstr "Konnte Ausgangskonfiguration des Plugins nicht ändern."
 msgid "Failed to alter plugin input configuration."
 msgstr "Konnte Eingangskonfiguration des Plugins nicht ändern."
 
-#: plugin_pin_dialog.cc:1750 processor_box.cc:2721
+#: plugin_pin_dialog.cc:1750 processor_box.cc:2719
 msgid "Cannot set up new send: %1"
 msgstr "Kann keinen neuen Send erstellen: %1"
 
@@ -11780,7 +11771,7 @@ msgstr "Return"
 msgid "New Favorite Preset for \"%1\""
 msgstr "Neuer Vorzugspreset für \"%1\""
 
-#: processor_box.cc:539 processor_box.cc:1662
+#: processor_box.cc:539 processor_box.cc:1660
 msgid ""
 "\n"
 "%1+double-click to toggle inline-display"
@@ -11796,7 +11787,7 @@ msgstr ""
 "\n"
 "Dieses Plugin ist %1 mal repliziert worden."
 
-#: processor_box.cc:548 processor_box.cc:1666
+#: processor_box.cc:548 processor_box.cc:1664
 msgid ""
 "<b>%1</b>\n"
 "Double-click to show GUI.\n"
@@ -11806,7 +11797,7 @@ msgstr ""
 "Doppelklick, um GUI zu zeigen.\n"
 "%2+Doppelklick , um einfaches GUI zu zeigen.%3"
 
-#: processor_box.cc:551 processor_box.cc:1669
+#: processor_box.cc:551 processor_box.cc:1667
 msgid ""
 "<b>%1</b>\n"
 "Double-click to show generic GUI.%2"
@@ -11840,7 +11831,7 @@ msgstr "Alle Regler verbergen"
 msgid "Allow Feedback Loop"
 msgstr "Rückkopplungsschleife erlauben"
 
-#: processor_box.cc:1867
+#: processor_box.cc:1865
 msgid ""
 "Right-click to add/remove/edit\n"
 "plugins,inserts,sends and more"
@@ -11848,7 +11839,7 @@ msgstr ""
 "Rechtsklick, um Plugins, Inserts, Sends etc.\n"
 "hinzuzufügen/zu editieren/zu löschen"
 
-#: processor_box.cc:2016
+#: processor_box.cc:2014
 msgid ""
 "Processor Drag/Drop failed. Probably because\n"
 "the I/O configuration of the plugins could\n"
@@ -11858,15 +11849,15 @@ msgstr ""
 "weil die E/A Konfiguration der Plugins nicht mit der\n"
 "dieser Spur übereinstimmt."
 
-#: processor_box.cc:2656 processor_box.cc:3182
+#: processor_box.cc:2654 processor_box.cc:3180
 msgid "Plugin Incompatibility"
 msgstr "Plugin-Inkompatibilität"
 
-#: processor_box.cc:2659
+#: processor_box.cc:2657
 msgid "You attempted to add the plugin \"%1\" in slot %2.\n"
 msgstr "Sie haben versucht, das Plugin \"%1\" im Einschub %2 hinzuzufügen.\n"
 
-#: processor_box.cc:2665
+#: processor_box.cc:2663
 msgid ""
 "\n"
 "This plugin has:\n"
@@ -11874,19 +11865,19 @@ msgstr ""
 "\n"
 "Dieses Plugin hat:\n"
 
-#: processor_box.cc:2668
+#: processor_box.cc:2666
 msgid "\t%1 MIDI input\n"
 msgid_plural "\t%1 MIDI inputs\n"
 msgstr[0] "\t%1 MIDI Eingang\n"
 msgstr[1] "\t%1 MIDI Eingänge\n"
 
-#: processor_box.cc:2672
+#: processor_box.cc:2670
 msgid "\t%1 audio input\n"
 msgid_plural "\t%1 audio inputs\n"
 msgstr[0] "\t%1 Audio-Eingang\n"
 msgstr[1] "\t%1 Audio-Eingänge\n"
 
-#: processor_box.cc:2675
+#: processor_box.cc:2673
 msgid ""
 "\n"
 "but at the insertion point, there are:\n"
@@ -11894,19 +11885,19 @@ msgstr ""
 "\n"
 "aber am Einfügepunkt gibt es:\n"
 
-#: processor_box.cc:2678
+#: processor_box.cc:2676
 msgid "\t%1 MIDI channel\n"
 msgid_plural "\t%1 MIDI channels\n"
 msgstr[0] "\t%1 MIDI-Kanal\n"
 msgstr[1] "\t%1 MIDI-Kanäle\n"
 
-#: processor_box.cc:2682
+#: processor_box.cc:2680
 msgid "\t%1 audio channel\n"
 msgid_plural "\t%1 audio channels\n"
 msgstr[0] "\t%1 Audio-Kanal\n"
 msgstr[1] "\t%1 Audio-Kanäle\n"
 
-#: processor_box.cc:2685
+#: processor_box.cc:2683
 msgid ""
 "\n"
 "%1 is unable to insert this plugin here.\n"
@@ -11914,7 +11905,7 @@ msgstr ""
 "\n"
 "%1 kann dieses Plugin hier nicht einfügen.\n"
 
-#: processor_box.cc:3185
+#: processor_box.cc:3183
 msgid ""
 "You cannot reorder these plugins/sends/inserts\n"
 "in that way because the inputs and\n"
@@ -11924,21 +11915,21 @@ msgstr ""
 "nicht auf diese Weise verändern, sonst würden\n"
 "die Ein-/Ausgänge nicht mehr richtig funktionieren."
 
-#: processor_box.cc:3385
+#: processor_box.cc:3383
 msgid "Rename Processor"
 msgstr "Prozessor umbenennen"
 
-#: processor_box.cc:3416
+#: processor_box.cc:3414
 msgid "At least 100 IO objects exist with a name like %1 - name not changed"
 msgstr ""
 "Es gibt mindestens 100 E/A-Objekte mit einem Namen wie %1 - Name nicht "
 "geändert"
 
-#: processor_box.cc:3580
+#: processor_box.cc:3578
 msgid "plugin insert constructor failed"
 msgstr "Einfügen des Plugins fehlgeschlagen"
 
-#: processor_box.cc:3591
+#: processor_box.cc:3589
 msgid ""
 "Copying the set of processors on the clipboard failed,\n"
 "probably because the I/O configuration of the plugins\n"
@@ -11948,7 +11939,7 @@ msgstr ""
 "kopieren, vermutlich weil die E/A Konfiguration der Plugins\n"
 "nicht mit der dieser Spur übereinstimmt."
 
-#: processor_box.cc:3645
+#: processor_box.cc:3643
 msgid ""
 "Do you really want to remove all processors from %1?\n"
 "(this cannot be undone)"
@@ -11956,15 +11947,15 @@ msgstr ""
 "Wollen Sie wirklich alle Prozessoren von %1 entfernen?\n"
 "(Dies kann nicht rückgängig gemacht werden)"
 
-#: processor_box.cc:3649 processor_box.cc:3674
+#: processor_box.cc:3647 processor_box.cc:3672
 msgid "Yes, remove them all"
 msgstr "Ja, alle löschen"
 
-#: processor_box.cc:3651 processor_box.cc:3676
+#: processor_box.cc:3649 processor_box.cc:3674
 msgid "Remove processors"
 msgstr "Prozessoren entfernen"
 
-#: processor_box.cc:3666
+#: processor_box.cc:3664
 msgid ""
 "Do you really want to remove all pre-fader processors from %1?\n"
 "(this cannot be undone)"
@@ -11972,7 +11963,7 @@ msgstr ""
 "Wollen Sie wirklich alle Pre-Fader-Prozessoren von %1 entfernen?\n"
 "(Dies kann nicht rückgängig gemacht werden)"
 
-#: processor_box.cc:3669
+#: processor_box.cc:3667
 msgid ""
 "Do you really want to remove all post-fader processors from %1?\n"
 "(this cannot be undone)"
@@ -11980,79 +11971,79 @@ msgstr ""
 "Wollen Sie wirklich alle Post-Fader-Prozessoren von %1 entfernen?\n"
 "(Dies kann nicht rückgängig gemacht werden)"
 
-#: processor_box.cc:3862
+#: processor_box.cc:3860
 msgid "New Plugin"
 msgstr "Plugin einfügen"
 
-#: processor_box.cc:3865
+#: processor_box.cc:3863
 msgid "New Insert"
 msgstr "Insert einfügen"
 
-#: processor_box.cc:3868
+#: processor_box.cc:3866
 msgid "New External Send ..."
 msgstr "Neuer externer Send..."
 
-#: processor_box.cc:3872
+#: processor_box.cc:3870
 msgid "New Aux Send ..."
 msgstr "Neuer Aux-Send..."
 
-#: processor_box.cc:3873
+#: processor_box.cc:3871
 msgid "New Foldback Send ..."
 msgstr "Neuer Foldback Send..."
 
-#: processor_box.cc:3874
+#: processor_box.cc:3872
 msgid "Remove Foldback Send ..."
 msgstr "Foldback Send entfernen ..."
 
-#: processor_box.cc:3877
+#: processor_box.cc:3875
 msgid "Send Options"
 msgstr "Send Optionen"
 
-#: processor_box.cc:3879
+#: processor_box.cc:3877
 msgid "Clear (all)"
 msgstr "Löschen (alle)"
 
-#: processor_box.cc:3881
+#: processor_box.cc:3879
 msgid "Clear (pre-fader)"
 msgstr "Löschen (Pre-Fader)"
 
-#: processor_box.cc:3883
+#: processor_box.cc:3881
 msgid "Clear (post-fader)"
 msgstr "Löschen (Post-Fader)"
 
-#: processor_box.cc:3913
+#: processor_box.cc:3911
 msgid "Activate All"
 msgstr "Alle aktivieren"
 
-#: processor_box.cc:3915
+#: processor_box.cc:3913
 msgid "Deactivate All"
 msgstr "Alle deaktivieren"
 
-#: processor_box.cc:3917
+#: processor_box.cc:3915
 msgid "A/B Plugins"
 msgstr "A/B Plugins"
 
-#: processor_box.cc:3925
+#: processor_box.cc:3923
 msgid "Disk I/O ..."
 msgstr "Disk E/A ..."
 
-#: processor_box.cc:3926
+#: processor_box.cc:3924
 msgid "Pre-Fader"
 msgstr "Pre-Fader"
 
-#: processor_box.cc:3927
+#: processor_box.cc:3925
 msgid "Post-Fader"
 msgstr "Post-Fader"
 
-#: processor_box.cc:3936
+#: processor_box.cc:3934
 msgid "Edit with generic controls..."
 msgstr "Mit einfachen Kontrollelementen editieren..."
 
-#: processor_box.cc:4290
+#: processor_box.cc:4288
 msgid "%1: %2 (by %3)"
 msgstr "%1: %2 (von %3)"
 
-#: processor_box.cc:4292
+#: processor_box.cc:4290
 msgid "%1 (by %2)"
 msgstr "%1 (von %2)"
 
@@ -17960,3 +17951,7 @@ msgstr ""
 "Sehen Sie bitte im Handbuch unter %2/Video-Zeitleiste/Bearbeitung/#Export.\n"
 "\n"
 "Handbuch im Browser öffnen? "
+
+#~ msgid "Could not configure Audio/MIDI engine with given settings."
+#~ msgstr ""
+#~ "Konnte Audio/MIDI Engine mit den angegebenen Einstellungen nicht starten."

--- a/gtk2_ardour/po/el.po
+++ b/gtk2_ardour/po/el.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk-ardour 0.347.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2007-04-11 02:27+0200\n"
 "Last-Translator: Klearchos Gourgourinis <muadib@in.gr>\n"
 "Language-Team: Hellenic\n"
@@ -906,7 +906,7 @@ msgstr ""
 msgid "About"
 msgstr "Πληροφορίες"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr ""
 
@@ -2699,7 +2699,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Υποβολέας"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2714,26 +2714,26 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr ""
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
 "audio may be played at the wrong sample rate.\n"
 msgstr ""
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr ""
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr ""
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2742,31 +2742,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr ""
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2775,8 +2775,16 @@ msgid ""
 "controlled by %2"
 msgstr ""
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
+msgstr ""
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
 msgstr ""
 
 #: ardour_ui_video.cc:70
@@ -3260,7 +3268,7 @@ msgstr ""
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr ""
 
@@ -5673,7 +5681,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "πρόσθεση στίγματος"
 
@@ -5693,7 +5701,7 @@ msgstr ""
 msgid "new range marker"
 msgstr "νέο στίγμα διαστήματος"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "απαλοιφή στίγματος"
 
@@ -5912,7 +5920,7 @@ msgstr ""
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr ""
 
@@ -8435,59 +8443,55 @@ msgstr ""
 msgid "Pre-Emphasis"
 msgstr ""
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr ""
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr ""
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr ""
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr ""
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr ""
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr ""
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr ""
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr ""
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr ""
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr ""
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "πρόσθεση στίγματος διαστήματος"
 

--- a/gtk2_ardour/po/en_GB.po
+++ b/gtk2_ardour/po/en_GB.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2016-07-24 16:09+0100\n"
 "Last-Translator: Colin Fletcher <colin.m.fletcher@googlemail.com>\n"
 "Language-Team: UK English <colin.m.fletcher@googlemail.com>\n"
@@ -910,7 +910,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr ""
 
@@ -2703,7 +2703,7 @@ msgstr ""
 msgid "Prompter"
 msgstr ""
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2718,26 +2718,26 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr ""
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
 "audio may be played at the wrong sample rate.\n"
 msgstr ""
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr ""
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr ""
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2746,31 +2746,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr ""
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2779,8 +2779,16 @@ msgid ""
 "controlled by %2"
 msgstr ""
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
+msgstr ""
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
 msgstr ""
 
 #: ardour_ui_video.cc:70
@@ -3264,7 +3272,7 @@ msgstr ""
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr ""
 
@@ -5672,7 +5680,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr ""
 
@@ -5692,7 +5700,7 @@ msgstr ""
 msgid "new range marker"
 msgstr ""
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr ""
 
@@ -5905,7 +5913,7 @@ msgstr ""
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr ""
 
@@ -8428,59 +8436,55 @@ msgstr ""
 msgid "Pre-Emphasis"
 msgstr ""
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr ""
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr ""
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr ""
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr ""
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr ""
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr ""
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr ""
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr ""
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr ""
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr ""
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr ""
 

--- a/gtk2_ardour/po/es.po
+++ b/gtk2_ardour/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk2_ardour\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2016-07-27 21:44+0100\n"
 "Last-Translator: Pablo Fernández <pablo.fbus@gmail.com>\n"
 "Language-Team: \n"
@@ -959,7 +959,7 @@ msgstr "Añadir Pistas/Buses"
 msgid "About"
 msgstr "Acerca de"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Posiciones"
 
@@ -2838,7 +2838,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Prompter"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2853,11 +2853,11 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Discrepancia de frecuencia de muestreo"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2867,15 +2867,15 @@ msgstr ""
 "pero %2 está ejecutándose actualmente a %3 Hz. Si cargas la sesión\n"
 "puede que el audio se reproduzca con una tasa de muestreo incorrecta.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "No cargar sesión"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Cargar sesión de todas formas"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2889,31 +2889,31 @@ msgstr ""
 "Reconfigura el motor de audio en\n"
 "Menú > Ventana > Configuración Audio/Midi "
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 está preparado para su uso"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2926,9 +2926,17 @@ msgstr ""
 "\n"
 "Puedes comprobar este límite con 'ulimit -l' y normalmente se establece en %2"
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "No volver a mostrar esta ventana"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3418,7 +3426,7 @@ msgstr "Tiempo"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Duración"
 
@@ -5856,7 +5864,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "añadir marca"
 
@@ -5876,7 +5884,7 @@ msgstr "rango"
 msgid "new range marker"
 msgstr "nueva marca de rango"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "eliminar marca"
 
@@ -6097,7 +6105,7 @@ msgstr "empujar atrás"
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Nuevo rango"
 
@@ -8676,59 +8684,55 @@ msgstr "Compositor:"
 msgid "Pre-Emphasis"
 msgstr "Pre-énfasis"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Eliminar este rango"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Establecer inicio de rango en posición de cursor"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Establecer fin de rango en posición de cursor"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Eliminar esta marca"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Establecer tiempo de marca en posición de cursor"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "No puedes colocar una marca de CD al inicio de la sesión"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Nueva marca"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Rangos de bucle/pinchazo</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Marcas (incluyendo índice de CD)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Rangos (incluyendo rangos de pistas de CD)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "añadir marca de rango"
 

--- a/gtk2_ardour/po/eu.po
+++ b/gtk2_ardour/po/eu.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-10 12:56+0200\n"
 "Last-Translator: Enara Larraitz & Porrumentzio <porruren-grabatokia@riseup."
 "net\n"
@@ -971,7 +971,7 @@ msgstr "Gehitu Pistak/Busak"
 msgid "About"
 msgstr "Honi buruz"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Kokalekuak"
 
@@ -2937,7 +2937,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Prompterra"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2963,11 +2963,11 @@ msgstr ""
 "\n"
 "Hemendik aurrera erabili babeskopia %3(r)en bertsio zaharragoekin"
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Lagin-tasan bat ez etortzea"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2977,15 +2977,15 @@ msgstr ""
 "%3 Hz-tan lanean ari da. Saioa kargatzen baduzu,\n"
 "audioa lagin-tasa okerrean erreproduzitu daiteke.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Ez kargatu saioa"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Kargatu saioa dena den"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2999,31 +2999,31 @@ msgstr ""
 "Birkonfiguratu audio-motorra hemen:\n"
 "Menua > Leihoa > Audio/Midi konfigurazioa"
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM: hasieraketak huts egin du"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "NSM morroia ez da iragarri"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM: ez da bezero-IDrik eman"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM: ez da saiorik sortu"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 erabiltzeko prest dago"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -3038,9 +3038,17 @@ msgstr ""
 "Memoriaren muga 'ulimit -l' komandoarekin ikus dezakezu, eta normalean %2 "
 "bidez kontrolatzen da"
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Ez erakutsi leiho hau berriro"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3528,7 +3536,7 @@ msgstr "Denbora"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Iraupena"
 
@@ -5965,7 +5973,7 @@ msgid "mark"
 msgstr "marka"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "gehitu marka"
 
@@ -5985,7 +5993,7 @@ msgstr "barrutia"
 msgid "new range marker"
 msgstr "barruti-marka berria"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "ezabatu marka"
 
@@ -6202,7 +6210,7 @@ msgstr "eraman ezkerrera"
 msgid "sequence regions"
 msgstr "sekuentziatu eremuak"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Barruti berria"
 
@@ -8849,59 +8857,55 @@ msgstr "Konpositorea:"
 msgid "Pre-Emphasis"
 msgstr "Aurrenfasia"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Ezabatu barruti hau"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Hasi denbora - erdiko botoiarekin klik hemen kokatzeko"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Bukatu denbora - erdiko botoiarekin klik hemen kokatzeko"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Ezarri barruti-hasiera denbora-barraren kokalekuan"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Ezarri barruti-amaiera denbora-barraren kokalekuan"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Ezabatu marka hau"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Kokalekua - erdiko botoiarekin klik hemen kokatzeko"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Ezarri marka-denbora denbora-barraren kokalekuaz"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Ezin duzu CD markarik jarri saioaren hasieran"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Marka berria"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Loop-/Grabazio-tarteak</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Markak (CD aurkibidea barne)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Barrutiak (CD pista-barrutiak barne)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "gehitu barruti-marka"
 

--- a/gtk2_ardour/po/fr.po
+++ b/gtk2_ardour/po/fr.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-19 21:03+0200\n"
 "Last-Translator: Fred Rech <fred_rech@laposte.net>\n"
 "Language-Team: French <>\n"
@@ -987,7 +987,7 @@ msgstr "Ajouter Pistes/Bus"
 msgid "About"
 msgstr "À propos"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Emplacements"
 
@@ -2953,7 +2953,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Question"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2979,11 +2979,11 @@ msgstr ""
 "\n"
 "Utiliser désormais l'ancienne version d'%3 pour cette sauvegarde"
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Mauvais taux d'échantillonnage"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2993,15 +2993,15 @@ msgstr ""
 "mais %2 tourne actuellement à %3 Hz. Si vous chargez cette session,\n"
 "l'audio pourra être lu avec une mauvaise fréquence d'echantillonnage.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Ne pas charger la session"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Charger quand-même la session"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -3015,31 +3015,31 @@ msgstr ""
 "d'échantillonnage. Reconfigurez le moteur audio en utilisant\n"
 "le menu Fenêtre > Réglages Audio/MIDI"
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM : échec d'initialisation"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "Le serveur NSM ne s'est pas annoncé"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM : pas d'ID client fourni"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM : pas de session créée"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 est prêt à être utilisé."
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -3055,9 +3055,17 @@ msgstr ""
 "Vous pouvez consulter la limite mémoire avec \"ulimit -l\" et elle est "
 "habituellement contrôlée par %2."
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Ne plus afficher cette fenêtre"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3549,7 +3557,7 @@ msgstr "Temps"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Durée"
 
@@ -6002,7 +6010,7 @@ msgid "mark"
 msgstr "repère"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "ajouter un repère"
 
@@ -6022,7 +6030,7 @@ msgstr "intervalle"
 msgid "new range marker"
 msgstr "nouveau repère d'intervalle"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "supprimer le repère"
 
@@ -6237,7 +6245,7 @@ msgstr "décaler vers la gauche"
 msgid "sequence regions"
 msgstr "séquencer les régions"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Nouvel intervalle"
 
@@ -8881,59 +8889,55 @@ msgstr "Compositeur :"
 msgid "Pre-Emphasis"
 msgstr "Pré-accentuation"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Supprimer cet intervalle"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Début - clic du milieu pour se placer ici"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Fin - clic du milieu pour se placer ici"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Régler le début de l'intervalle à la position de la Tête"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Régler la fin de l'intervalle à la position de la Tête"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Supprimer ce repère"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Position - clic du milieu pour se placer ici"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Placer le repère en fonction de la position de la Tête"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Vous ne pouvez pas mettre un repère de CD au début de la session"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Nouveau repère"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Intervalles de Boucle/Punch</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Repères (Y compris index de CD)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Intervalles (Y compris intervalles de piste CD)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "ajouter un repère d'intervalle"
 

--- a/gtk2_ardour/po/it.po
+++ b/gtk2_ardour/po/it.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ardour 0.354.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-02 17:39+0200\n"
 "Last-Translator: Stefano Della Morte <stefano1996linc@gmail.com>\n"
 "Language-Team: Italiano <>\n"
@@ -974,7 +974,7 @@ msgstr "Aggiungi tracce/bus"
 msgid "About"
 msgstr "Informazioni"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Posizioni"
 
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Suggeritore"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2955,11 +2955,11 @@ msgstr ""
 "\n"
 "Da ora in poi,  usa la copia di backup con le vecchie versioni di %3"
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Frequenza di campionamento non coincidente"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2969,15 +2969,15 @@ msgstr ""
 "ma %2 al momento funziona a %3 Hz. Se carichi questa sessione l'audio\n"
 "potrà essere riprodotto alla frequenza di campionamento errata.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Non caricare la sessione"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Apri comunque la sessione"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2992,31 +2992,31 @@ msgstr ""
 "Riconfigura il motore audio in\n"
 "Menu > Finestre > Impostazioni audio/MIDI"
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM: inizializzazione fallita"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "Nessuna notifica dal server NSM"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM: non è stato fornito nessun ID dal client"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM: non è stata creata una sessione"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 è pronto"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -3030,9 +3030,17 @@ msgstr ""
 "Puoi controllare il limite massimo di memoria usando 'ulimit -l', "
 "normalmente gestito da %2"
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Non mostrare di nuovo"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3523,7 +3531,7 @@ msgstr "Tempo"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Durata"
 
@@ -5968,7 +5976,7 @@ msgid "mark"
 msgstr "marcatore"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "aggiungi marcatore"
 
@@ -5988,7 +5996,7 @@ msgstr "intervallo"
 msgid "new range marker"
 msgstr "nuovo marcatore di intervallo"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "rimuovi marcatore"
 
@@ -6208,7 +6216,7 @@ msgstr "spingi indietro"
 msgid "sequence regions"
 msgstr "sequenzia regioni"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Nuovo Intervallo"
 
@@ -8847,59 +8855,55 @@ msgstr "Compositore:"
 msgid "Pre-Emphasis"
 msgstr "Pre-enfasi"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Rimuovi questo intervallo"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Tempo d'inizio - clicca con il centrale per posizionarti qui"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Tempo di fine - clicca con il centrale per posizionarti qui"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Imposta l'inizio intervallo dalla posizione della testina"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Imposta la fine intervallo dalla posizione della testina"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Rimuovi questo marcatore"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Posizione - clicca con il centrale per posizionarti qui"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Imposta il cambio di tempo dalla posizione della testina"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Impossibile inserire un marcatore CD all'inizio della sessione"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Nuovo marcatore"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Intervalli di Ciclo/Punch</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Marcatori (inclusi gli indici CD)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Intervalli (inclusi gli intervalli traccia CD)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "aggiungi marcatore di intervallo"
 

--- a/gtk2_ardour/po/ja.po
+++ b/gtk2_ardour/po/ja.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-04-25 22:39+0100\n"
 "Last-Translator: Hiroki Inagaki <hiroki.ingk@gmail.com>\n"
 "Language-Team: Japanese <ardour-dev@lists.ardour.org>\n"
@@ -970,7 +970,7 @@ msgstr "トラック/バスを追加"
 msgid "About"
 msgstr "Ardour について"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "ロケーション"
 
@@ -2909,7 +2909,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "プロンプター"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2937,11 +2937,11 @@ msgstr ""
 "\n"
 "今後、%3 の古いバージョンのバックアップコピーを使用してください。"
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "サンプルレート不一致"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2951,15 +2951,15 @@ msgstr ""
 "%2 は現在 %3 Hzで動作しています。このセッションを読み込んだ場合、\n"
 "オーディオは異なるサンプルレートで再生される可能性があります。\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "セッションを読み込まない"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "とにかくセッションを読み込む"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2973,31 +2973,31 @@ msgstr ""
 "以下からオーディオエンジンを再設定してください\n"
 "メニュー > ウインドウ > オーティオ/MIDI セットアップ"
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM: 初期化に失敗しました"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "NSM サーバが応答していません"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM: クライアント ID が提供されていません"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM: セッションが作成されていません"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 を使用する準備ができました"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -3011,9 +3011,17 @@ msgstr ""
 "'ulimit -l’ によりメモリの制限を参照できます。メモリの制限は通常、%2 により制"
 "御されます。"
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "今後このウィンドウを表示しない"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3500,7 +3508,7 @@ msgstr "時間"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "長さ"
 
@@ -5944,7 +5952,7 @@ msgid "mark"
 msgstr "マーク"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "マーカーを追加"
 
@@ -5964,7 +5972,7 @@ msgstr "レンジ"
 msgid "new range marker"
 msgstr "新規レンジメーカー"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "マーカーを削除"
 
@@ -6182,7 +6190,7 @@ msgstr "後ろに動かす"
 msgid "sequence regions"
 msgstr "リージョンを順番に配列"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "新規レンジ"
 
@@ -8806,59 +8814,55 @@ msgstr "作曲者:"
 msgid "Pre-Emphasis"
 msgstr "プリエンファシス"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "このレンジを削除"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "開始時間 - 中央クリックでここに設定"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "終了時間 - 中央クリックでここに設定"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "再生ヘッド位置からレンジ開始位置を設定"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "再生ヘッド位置からレンジ終了位置を設定"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "このマーカーを削除"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "ポジション - 中央クリックでここに設定"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "再生ヘッド位置からマーカー時間位置を設定"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "セッションの最初に CD マーカーを設定することはできません"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "新規マーカー"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>ループ/パンチ・レンジ</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>マーカー (CD インデックス含む)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>レンジ (CD トラックレンジ含む)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "レンジマーカーを追加"
 

--- a/gtk2_ardour/po/nn.po
+++ b/gtk2_ardour/po/nn.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk2_ardour 3.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2013-01-05 14:48+0100\n"
 "Last-Translator: Eivind Ødegård <meinmycell-lists@yahoo.no>\n"
 "Language-Team:  <i18n-nn@lister.ping.uio.no>\n"
@@ -938,7 +938,7 @@ msgstr ""
 msgid "About"
 msgstr "Om"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr ""
 
@@ -2778,7 +2778,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Spørsmål"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2793,11 +2793,11 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Punktfrekvensen passar ikkje"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2807,15 +2807,15 @@ msgstr ""
 "%2 køyrer på %3 Hz nett no. Viss du lastar denne økta,\n"
 "kan det henda lyden blir spelt med feil punktfrekvens.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Ikkje last økta"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Last økta likevel"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2824,31 +2824,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 er klar til bruk"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2862,9 +2862,17 @@ msgstr ""
 "Du kan finna ut kva minnegrensa er med 'ulimit -l'. Minnegrensa er vanlegvis "
 "kontrollert av %2"
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Ikkje vis denne ruta att"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3347,7 +3355,7 @@ msgstr "Tid"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Lengd"
 
@@ -5769,7 +5777,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "legg til merke"
 
@@ -5789,7 +5797,7 @@ msgstr "område"
 msgid "new range marker"
 msgstr "nytt områdemerke"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "fjern markør"
 
@@ -6006,7 +6014,7 @@ msgstr "skubb bakover"
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Nytt område"
 
@@ -8566,59 +8574,55 @@ msgstr "Komponist:"
 msgid "Pre-Emphasis"
 msgstr "Før-framheving for CD"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Fjern dette området"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Starttid - midtklikk for å gå hit"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Sluttid - midtklikk for å gå hit"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Set områdestart ved spelehovudet"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Set områdeslutt ved spelehovudet"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Fjern denne markøren"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Posisjon - midtklikk for å gå hit"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Set markørtid ved spelehovudet"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Du kan ikkje leggja ein CD-markør på starten av økta"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Nytt merke"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Lykkje-/innslagsområde</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Markørar (inkl. CD-indeks)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Bolkar (inkl. CD-sporbolkar)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "legg til områdemarkørar"
 

--- a/gtk2_ardour/po/pl.po
+++ b/gtk2_ardour/po/pl.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk2_ardour\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2008-04-10 10:47+0100\n"
 "Last-Translator: Piotr Zaryk <pzaryk@gmail.com>\n"
 "Language-Team: Polish <pzaryk@gmail.com>\n"
@@ -917,7 +917,7 @@ msgstr ""
 msgid "About"
 msgstr "O programie"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr ""
 
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Prompter"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2737,26 +2737,26 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Błędna częstotliwość próbkowania"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
 "audio may be played at the wrong sample rate.\n"
 msgstr ""
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Nie ładuj sesji"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Załaduj sesję mimo to"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2765,31 +2765,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr ""
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2798,9 +2798,17 @@ msgid ""
 "controlled by %2"
 msgstr ""
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Nie pokazuj tego okna więcej"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3284,7 +3292,7 @@ msgstr ""
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr ""
 
@@ -5697,7 +5705,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "dodaj znacznik"
 
@@ -5717,7 +5725,7 @@ msgstr ""
 msgid "new range marker"
 msgstr "nowy znacznik zakresu"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "usuń znacznik"
 
@@ -5930,7 +5938,7 @@ msgstr ""
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr ""
 
@@ -8456,59 +8464,55 @@ msgstr ""
 msgid "Pre-Emphasis"
 msgstr "Przed naciskiem"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr ""
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr ""
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr ""
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr ""
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr ""
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr ""
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr ""
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr ""
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr ""
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr ""
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "dodaj znacznik zakresu"
 

--- a/gtk2_ardour/po/pt.po
+++ b/gtk2_ardour/po/pt.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ardour 0.688.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2005-08-15 21:50-0000\n"
 "Last-Translator: Chris Ross, Alexander Franca & Leandro Marco\n"
 "Language-Team: Portuguese\n"
@@ -910,7 +910,7 @@ msgstr "Adicionar Trilhas/Bus"
 msgid "About"
 msgstr "Sobre"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Localizações"
 
@@ -2717,7 +2717,7 @@ msgstr ""
 msgid "Prompter"
 msgstr ""
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2732,26 +2732,26 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr ""
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
 "audio may be played at the wrong sample rate.\n"
 msgstr ""
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr ""
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr ""
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2760,31 +2760,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr ""
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2793,9 +2793,17 @@ msgid ""
 "controlled by %2"
 msgstr ""
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Não mostrar esta janela novamente"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3278,7 +3286,7 @@ msgstr "Tempo"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Duração"
 
@@ -5686,7 +5694,7 @@ msgid "mark"
 msgstr "marca"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "adicionar marca"
 
@@ -5706,7 +5714,7 @@ msgstr ""
 msgid "new range marker"
 msgstr ""
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "remover marca"
 
@@ -5919,7 +5927,7 @@ msgstr ""
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr ""
 
@@ -8441,59 +8449,55 @@ msgstr ""
 msgid "Pre-Emphasis"
 msgstr ""
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr ""
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr ""
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr ""
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr ""
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr ""
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr ""
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr ""
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr ""
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr ""
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr ""
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "adicionar marca de intervalo"
 

--- a/gtk2_ardour/po/pt_PT.po
+++ b/gtk2_ardour/po/pt_PT.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk2_ardour rev.1702\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2007-04-15 19:00+0100\n"
 "Last-Translator: Rui Nuno Capela <rncbc@rncbc.org>\n"
 "Language-Team: Portuguese\n"
@@ -906,7 +906,7 @@ msgstr ""
 msgid "About"
 msgstr "Acerca de"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr ""
 
@@ -2703,7 +2703,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Alerta"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2718,26 +2718,26 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr ""
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
 "audio may be played at the wrong sample rate.\n"
 msgstr ""
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr ""
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr ""
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2746,31 +2746,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr ""
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr ""
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr ""
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2779,8 +2779,16 @@ msgid ""
 "controlled by %2"
 msgstr ""
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
+msgstr ""
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
 msgstr ""
 
 #: ardour_ui_video.cc:70
@@ -3264,7 +3272,7 @@ msgstr ""
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr ""
 
@@ -5675,7 +5683,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "acrescentar marcador"
 
@@ -5695,7 +5703,7 @@ msgstr ""
 msgid "new range marker"
 msgstr "novo marcador de região"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "remover marcador"
 
@@ -5908,7 +5916,7 @@ msgstr ""
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr ""
 
@@ -8430,59 +8438,55 @@ msgstr ""
 msgid "Pre-Emphasis"
 msgstr "Pré-êmfase"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr ""
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr ""
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr ""
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr ""
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr ""
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr ""
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr ""
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr ""
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr ""
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr ""
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "acrescentar marcador de região"
 

--- a/gtk2_ardour/po/ru.po
+++ b/gtk2_ardour/po/ru.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-04-22 19:30+0300\n"
 "Last-Translator: Alexandre Prokoudine <alexandre.prokoudine@gmail.com>\n"
 "Language-Team: русский <gnome-cyr@lists.gnome.org>\n"
@@ -973,7 +973,7 @@ msgstr "Добавить дорожки/шины"
 msgid "About"
 msgstr "О программе"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Позиции"
 
@@ -2900,7 +2900,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Суфлер"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2926,11 +2926,11 @@ msgstr ""
 "\n"
 "С этого момента открывайте архивную копию только в более ранних версиях %3."
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "Несовпадение частот сэмплирования"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2942,15 +2942,15 @@ msgstr ""
 "Если вы загрузите эту сессию, звуковые данные могут быть\n"
 "воспроизведены с некорректной частотой сэмплирования.\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "Не загружать сессию"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "Все равно загрузить"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2963,31 +2963,31 @@ msgstr ""
 "Звук будет записан и воспроизведен c неправильной частотой дискретизации.\n"
 "Настройте звуковой движок через «Меню > Окно > Настройка Аудио/MIDI»."
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM: сбой инициализации"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "Сервер NSM не объявлял о себе"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM: не предоставлен ни один ID-клиент"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM: нет созданной сессии"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 готов к работе"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -3002,9 +3002,17 @@ msgstr ""
 "Вы можете узнать установленный предел при помощи команды 'ulimit -l'. Обычно "
 "это контролируется в %2."
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Больше не показывать это окно"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3492,7 +3500,7 @@ msgstr "Время"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Длительность"
 
@@ -5923,7 +5931,7 @@ msgid "mark"
 msgstr "пометка"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "Добавить пометку"
 
@@ -5943,7 +5951,7 @@ msgstr "Диапазон"
 msgid "new range marker"
 msgstr "Новая пометка диапазона"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "Удаление пометки"
 
@@ -6159,7 +6167,7 @@ msgstr "Толчок назад"
 msgid "sequence regions"
 msgstr "выстраивание областей встык"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Создать диапазон"
 
@@ -8768,59 +8776,55 @@ msgstr "Композитор:"
 msgid "Pre-Emphasis"
 msgstr "Пред. акцент"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "Удалить эту область"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "Время начала - средний клик, чтобы разместить здесь"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "Время окончания - средний клик, чтобы разместить здесь"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "Установить начало диапазона по указателю воспроизведения"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "Установить конец диапазона по указателю воспроизведения"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "Удалить эту пометку"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "Позиция - средний клик, чтобы разместить здесь"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "Установить время пометки по месту воспроизведения"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "Размещение пометки CD в начале сессии невозможно"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Создать маркер"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Диапазоны петель/врезок</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Пометки (включая индекс CD)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Диапазоны (включая диапазоны дорожек CD)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "Добавка пометки диапазона"
 

--- a/gtk2_ardour/po/sv.po
+++ b/gtk2_ardour/po/sv.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ardour-gtk 1.0.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2006-06-26 23:57+GMT+1\n"
 "Last-Translator: Kristoffer Grundström <hamnisdude@gmail.com>\n"
 "Language-Team: Svenska <sv@li.org>\n"
@@ -912,7 +912,7 @@ msgstr "Lägg till Spår/Bussar"
 msgid "About"
 msgstr "Om"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "Platser"
 
@@ -2719,7 +2719,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "Fråga"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2734,26 +2734,26 @@ msgid ""
 "From now on, use the backup copy with older versions of %3"
 msgstr ""
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr ""
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
 "audio may be played at the wrong sample rate.\n"
 msgstr ""
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr ""
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr ""
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2762,31 +2762,31 @@ msgid ""
 "Menu > Window > Audio/Midi Setup"
 msgstr ""
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM: initialiseringen misslyckades"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr ""
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr ""
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM: ingen session skapad"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 används redan"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2795,9 +2795,17 @@ msgid ""
 "controlled by %2"
 msgstr ""
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "Visa inte det här fönstret igen"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3280,7 +3288,7 @@ msgstr ""
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "Längd"
 
@@ -5694,7 +5702,7 @@ msgid "mark"
 msgstr ""
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr ""
 
@@ -5714,7 +5722,7 @@ msgstr "omfång"
 msgid "new range marker"
 msgstr "ny omfångsmarkör"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "ta bort markör"
 
@@ -5927,7 +5935,7 @@ msgstr ""
 msgid "sequence regions"
 msgstr ""
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "Nytt omfång"
 
@@ -8449,59 +8457,55 @@ msgstr ""
 msgid "Pre-Emphasis"
 msgstr ""
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr ""
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr ""
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr ""
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr ""
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr ""
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr ""
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr ""
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "Ny markör"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>Loop-/inslagsomfång</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>Markörer (inkl CD-index)</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>Omfång (inkl CD-spårsomfång)</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "lägg till omfångsmarkör"
 

--- a/gtk2_ardour/po/zh.po
+++ b/gtk2_ardour/po/zh.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 6.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-17 12:07+0800\n"
 "Last-Translator: \n"
 "Language-Team: 一善鱼 YQ-YSY@163.com\n"
@@ -967,7 +967,7 @@ msgstr "添加音轨/总线"
 msgid "About"
 msgstr "关于"
 
-#: ardour_ui.cc:331 location_ui.cc:1215
+#: ardour_ui.cc:331 location_ui.cc:1191
 msgid "Ranges|Locations"
 msgstr "位置"
 
@@ -2888,7 +2888,7 @@ msgstr ""
 msgid "Prompter"
 msgstr "提词机"
 
-#: ardour_ui_startup.cc:167
+#: ardour_ui_startup.cc:168
 msgid ""
 "%4This is a session from an older version of %3%5\n"
 "\n"
@@ -2914,11 +2914,11 @@ msgstr ""
 "\n"
 "从现在开始，使用 %3 的旧版本备份副本"
 
-#: ardour_ui_startup.cc:183
+#: ardour_ui_startup.cc:184
 msgid "Sample Rate Mismatch"
 msgstr "采样率不匹配"
 
-#: ardour_ui_startup.cc:184
+#: ardour_ui_startup.cc:185
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.  If you load this session,\n"
@@ -2928,15 +2928,15 @@ msgstr ""
 "但是 %2 目前运行在 %3 Hz。如果您加载这个会话，\n"
 "音频可能会处在错误的采样率上播放。\n"
 
-#: ardour_ui_startup.cc:193
+#: ardour_ui_startup.cc:194
 msgid "Do not load session"
 msgstr "不要载入会话"
 
-#: ardour_ui_startup.cc:194
+#: ardour_ui_startup.cc:195
 msgid "Load session anyway"
 msgstr "只管载入会话"
 
-#: ardour_ui_startup.cc:214
+#: ardour_ui_startup.cc:215
 msgid ""
 "This session was created with a sample rate of %1 Hz, but\n"
 "%2 is currently running at %3 Hz.\n"
@@ -2950,31 +2950,31 @@ msgstr ""
 "重新配置音频引擎请点击菜单\n"
 "菜单 > 窗口 > 音频/MIDI 设置"
 
-#: ardour_ui_startup.cc:380
+#: ardour_ui_startup.cc:381
 msgid "NSM: initialization failed"
 msgstr "NSM（网络服务管理）：初始化失败"
 
-#: ardour_ui_startup.cc:407
+#: ardour_ui_startup.cc:408
 msgid "NSM server did not announce itself. Continuing without NSM."
 msgstr ""
 
-#: ardour_ui_startup.cc:409
+#: ardour_ui_startup.cc:410
 msgid "NSM server did not announce itself"
 msgstr "NSM（网络服务管理）服务器没有表明身份"
 
-#: ardour_ui_startup.cc:425
+#: ardour_ui_startup.cc:427
 msgid "NSM: no client ID provided"
 msgstr "NSM（网络服务管理）: 没有提供客户机识别号"
 
-#: ardour_ui_startup.cc:434
+#: ardour_ui_startup.cc:436
 msgid "NSM: no session created"
 msgstr "NSM（网络服务管理）：没有已创建的会话"
 
-#: ardour_ui_startup.cc:581 new_user_wizard.cc:419
+#: ardour_ui_startup.cc:586 new_user_wizard.cc:419
 msgid "%1 is ready for use"
 msgstr "%1 准备就绪"
 
-#: ardour_ui_startup.cc:631
+#: ardour_ui_startup.cc:636
 msgid ""
 "WARNING: Your system has a limit for maximum amount of locked memory. This "
 "might cause %1 to run out of memory before your system runs out of memory. \n"
@@ -2987,9 +2987,17 @@ msgstr ""
 "\n"
 "您可以使用“ulimit -l”命令来查看内存限制，通常它由 %2 来控制。"
 
-#: ardour_ui_startup.cc:648
+#: ardour_ui_startup.cc:653
 msgid "Do not show this window again"
 msgstr "不再显示此窗口"
+
+#: ardour_ui_startup.cc:709
+msgid "NSM: The JACK backend is mandatory and can not be loaded."
+msgstr ""
+
+#: ardour_ui_startup.cc:727
+msgid "NSM: %1 cannot connect to the JACK server. Please start jackd first."
+msgstr ""
 
 #: ardour_ui_video.cc:70
 msgid "Video-Server was not launched by %1. The request to stop it is ignored."
@@ -3472,7 +3480,7 @@ msgstr "时间"
 
 #: edit_note_dialog.cc:101 editor_regions.cc:178
 #: export_timespan_selector.cc:412 export_timespan_selector.cc:534
-#: location_ui.cc:336 midi_list_editor.cc:117 time_info_box.cc:100
+#: location_ui.cc:330 midi_list_editor.cc:117 time_info_box.cc:100
 msgid "Length"
 msgstr "长度"
 
@@ -5902,7 +5910,7 @@ msgid "mark"
 msgstr "标记"
 
 #: editor_markers.cc:665 editor_ops.cc:2233 editor_ops.cc:2255
-#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1073
+#: editor_ops.cc:2392 editor_ops.cc:2429 location_ui.cc:1049
 msgid "add marker"
 msgstr "添加标记"
 
@@ -5922,7 +5930,7 @@ msgstr "范围"
 msgid "new range marker"
 msgstr "新建范围标记"
 
-#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:906
+#: editor_markers.cc:766 editor_ops.cc:2353 location_ui.cc:882
 msgid "remove marker"
 msgstr "移除标记"
 
@@ -6135,7 +6143,7 @@ msgstr "向后微调"
 msgid "sequence regions"
 msgstr "序列区域"
 
-#: editor_ops.cc:2184 location_ui.cc:769
+#: editor_ops.cc:2184 location_ui.cc:745
 msgid "New Range"
 msgstr "新建范围"
 
@@ -8741,59 +8749,55 @@ msgstr "作曲家："
 msgid "Pre-Emphasis"
 msgstr "预加重"
 
-#: location_ui.cc:333
+#: location_ui.cc:327
 msgid "Remove this range"
 msgstr "移除这个范围"
 
-#: location_ui.cc:334
+#: location_ui.cc:328
 msgid "Start time - middle click to locate here"
 msgstr "起点时间 —— 鼠标中键点击放置在此处"
 
-#: location_ui.cc:335
+#: location_ui.cc:329
 msgid "End time - middle click to locate here"
 msgstr "终点时间 —— 鼠标中键点击放置在此处"
 
-#: location_ui.cc:338
+#: location_ui.cc:332
 msgid "Set range start from playhead location"
 msgstr "从指针位置设置范围起点"
 
-#: location_ui.cc:339
+#: location_ui.cc:333
 msgid "Set range end from playhead location"
 msgstr "从指针位置设置范围终点"
 
-#: location_ui.cc:343
+#: location_ui.cc:337
 msgid "Remove this marker"
 msgstr "移除这个标记"
 
-#: location_ui.cc:344
+#: location_ui.cc:338
 msgid "Position - middle click to locate here"
 msgstr "位置 —— 鼠标中键点击放置在此处"
 
-#: location_ui.cc:346
+#: location_ui.cc:340
 msgid "Set marker time from playhead location"
 msgstr "从指针位置设置标记时间"
 
-#: location_ui.cc:542
-msgid "You cannot put a CD marker at the start of the session"
-msgstr "您不能在会话起点处放置 CD 光盘标记"
-
-#: location_ui.cc:768
+#: location_ui.cc:744
 msgid "New Marker"
 msgstr "新建标记"
 
-#: location_ui.cc:785
+#: location_ui.cc:761
 msgid "<b>Loop/Punch Ranges</b>"
 msgstr "<b>循环/切换范围</b>"
 
-#: location_ui.cc:811
+#: location_ui.cc:787
 msgid "<b>Markers (Including CD Index)</b>"
 msgstr "<b>标记（包括 CD 光盘索引）</b>"
 
-#: location_ui.cc:846
+#: location_ui.cc:822
 msgid "<b>Ranges (Including CD Track Ranges)</b>"
 msgstr "<b>范围（包括 CD 光盘音轨范围）</b>"
 
-#: location_ui.cc:1092
+#: location_ui.cc:1068
 msgid "add range marker"
 msgstr "添加范围标记"
 

--- a/libs/ardour/location.cc
+++ b/libs/ardour/location.cc
@@ -213,12 +213,6 @@ Location::set_start (samplepos_t s, bool force, bool allow_beat_recompute, const
 		}
 	}
 
-	if (is_cd_marker()) {
-		if (s <= _session.current_start_sample()) {
-			return -1;
-		}
-	}
-
 	if (is_mark()) {
 		if (_start != s) {
 			_start = s;
@@ -470,14 +464,6 @@ Location::set_hidden (bool yn, void*)
 void
 Location::set_cd (bool yn, void*)
 {
-	// XXX this really needs to be session start
-	// but its not available here - leave to GUI
-
-	if (yn && _start == 0) {
-		error << _("You cannot put a CD marker at this position") << endmsg;
-		return;
-	}
-
 	if (set_flag_internal (yn, IsCDMarker)) {
 		flags_changed (this); /* EMIT SIGNAL */
 		FlagsChanged ();

--- a/libs/ardour/po/cs.po
+++ b/libs/ardour/po/cs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gtk-ardour 0.347.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-08 14:31+0200\n"
 "Last-Translator: Pavel Fric <pavelfric@seznam.cz>\n"
 "Language-Team: Czech <translation-team-cs@lists.sourceforge.net>\n"
@@ -1374,47 +1374,43 @@ msgstr "Chyba při ukládání souboru s přednastavením %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "Nepodařilo se najít HOME. Přednastavení neuloženo."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "V této poloze nelze dát značku CD."
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "Nesprávný uzel XML předán do Location::set_state"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "Uzel XML pro polohu nemá žádnou informaci o ID"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "Uzel XML pro polohu nemá žádnou informaci o názvu"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "Uzel XML pro polohu nemá žádnou informaci o začátku"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "Uzel XML pro polohu nemá žádnou informaci o konci"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "Uzel XML pro polohu nemá žádnou informaci o příznaku"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr "Polohy: pokus o použití neznámé polohy jako vybrané polohy"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "Nesprávný režim XML předán do Locations::set_state"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "Sezení"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr "Nepodařilo se nahrát polohu ze souboru se sezením - přehlíží se"
 
@@ -10075,9 +10071,6 @@ msgstr "Nelze nastavit stav VCA"
 
 #~ msgid "Set marker time from playhead location"
 #~ msgstr "Nastavit čas značky z místa ukazatele polohy"
-
-#~ msgid "You cannot put a CD marker at the start of the session"
-#~ msgstr "Na začátku sezení nemůžete zřídit žádnou značku na CD"
 
 #~ msgid "New Marker"
 #~ msgstr "Nová značka"

--- a/libs/ardour/po/de.po
+++ b/libs/ardour/po/de.po
@@ -1376,49 +1376,45 @@ msgstr "Fehler beim Sichern der Preset-Datei %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "Konnte HOME nicht eruieren. Preset nicht gesichert."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "An dieser Stelle können Sie keinen CD-Marker ablegen"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "Unkorrekter XML-Knoten an Location::set_state weitergereicht"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "XML-Knoten für Position hat keine ID-Information"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "XML-Knoten für Position hat keine Namensinformation"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "XML-Knoten für Position hat keine Start-Information"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "XML-Knoten für Position hat keine End-Information"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "XML-Knoten für Position hat keine Flags-Information"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 "Locations: Versuch, eine unbekannte Position als ausgewählte Position zu "
 "verwenden"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "unkorrekter XML-Modus an Locations::set_state weitergereicht"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "Projekt"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr "konnte Position nicht aus Projektdatei laden - ignoriert"
 

--- a/libs/ardour/po/el.po
+++ b/libs/ardour/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour 0.664.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2007-04-16 00:38+0200\n"
 "Last-Translator: Klearchos Gourgourinis <muadib@in.gr>\n"
 "Language-Team: Hellenic(Greek)\n"
@@ -1312,49 +1312,45 @@ msgstr "Σφάλμα στην αποθήκευση αρχείου προ-ρυθ�
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "Δεν μπόρεσα να βρώ το HOME.  Προ-ρύθμιση δεν αποθηκεύθηκε."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr ""
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "λανθασμένος κόμβος XML πέρασε στην Τοποθεσία::set_state"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "Ο κόμβος XML για την Τοποθεσία δεν έχει πληροφορίες ονόματος"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "Ο κόμβος XML για την Τοποθεσία δεν έχει πληροφορίες ενάρξεως"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "Ο κόμβος XML για την Τοποθεσία δεν έχει πληροφορίες τέλους"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "Ο κόμβος XML για την Τοποθεσία δεν έχει πληροφορίες για σημαίες(flags)"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 "Τοποθεσίες: απόπειρα να χρησιμοποιηθεί άγνωστη τοποθεσία σαν επιλεγμένη "
 "τοποθεσία"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "λανθασμένο XML mode πέρασε στις Τοποθεσίες::set_state"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr ""
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/en_GB.po
+++ b/libs/ardour/po/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2016-07-24 16:09+0100\n"
 "Last-Translator: Colin Fletcher <colin.m.fletcher@googlemail.com>\n"
 "Language-Team: colin.m.fletcher@googlemail.com\n"
@@ -1315,47 +1315,43 @@ msgstr ""
 msgid "Could not locate HOME.  Preset not saved."
 msgstr ""
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr ""
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr ""
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr ""
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr ""
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr ""
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr ""
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr ""
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr ""
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/es.po
+++ b/libs/ardour/po/es.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2015-03-15 \n"
 "Last-Translator: Pablo Fernández <pablo.fbus@gmail.com>\n"
 "Language-Team: \n"
@@ -1308,47 +1308,43 @@ msgstr "Error al guardar el archivo de preset %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr ""
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "No puedes poner una marca de CD en esta posición."
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr ""
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr ""
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr ""
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr ""
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr ""
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr ""
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "sesión"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/eu.po
+++ b/libs/ardour/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-02 18:26+0200\n"
 "Last-Translator: Enara Larraitz & Porrumentzio <porruren-grabatokia@riseup."
 "net>\n"
@@ -1379,49 +1379,45 @@ msgstr "Errorea %1 aurrezarpen-fitxategia gordetzerakoan."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "Ezin izan da ETXEA aurkitu. Aurrezarpena ez da gorde."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "Ezin duzu CD markatzailea posizio honetan jarri"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "XML nodo okerra hona pasa da: Location::set_state"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "Kokalekuaren XML nodoak ez du ID informaziorik"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "Kokalekuaren XML nodoak ez du izen informaziorik"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "Kokalekuaren XML nodoak ez du hasiera informaziorik"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "Kokalekuaren XML nodoak ez du bukaera informaziorik"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "Kokalekuaren XML nodoak ez du marka informaziorik"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 "Kokalekuak: kokaleku ezezaguna hautatutako kokalekua bezala erabiltzeko "
 "saiakera egin da"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "XML modu okerra hona pasa da: Location::set_state"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "saioa"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 "ezin izan da saio-fitxategiaren kokalekua kargatu - alde batera utzi da"

--- a/libs/ardour/po/fr.po
+++ b/libs/ardour/po/fr.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour 5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-04-28 16:06+0200\n"
 "Last-Translator: Olivier Humbert <trebmuh@tuxfamily.org>\n"
 "Language-Team: \n"
@@ -1373,47 +1373,43 @@ msgstr "Erreur lors de la sauvegarde du fichier de pré-réglage %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "HOME introuvable. Préset non sauvegardé."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "Impossible de placer un repère de CD ici"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr ""
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr ""
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr ""
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr ""
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr ""
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr ""
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "session"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/it.po
+++ b/libs/ardour/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour 0.664.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2003-05-21 12:50+0500\n"
 "Last-Translator: Filippo Pappalardo <filippo@email.it>\n"
 "Language-Team: Italian\n"
@@ -1307,47 +1307,43 @@ msgstr "Errore nel salvare il file di preset %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "impossibile localizzare HOME.  Preset non salvato."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr ""
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr ""
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "il nodo XML per la Location non ha informazioni sul nome"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "il nodo XML per la Location non ha informazioni sull'inizio"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "il nodo XML per la Location non ha informazioni sulla fine"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "il nodo XML per la Location non ha informazioni sui flags"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr ""
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr ""
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/ja.po
+++ b/libs/ardour/po/ja.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-04-26 22:25+0100\n"
 "Last-Translator: Hiroki Inagaki <hiroki.ingk@gmail.com>\n"
 "Language-Team: Japanese <ardour-dev@lists.ardour.org>\n"
@@ -1377,47 +1377,43 @@ msgstr "プリセットファイル %1 保存エラー。"
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "HOME の場所を特定できません。プリセットは保存されません。"
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "この位置に CD マーカーを置くことはできません"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "誤った XML ノードを Location::set_state に渡しました"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "Location の XML ノードに ID 情報がありません"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "Location の XML ノードに名前情報がありません"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "Location の XML ノードに開始情報がありません"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "Location の XML ノードに終了情報がありません"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "Location の XML ノードにフラグ情報がありません"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr "Locations: 選択した位置として不明な位置を使用しようとしています"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "不正な XML モードを Locations::set_state に渡しました"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "session"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr "セッションファイルから位置を読み込めません - 無視します"
 

--- a/libs/ardour/po/nn.po
+++ b/libs/ardour/po/nn.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2011-09-13 22:43+0100\n"
 "Last-Translator: Eivind Ødegård <meinmycell-lists@yahoo.no>\n"
 "Language-Team: Nynorsk <i18n-nn@lister.ping.uio.no>\n"
@@ -1326,47 +1326,43 @@ msgstr "Feil med å lagra ferdigoppsettfila %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "Greidde ikkje finna heimemappa. Har ikkje lagra ferdigoppsett."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "Du kan ikkje leggja til ein CD-markør her"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "feil XML-punkt sendt til Location::set_state"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "XML-punktet for denne staden har ingen ID-informasjon"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "XML-punktet for denne staden har ingen namneinformasjon"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "XML-punktet for denne staden har ingen startinformasjon"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "XML-punktet for denne staden har ingen sluttinformasjon"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "XML-punktet for denne staden har ingen flagginformasjon"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr "Stader: forsøk på å bruka ukjend stad som vald stad"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "feil XML-modus send til Locations::set_state"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "økt"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr "greidde ikkje lasta stad frå øktfila - hoppa over"
 

--- a/libs/ardour/po/pl.po
+++ b/libs/ardour/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2008-04-10 10:51+0100\n"
 "Last-Translator: Piotr Zaryk <pzaryk@gmail.com>\n"
 "Language-Team: Polish <pl@li.org>\n"
@@ -1301,47 +1301,43 @@ msgstr ""
 msgid "Could not locate HOME.  Preset not saved."
 msgstr ""
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr ""
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr ""
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr ""
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr ""
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr ""
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr ""
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr ""
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr ""
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/ru.po
+++ b/libs/ardour/po/ru.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: libardour 4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-04-22 19:41+0300\n"
 "Last-Translator: Alexandre Prokoudine <alexandre.prokoudine@gmail.com>\n"
 "Language-Team: русский <gnome-cyr@lists.gnome.org>\n"
@@ -1352,47 +1352,43 @@ msgstr "Ошибка сохранения файла пресетов %1."
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "Невозможно найти HOME. Предустановки не сохранены."
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "Вы не можете поставить CD-маркер в это положение"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "некорректный XML узел одобрен для Location::set_state"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "У XML-узла позиции нет данных ID"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "У XML-узла позиции нет данных имени"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "У XML-узла позиции нет данных о начале"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "У XML-узла позиции нет данных о конце"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "У XML-узла позиции нет данных о флагах"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr "Позиции: попытка использовать неизвестную позицию как выбранную"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "Неверный режим XML одобрен для Locations::set_state"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "Сесссия"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr "Не удалось загрузить позицию из файла сессии, проигнорировано"
 

--- a/libs/ardour/po/sv.po
+++ b/libs/ardour/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ardour\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2006-10-03 01:09+GMT+1\n"
 "Last-Translator: Petter Sundlöf <petter.sundlof@findus.dhs.org>\n"
 "Language-Team: Swedish <sv@li.org>\n"
@@ -1301,47 +1301,43 @@ msgstr ""
 msgid "Could not locate HOME.  Preset not saved."
 msgstr ""
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr ""
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr ""
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr ""
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr ""
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr ""
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr ""
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr ""
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr ""
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr ""
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr ""
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr ""
 

--- a/libs/ardour/po/zh.po
+++ b/libs/ardour/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Ardour 6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 14:36-0600\n"
+"POT-Creation-Date: 2020-05-21 22:10+0200\n"
 "PO-Revision-Date: 2020-05-17 12:05+0800\n"
 "Last-Translator: \n"
 "Language-Team: 一善鱼 YQ-YSY@163.com\n"
@@ -1333,47 +1333,43 @@ msgstr "保存预设文件 %1 时出错。"
 msgid "Could not locate HOME.  Preset not saved."
 msgstr "无法定位 HOME。预设未保存。"
 
-#: location.cc:477
-msgid "You cannot put a CD marker at this position"
-msgstr "您不能安放一个 CD 标记在这个位置"
-
-#: location.cc:636
+#: location.cc:622
 msgid "incorrect XML node passed to Location::set_state"
 msgstr "不正确的 XML节点传递给 Location::set_state（位置 :: 设置状态）"
 
-#: location.cc:641
+#: location.cc:627
 msgid "XML node for Location has no ID information"
 msgstr "用于定位的 XML 节点没有 ID 信息"
 
-#: location.cc:646
+#: location.cc:632
 msgid "XML node for Location has no name information"
 msgstr "用于定位的 XML 节点没有名称信息"
 
-#: location.cc:657
+#: location.cc:643
 msgid "XML node for Location has no start information"
 msgstr "用于定位的 XML 节点没有起点信息"
 
-#: location.cc:662
+#: location.cc:648
 msgid "XML node for Location has no end information"
 msgstr "用于定位的 XML 节点没有终点信息"
 
-#: location.cc:671
+#: location.cc:657
 msgid "XML node for Location has no flags information"
 msgstr "用于定位的 XML 节点没有标志信息"
 
-#: location.cc:907
+#: location.cc:893
 msgid "Locations: attempt to use unknown location as selected location"
 msgstr "位置：尝试使用未知的位置作为已选择的位置"
 
-#: location.cc:1101
+#: location.cc:1087
 msgid "incorrect XML mode passed to Locations::set_state"
 msgstr "不正确的 XML模式传递给 Location::set_state（位置 :: 设置状态）"
 
-#: location.cc:1114 session.cc:1601 session_state.cc:1441
+#: location.cc:1100 session.cc:1601 session_state.cc:1441
 msgid "session"
 msgstr "会话"
 
-#: location.cc:1181
+#: location.cc:1167
 msgid "could not load location from session file - ignored"
 msgstr "无法从会话文件载入位置——已忽略"
 


### PR DESCRIPTION
This removes the policy that a CD marker cannot be placed at (or before) session start. The current policy is enforced inconsistently, as it is not encapsulated/established as an invariant. Imho the current policy doesn't solve any, but introduces problems.

According to my analysis, the current behavior is this:

* You cannot add a CD marker before or at session start in the markers ruler. That is only the case since the recent commit 82eba76c8f, before you could add them but they were lost when reopening the session.
* CD marker tickbox in the Locations window is only deactivated for markers at session start, but not before session start.
* When you move the session start before any CD marker (or to coincide with session start), the CD markers are kept. But if you then open the Locations window, the CD flag is being removed from them.
* The intended policy to restrict CD markers is only enforced by the GUI, but not by libardour.
* You can put a CD marker one CD frame after session start. I understand the intention of this whole policy as an attempt to enforce the Red Book standard (2 seconds pregap). The policy only prevents to place CD markers at or before session start. Also, in my understanding, the fulfilment of this aspect of the standard doesn't have to be taken into account in CUE sheets at all (see below).

According to [this document](https://github.com/libyal/libodraw/blob/master/documentation/CUE%20sheet%20format.asciidoc#61-msf), the MSF is relative to the last FILE command. MSF is defined without the 2 seconds MFS offset.

Also, when looking at examples of cue sheets [here](http://wiki.hydrogenaud.io/index.php?title=Cue_sheet), all of the **Track 1, Index 0 (or Index 1 without hidden track)** times start at 00:00:00.

The same goes for [the CUE sheet article](https://en.wikipedia.org/wiki/Cue_sheet_(computing)) on Wikipedia. The author(s) also mention, that *"...INDEX 00 is optional and denotes the pregap. The pregap of Track 1 is used for Hidden Track One Audio (HTOA)"*.

I also added some details on that matter in the [bug report](https://tracker.ardour.org/view.php?id=8029).

In my first version to remove this restriction from Ardour, I changed the policy from "not at session start" to "not before session start", thereby also resolving the inconsistencies mentioned above. E.g. removing the CD flag from a CD marker when moving the session start to a position at a later point in time than the marker. But I realized, that it doesn't even matter and all special cases could be entirely removed, because when exporting the session range with CD markers in it as a CUE, CD markers outside of that range are not used anyhow. Also, that doesn't require updating any .po files, as the corresponding messages can just be removed.

I extensively tested this and exported and burned a couple of CDs with it.
* [DDP tools](http://ddp.andreasruge.de) tools handles it correctly and satisfies the Red Book standard in any case
* **cdrdao** generates two seconds pregap before track 1 and adds any audio material (silence or not) between session start and the first CD marker to it
* **wodim**/**cdrecord** generates two seconds pregap before track 1 and fails when *Index 0* for Track 1 is given

Thus:
* **DDP tools** does the right thing with or without Ardour's current policy
* With **cdrdao**, I always end up with more than two seconds of pregap when burning from CUE sheets exported by Ardour with its current policy
* **wodim** doesn't allow me to burn CDs from CUE sheets exported by Ardour with its current policy

Merging this wouldn't affect anybody's established workflow, but imho it allows for more control without removing anything that enforced standard compliance. It also removes inconsistent special casing from Ardour.

If of interest, here's a transcript of my experimentation:

### r1_session.wav.cue (with two seconds silence between session start and first CD marker)

```
# cat r1_session.wav.cue
REM Cue file generated by Ardour
TITLE "session"
FILE "r1_session.wav" WAVE
  TRACK 01 AUDIO
    FLAGS DCP 
    TITLE "unnamed1"
    INDEX 00 00:00:00
    INDEX 01 00:02:00
  TRACK 02 AUDIO
    FLAGS DCP 
    TITLE "unnamed2"
    INDEX 00 00:18:00
    INDEX 01 00:20:00
...
```

All good with two seconds pregap:
```
# cue2ddp r1_session.wav.cue
=== CUE IMAGE SUMMARY ===
Cue file : r1_session.wav.cue
*** Audio data ***
File name: r1_session.wav
File type: Microsoft Wave
Starts at: 00:00:00.000
Ends at  : 00:01:40.845
Length   : 00:01:40.845
Padding : 00:00:00.007 (1344 bytes)
*** PQ Listing ***
UPC/EAN: 
Trk Idx  Start Time         Track Length       ISRC          PRE DCP 4CH SCMS
--- ---  -----------------  -----------------  ------------  --- --- --- ----
 01  00  00:00:00 (     0)
 01  01  00:02:00 (   150)  00:16:00 (  1200)                 N   Y   N   N
 02  00  00:18:00 (  1350)
 02  01  00:20:00 (  1500)  01:20:64 (  6064)                 N   Y   N   N
...
```

This leads to four seconds pregap:
```
cdrdao write --driver generic-mmc-raw r1_session.wav.cue
```

This fails:
```
wodim -audio -useinfo -text -dao --cuefile='r1_session.wav.cue'
```

### session.wav.cue (session start and first CD marker coincide)
```
# cat session.wav.cue
REM Cue file generated by Ardour
TITLE "session"
FILE "session.wav" WAVE
  TRACK 01 AUDIO
    FLAGS DCP 
    TITLE "unnamed1"
    INDEX 01 00:00:00
  TRACK 02 AUDIO
    FLAGS DCP 
    TITLE "unnamed2"
    INDEX 00 00:16:00
    INDEX 01 00:18:00
...
```

All good with two seconds pregap:
```
# cue2ddp session.wav.cue
=== CUE IMAGE SUMMARY ===
Cue file : session.wav.cue
*** Audio data ***
File name: session.wav
File type: Microsoft Wave
Starts at: 00:00:02.000
Ends at  : 00:01:40.845
Length   : 00:01:38.845
Padding : 00:00:00.007 (1344 bytes)
*** PQ Listing ***
UPC/EAN: 
Trk Idx  Start Time         Track Length       ISRC          PRE DCP 4CH SCMS
--- ---  -----------------  -----------------  ------------  --- --- --- ----
 01  00  00:00:00 (     0)
 01  01  00:02:00 (   150)  00:16:00 (  1200)                 N   Y   N   N
 02  00  00:18:00 (  1350)
 02  01  00:20:00 (  1500)  01:20:64 (  6064)                 N   Y   N   N
...
```

All good with two seconds pregap:
```
cdrdao write --driver generic-mmc-raw session.wav.cue
```

All good with two seconds pregap:
```
wodim -audio -useinfo -text -dao --cuefile='session.wav.cue'
```
