### PR TITLE
Fix build for clang - libs/pbd/pbs/compose.h

### DIFF
--- a/libs/pbd/pbd/compose.h
+++ b/libs/pbd/pbd/compose.h
@@ -36,6 +36,7 @@
 #include <string>
 #include <list>
 #include <map> // for multimap
+#include <ostream>
 
 #include "pbd/libpbd_visibility.h"
 


### PR DESCRIPTION
Without this change, build failes on clang with the following error:-

error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup