### PR TITLE
WebSockets: improve client API

### DIFF
--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { ArdourClient } from '/shared/ardour.js';
+import ArdourClient from '/shared/ardour.js';
 
 import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
         StripPanSlider, StripGainSlider, StripMeter } from './widget.js';

--- a/share/web_surfaces/builtin/mixer-demo/js/main.js
+++ b/share/web_surfaces/builtin/mixer-demo/js/main.js
@@ -27,29 +27,21 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
     
     const ardour = new ArdourClient();
 
-    function main () {
-        ardour.handlers = {
-            onConnected: (connected) => {
-                if (connected) {
-                    log('Client connected', 'info');
-                } else {
-                    log('Client disconnected', 'error');
-                }
-            },
-
-            onMessage: (message, inbound) => {
-                if (inbound) {
-                    log(`↙ ${message}`, 'message-in');
-                } else {
-                    log(`↗ ${message}`, 'message-out');
-                }
+    async function main () {
+        ardour.on('connected', (connected) => {
+            if (connected) {
+                log('Client connected', 'info');
+            } else {
+                log('Client disconnected', 'error');
             }
-        };
+        });
 
-        ardour.getSurfaceManifest().then((manifest) => {
-            const div = document.getElementById('manifest');
-            div.innerHTML = manifest.name.toUpperCase()
-                            + ' v' + manifest.version + ' — ' + manifest.description;
+        ardour.on('message', (msg, inbound) => {
+            if (inbound) {
+                log(`↙ ${msg}`, 'message-in');
+            } else {
+                log(`↗ ${msg}`, 'message-out');
+            }
         });
 
         ardour.mixer.on('ready', () => {
@@ -59,7 +51,11 @@ import { Switch, DiscreteSlider, ContinuousSlider, LogarithmicSlider,
             }
         });
 
-        ardour.connect();
+        await ardour.connect();
+
+        const manifest = await ardour.getSurfaceManifest();
+        document.getElementById('manifest').innerHTML = manifest.name.toUpperCase()
+                        + ' v' + manifest.version + ' — ' + manifest.description;
     }
 
     function createStrip (strip, parentDiv) {

--- a/share/web_surfaces/builtin/mixer-demo/manifest.xml
+++ b/share/web_surfaces/builtin/mixer-demo/manifest.xml
@@ -2,5 +2,5 @@
 <WebSurface>
   <Name value="Mixer Demo"/>
   <Description value="Mixer control capabilities demo aimed at developers"/>
-  <Version value="0.1.1"/>
+  <Version value="0.1.2"/>
 </WebSurface>

--- a/share/web_surfaces/builtin/transport/main.js
+++ b/share/web_surfaces/builtin/transport/main.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { ArdourClient } from '/shared/ardour.js';
+import ArdourClient from '/shared/ardour.js';
 
 (() => {
 

--- a/share/web_surfaces/builtin/transport/manifest.xml
+++ b/share/web_surfaces/builtin/transport/manifest.xml
@@ -2,5 +2,5 @@
 <WebSurface>
   <Name value="Transport"/>
   <Description value="Provides basic transport control"/>
-  <Version value="0.1.1"/>
+  <Version value="0.1.2"/>
 </WebSurface>

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { ArdourClient } from '/shared/ardour.js';
+import ArdourClient from '/shared/ardour.js';
 
 (() => {
 

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -45,7 +45,7 @@ export class ArdourClient {
 
 	set handlers (handlers) {
 		this._handlers = handlers || {};
-		this._channel.onError = this._handlers['onError'] || console.log;
+		this._channel.onError = this._handlers.onError || console.log;
 	}
 
 	// Access to the object-oriented API (enabled by default)
@@ -133,14 +133,14 @@ export class ArdourClient {
 	_setConnected (connected) {
 		this._connected = connected;
 		
-		if (this._handlers['onConnected']) {
-			this._handlers['onConnected'](this._connected);
+		if (this._handlers.onConnected) {
+			this._handlers.onConnected(this._connected);
 		}
 	}
 
 	_handleMessage (msg, inbound) {
-		if (this._handlers['onMessage']) {
-			this._handlers['onMessage'](msg, inbound);
+		if (this._handlers.onMessage) {
+			this._handlers.onMessage(msg, inbound);
 		}
 
 		if (inbound) {

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -16,12 +16,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { MessageChannel } from './base/channel.js';
 import { StateNode } from './base/protocol.js';
-import { Mixer } from './components/mixer.js';
-import { Transport } from './components/transport.js';
+import MessageChannel from './base/channel.js';
+import Mixer from './components/mixer.js';
+import Transport from './components/transport.js';
 
-export class ArdourClient {
+export default class ArdourClient {
 
 	constructor (handlers, options) {
 		this._options = options || {};

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -32,8 +32,8 @@ export default class ArdourClient extends Component {
 		super(new MessageChannel(getOption(options, 'host', location.host)));
 
 		if (getOption(options, 'components', true)) {
-			this._mixer = new Mixer(this.channel);
-			this._transport = new Transport(this.channel);
+			this._mixer = new Mixer(this);
+			this._transport = new Transport(this);
 			this._components = [this._mixer, this._transport];
 		} else {
 			this._components = [];

--- a/share/web_surfaces/shared/base/channel.js
+++ b/share/web_surfaces/shared/base/channel.js
@@ -18,7 +18,7 @@
 
 import { Message } from './protocol.js';
 
-export class MessageChannel {
+export default class MessageChannel {
 
 	constructor (host) {
 		// https://developer.mozilla.org/en-US/docs/Web/API/URL/host

--- a/share/web_surfaces/shared/base/component.js
+++ b/share/web_surfaces/shared/base/component.js
@@ -21,13 +21,13 @@ import { Observable } from './observable.js';
 
 export class Component extends Observable {
 
- 	constructor (parent) {
- 		super();
- 		this._parent = parent;
- 	}
+	constructor (channel) {
+		super(null);
+		this._channel = channel;
+	}
 
  	get channel () {
- 		return this._parent.channel;
+ 		return this._channel;
  	}
 
 	on (property, callback) {
@@ -58,20 +58,20 @@ export class Component extends Observable {
 
 }
 
-export class RootComponent extends Component {
-
-	constructor (channel) {
-		super(null);
-		this._channel = channel;
-	}
+export class ChildComponent extends Component {
+ 	
+ 	constructor (parent) {
+ 		super();
+ 		this._parent = parent;
+ 	}
 
  	get channel () {
- 		return this._channel;
+ 		return this._parent.channel;
  	}
 
 }
 
-export class AddressableComponent extends Component {
+export class AddressableComponent extends ChildComponent {
 
 	constructor (parent, addr) {
 		super(parent);

--- a/share/web_surfaces/shared/base/component.js
+++ b/share/web_surfaces/shared/base/component.js
@@ -34,7 +34,7 @@ export class Component extends Observable {
 		this.addObserver(event, callback);
 	}
 	
-	notify (property) {
+	notifyPropertyChanged (property) {
 		this.notifyObservers(property, this['_' + property]);
 	}
 
@@ -52,7 +52,7 @@ export class Component extends Observable {
 
 	updateLocal (property, value) {
 		this['_' + property] = value;
-		this.notify(property);
+		this.notifyPropertyChanged(property);
 	}
 
 	updateRemote (property, value, node, addr) {

--- a/share/web_surfaces/shared/base/component.js
+++ b/share/web_surfaces/shared/base/component.js
@@ -30,8 +30,12 @@ export class Component extends Observable {
  		return this._channel;
  	}
 
-	on (property, callback) {
-		this.addObserver(property, (self) => callback(self[property]));
+	on (event, callback) {
+		this.addObserver(event, callback);
+	}
+	
+	notify (property) {
+		this.notifyObservers(property, this['_' + property]);
 	}
 
  	send (node, addr, val) {
@@ -48,7 +52,7 @@ export class Component extends Observable {
 
 	updateLocal (property, value) {
 		this['_' + property] = value;
-		this.notifyObservers(property);
+		this.notify(property);
 	}
 
 	updateRemote (property, value, node, addr) {

--- a/share/web_surfaces/shared/base/component.js
+++ b/share/web_surfaces/shared/base/component.js
@@ -17,7 +17,7 @@
  */
 
 import { Message } from './protocol.js';
-import { Observable } from './observable.js';
+import Observable from './observable.js';
 
 export class Component extends Observable {
 

--- a/share/web_surfaces/shared/base/component.js
+++ b/share/web_surfaces/shared/base/component.js
@@ -22,7 +22,7 @@ import Observable from './observable.js';
 export class Component extends Observable {
 
 	constructor (channel) {
-		super(null);
+		super();
 		this._channel = channel;
 	}
 
@@ -65,12 +65,8 @@ export class Component extends Observable {
 export class ChildComponent extends Component {
  	
  	constructor (parent) {
- 		super();
+ 		super(parent.channel);
  		this._parent = parent;
- 	}
-
- 	get channel () {
- 		return this._parent.channel;
  	}
 
 }

--- a/share/web_surfaces/shared/base/observable.js
+++ b/share/web_surfaces/shared/base/observable.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-export class Observable {
+export default class Observable {
 
 	constructor () {
 		this._observers = {};

--- a/share/web_surfaces/shared/base/observable.js
+++ b/share/web_surfaces/shared/base/observable.js
@@ -22,41 +22,40 @@ export default class Observable {
 		this._observers = {};
 	}
 
-	addObserver (property, observer) {
-		// property=undefined means the caller is interested in observing all properties
-		if (!(property in this._observers)) {
-			this._observers[property] = [];
+	addObserver (event, observer) {
+		// event=undefined means the caller is interested in observing all events
+		if (!(event in this._observers)) {
+			this._observers[event] = [];
 		}
 
-		this._observers[property].push(observer);
+		this._observers[event].push(observer);
 	}
 
-	removeObserver (property, observer) {
-		// property=undefined means the caller is not interested in any property anymore
-		if (typeof(property) == 'undefined') {
-			for (const property in this._observers) {
-				this.removeObserver(property, observer);
+	removeObserver (event, observer) {
+		// event=undefined means the caller is not interested in any event anymore
+		if (typeof(event) == 'undefined') {
+			for (const event in this._observers) {
+				this.removeObserver(event, observer);
 			}
 		} else {
-			const index = this._observers[property].indexOf(observer);
-
+			const index = this._observers[event].indexOf(observer);
 			if (index > -1) {
-				this._observers[property].splice(index, 1);
+				this._observers[event].splice(index, 1);
 			}
 		}
 	}
 
-	notifyObservers (property) {
-		// always notify observers that observe all properties
+	notifyObservers (event, ...args) {
+		// always notify observers that observe all events
 		if (undefined in this._observers) {
 			for (const observer of this._observers[undefined]) {
-				observer(this, property);
+				observer(event, ...args);
 			}
 		}
 
-		if (property in this._observers) {
-			for (const observer of this._observers[property]) {
-				observer(this);
+		if (event in this._observers) {
+			for (const observer of this._observers[event]) {
+				observer(...args);
 			}
 		}
 	}

--- a/share/web_surfaces/shared/components/mixer.js
+++ b/share/web_surfaces/shared/components/mixer.js
@@ -18,9 +18,9 @@
 
 import { Component } from '../base/component.js';
 import { StateNode } from '../base/protocol.js';
-import { Strip } from './strip.js';
+import Strip from './strip.js';
 
-export class Mixer extends Component {
+export default class Mixer extends Component {
 
 	constructor (channel) {
 		super(channel);

--- a/share/web_surfaces/shared/components/mixer.js
+++ b/share/web_surfaces/shared/components/mixer.js
@@ -16,14 +16,14 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { Component } from '../base/component.js';
+import { ChildComponent } from '../base/component.js';
 import { StateNode } from '../base/protocol.js';
 import Strip from './strip.js';
 
-export default class Mixer extends Component {
+export default class Mixer extends ChildComponent {
 
-	constructor (channel) {
-		super(channel);
+	constructor (parent) {
+		super(parent);
 		this._strips = {};
 		this._ready = false;
 	}

--- a/share/web_surfaces/shared/components/mixer.js
+++ b/share/web_surfaces/shared/components/mixer.js
@@ -45,7 +45,7 @@ export default class Mixer extends Component {
  		if (node.startsWith('strip')) {
 	 		if (node == StateNode.STRIP_DESCRIPTION) {
 	 			this._strips[addr] = new Strip(this, addr, val);
-	 			this.notifyObservers('strips');
+	 			this.notify('strips');
 	 			return true;
 	 		} else {
 	 			const stripAddr = [addr[0]];

--- a/share/web_surfaces/shared/components/mixer.js
+++ b/share/web_surfaces/shared/components/mixer.js
@@ -45,7 +45,7 @@ export default class Mixer extends Component {
  		if (node.startsWith('strip')) {
 	 		if (node == StateNode.STRIP_DESCRIPTION) {
 	 			this._strips[addr] = new Strip(this, addr, val);
-	 			this.notify('strips');
+	 			this.notifyPropertyChanged('strips');
 	 			return true;
 	 		} else {
 	 			const stripAddr = [addr[0]];

--- a/share/web_surfaces/shared/components/mixer.js
+++ b/share/web_surfaces/shared/components/mixer.js
@@ -16,11 +16,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { RootComponent } from '../base/component.js';
+import { Component } from '../base/component.js';
 import { StateNode } from '../base/protocol.js';
 import { Strip } from './strip.js';
 
-export class Mixer extends RootComponent {
+export class Mixer extends Component {
 
 	constructor (channel) {
 		super(channel);

--- a/share/web_surfaces/shared/components/parameter.js
+++ b/share/web_surfaces/shared/components/parameter.js
@@ -39,7 +39,7 @@ class ValueType {
 
 }
 
-export class Parameter extends AddressableComponent {
+export default class Parameter extends AddressableComponent {
 
 	constructor (parent, addr, desc) {
 		super(parent, addr);

--- a/share/web_surfaces/shared/components/plugin.js
+++ b/share/web_surfaces/shared/components/plugin.js
@@ -53,7 +53,7 @@ export default class Plugin extends AddressableComponent {
 		if (node.startsWith('strip_plugin_param')) {
 	 		if (node == StateNode.STRIP_PLUGIN_PARAM_DESCRIPTION) {
 	 			this._parameters[addr] = new Parameter(this, addr, val);
-	 			this.notifyObservers('parameters');
+	 			this.notify('parameters');
 	 			return true;
 	 		} else {
 	 			if (addr in this._parameters) {

--- a/share/web_surfaces/shared/components/plugin.js
+++ b/share/web_surfaces/shared/components/plugin.js
@@ -17,10 +17,10 @@
  */
 
 import { AddressableComponent } from '../base/component.js';
-import { Parameter } from './parameter.js';
 import { StateNode } from '../base/protocol.js';
+import Parameter from './parameter.js';
 
-export class Plugin extends AddressableComponent {
+export default class Plugin extends AddressableComponent {
 
 	constructor (parent, addr, desc) {
 		super(parent, addr);

--- a/share/web_surfaces/shared/components/plugin.js
+++ b/share/web_surfaces/shared/components/plugin.js
@@ -53,7 +53,7 @@ export default class Plugin extends AddressableComponent {
 		if (node.startsWith('strip_plugin_param')) {
 	 		if (node == StateNode.STRIP_PLUGIN_PARAM_DESCRIPTION) {
 	 			this._parameters[addr] = new Parameter(this, addr, val);
-	 			this.notify('parameters');
+	 			this.notifyPropertyChanged('parameters');
 	 			return true;
 	 		} else {
 	 			if (addr in this._parameters) {

--- a/share/web_surfaces/shared/components/strip.js
+++ b/share/web_surfaces/shared/components/strip.js
@@ -84,7 +84,7 @@ export default class Strip extends AddressableComponent {
  		if (node.startsWith('strip_plugin')) {
 	 		if (node == StateNode.STRIP_PLUGIN_DESCRIPTION) {
 	 			this._plugins[addr] = new Plugin(this, addr, val);
-	 			this.notify('plugins');
+	 			this.notifyPropertyChanged('plugins');
 	 			return true;
 	 		} else {
 	 			const pluginAddr = [addr[0], addr[1]];

--- a/share/web_surfaces/shared/components/strip.js
+++ b/share/web_surfaces/shared/components/strip.js
@@ -84,7 +84,7 @@ export default class Strip extends AddressableComponent {
  		if (node.startsWith('strip_plugin')) {
 	 		if (node == StateNode.STRIP_PLUGIN_DESCRIPTION) {
 	 			this._plugins[addr] = new Plugin(this, addr, val);
-	 			this.notifyObservers('plugins');
+	 			this.notify('plugins');
 	 			return true;
 	 		} else {
 	 			const pluginAddr = [addr[0], addr[1]];

--- a/share/web_surfaces/shared/components/strip.js
+++ b/share/web_surfaces/shared/components/strip.js
@@ -17,8 +17,8 @@
  */
 
 import { AddressableComponent } from '../base/component.js';
-import { Plugin } from './plugin.js';
 import { StateNode } from '../base/protocol.js';
+import Plugin from './plugin.js';
 
 const NodeToProperty = Object.freeze({
 	[StateNode.STRIP_METER] : 'meter',
@@ -27,7 +27,7 @@ const NodeToProperty = Object.freeze({
 	[StateNode.STRIP_MUTE]  : 'mute'
 });
 
-export class Strip extends AddressableComponent {
+export default class Strip extends AddressableComponent {
 
 	constructor (parent, addr, desc) {
 		super(parent, addr);

--- a/share/web_surfaces/shared/components/transport.js
+++ b/share/web_surfaces/shared/components/transport.js
@@ -26,7 +26,7 @@ const NodeToProperty = Object.freeze({
 	[StateNode.TRANSPORT_RECORD] : 'record'
 });
 
-export class Transport extends Component {
+export default class Transport extends Component {
 
 	constructor (channel) {
 		super(channel);

--- a/share/web_surfaces/shared/components/transport.js
+++ b/share/web_surfaces/shared/components/transport.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { Component } from '../base/component.js';
+import { ChildComponent } from '../base/component.js';
 import { StateNode } from '../base/protocol.js';
 
 const NodeToProperty = Object.freeze({
@@ -26,10 +26,10 @@ const NodeToProperty = Object.freeze({
 	[StateNode.TRANSPORT_RECORD] : 'record'
 });
 
-export default class Transport extends Component {
+export default class Transport extends ChildComponent {
 
-	constructor (channel) {
-		super(channel);
+	constructor (parent) {
+		super(parent);
 		this._time = 0;
 		this._tempo = 0;
 		this._roll = false;

--- a/share/web_surfaces/shared/components/transport.js
+++ b/share/web_surfaces/shared/components/transport.js
@@ -16,7 +16,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-import { RootComponent } from '../base/component.js';
+import { Component } from '../base/component.js';
 import { StateNode } from '../base/protocol.js';
 
 const NodeToProperty = Object.freeze({
@@ -26,7 +26,7 @@ const NodeToProperty = Object.freeze({
 	[StateNode.TRANSPORT_RECORD] : 'record'
 });
 
-export class Transport extends RootComponent {
+export class Transport extends Component {
 
 	constructor (channel) {
 		super(channel);


### PR DESCRIPTION
This patch mostly does two things:

- Makes the JS client object observable just like the rest of the observable components (track, plugins...) so one can listen to events like `connected`, `message` using `client.on(...)` instead of passing a bunch of callbacks to the constructor.

- Improves some ES6 related syntax
