### PR TITLE
Emphasise beat lines; fix issue 8156

### DIFF
--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -110,7 +110,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:foregroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:midground"/>
+    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="neutral:background2"/>
     <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -111,7 +111,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:foregroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:midground"/>
+    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="widget:bg"/>
     <ColorAlias name="gtk_audio_track" alias="widget:gray"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -111,7 +111,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:backgroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:midground"/>
+    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="widget:blue darker"/>
     <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -111,7 +111,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:foregroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:midground"/>
+    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="widget:blue darker"/>
     <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -111,7 +111,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:foregroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:midground"/>
+    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="widget:blue darker"/>
     <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -110,7 +110,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:foregroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:midground"/>
+    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="widget:blue darker"/>
     <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>


### PR DESCRIPTION
"grid line micro" and "grid line minor" colours were the same so it was
difficult to tell where in a bar you were when zoomed in.