### PR TITLE
Adds a midi map for the M-Audio Oxygen 25 3rd Gen controller

### DIFF
--- a/share/midi_maps/m-audio_oxygen25_3rdGen.map
+++ b/share/midi_maps/m-audio_oxygen25_3rdGen.map
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="M-Audio Oxygen25 (3rd Gen)">
+  <Binding channel="16" ctl="113" function="loop-toggle"/>
+  <Binding channel="16" ctl="114" function="transport-start"/>
+  <Binding channel="16" ctl="115" function="transport-end"/>
+  <Binding channel="16" ctl="116" function="transport-stop"/>
+  <Binding channel="16" ctl="117" function="transport-roll"/>
+  <Binding channel="16" ctl="118" function="rec-enable"/>
+</ArdourMIDIBindings>
+


### PR DESCRIPTION
The existing midi map for the M-Audio Oxygen controller did not work for me.
I note that my controller says 3rd Gen on the back
I used the documentation: https://manual.ardour.org/using-control-surfaces/generic-midi/midi-binding-maps/ to create a new map.
I think adding it to the rest of the files might be better than overwriting the old one, but happy for others to decide.
Maps the transport control buttons on the device only. They are labelled C10 to C15 on the controller, and map to 113 to 118 in the file.