### PR TITLE
Fix compiling cycles.h on ppc64, don't reference unused external `cacheflush_time` variable

### DIFF
--- a/libs/ardour/ardour/cycles.h
+++ b/libs/ardour/ardour/cycles.h
@@ -74,6 +74,7 @@ static inline cycles_t get_cycles (void)
 
 #elif defined(__powerpc64__)
 
+typedef uint64_t cycles_t;
 static inline cycles_t get_cycles(void)
 {
 #warning You are compiling libardour on a platform for which ardour/cycles.h needs work

--- a/libs/ardour/ardour/cycles.h
+++ b/libs/ardour/ardour/cycles.h
@@ -43,8 +43,6 @@
  */
 typedef uint64_t cycles_t;
 
-extern cycles_t cacheflush_time;
-
 #if defined(__x86_64__)
 
 #define rdtscll(lo, hi) \
@@ -91,8 +89,6 @@ typedef uint32_t cycles_t;
  * For the "cycle" counter we use the timebase lower half.
  * Currently only used on SMP.
  */
-
-extern cycles_t cacheflush_time;
 
 static inline cycles_t get_cycles(void)
 {
@@ -235,8 +231,6 @@ static inline cycles_t get_cycles (void)
 #include <sys/time.h>
 
 typedef long cycles_t;
-
-extern cycles_t cacheflush_time;
 
 static inline cycles_t get_cycles(void)
 {


### PR DESCRIPTION
When attempting to build Ardour on ppc64le, I ran into the error linked below because `cycles_t` is undefined. I also noticed that nothing ever uses `cacheflush_time` and removed it.

* https://koji.fedoraproject.org/koji/taskinfo?taskID=45321920 
* https://kojipkgs.fedoraproject.org//work/tasks/1920/45321920/build.log