### PR TITLE
Added midimap for Arturia MiniLab mkII

### DIFF
--- a/share/midi_maps/Arturia_MiniLab_mkII.map
+++ b/share/midi_maps/Arturia_MiniLab_mkII.map
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="Arturia MiniLab mkII">
+<!-- Works with device's factory settings, 1 (Analog Lab). -->
+
+<!-- Leftmost knobs are special, 7 left. -->
+  <DeviceInfo bank-size="7"/>
+
+<!-- Knobs -->
+  <!-- Pan controls. Upper controller knobs mapped to pan direction. -->
+  <Binding channel="1" ctl="74" uri="/route/pandirection B1"/>
+  <Binding channel="1" ctl="71" uri="/route/pandirection B2"/>
+  <Binding channel="1" ctl="76" uri="/route/pandirection B3"/>
+  <Binding channel="1" ctl="77" uri="/route/pandirection B4"/>
+  <Binding channel="1" ctl="93" uri="/route/pandirection B5"/>
+  <Binding channel="1" ctl="73" uri="/route/pandirection B6"/>
+  <Binding channel="1" ctl="75" uri="/route/pandirection B7"/>
+
+  <!-- Gain controls. Lower controller knobs mapped to faders. -->
+  <Binding channel="1" ctl="18" uri="/route/gain B1"/>
+  <Binding channel="1" ctl="19" uri="/route/gain B2"/>
+  <Binding channel="1" ctl="16" uri="/route/gain B3"/>
+  <Binding channel="1" ctl="17" uri="/route/gain B4"/>
+  <Binding channel="1" ctl="91" uri="/route/gain B5"/>
+  <Binding channel="1" ctl="79" uri="/route/gain B6"/>
+  <Binding channel="1" ctl="72" uri="/route/gain B7"/>
+
+<!-- Pads -->
+  <!-- Pads 2-8 are mapped to mute toggles.  -->
+
+  <Binding channel="10" note="37" uri="/route/mute B1"/>
+  <Binding channel="10" note="38" uri="/route/mute B2"/>
+  <Binding channel="10" note="39" uri="/route/mute B3"/>
+  <Binding channel="10" note="40" uri="/route/mute B4"/>
+  <Binding channel="10" note="41" uri="/route/mute B5"/>
+  <Binding channel="10" note="42" uri="/route/mute B6"/>
+  <Binding channel="10" note="43" uri="/route/mute B7"/>
+
+  <!-- Pads 10-16 are mapped to solo toggles.  -->
+
+  <Binding channel="1" ctl="23" uri="/route/solo B1"/>
+  <Binding channel="1" ctl="24" uri="/route/solo B2"/>
+  <Binding channel="1" ctl="25" uri="/route/solo B3"/>
+  <Binding channel="1" ctl="26" uri="/route/solo B4"/>
+  <Binding channel="1" ctl="27" uri="/route/solo B5"/>
+  <Binding channel="1" ctl="28" uri="/route/solo B6"/>
+  <Binding channel="1" ctl="29" uri="/route/solo B7"/>
+
+<!-- Button Oct - and Oct + are mapped to bank changes. -->
+
+  <Binding sysex="f0 00 20 6b 7f 42 02 00 00 11 7f f7" function="next-bank"/>
+  <Binding sysex="f0 00 20 6b 7f 42 02 00 00 10 7f f7" function="prev-bank"/>
+
+</ArdourMIDIBindings>


### PR DESCRIPTION
Use the factory settings 1 (Analog Lab)

Allow controlling a bank of 7

More details:

1. The MiniLab controls can be mapped as one want. Except memory 1 that is used for their Analog Lab software. I chose to map based on this configuration because this is the most plug and play. [Shift] + Pad 1 and it's in the right config. It maps the 25 keys keyboard to channel 1 and the pads to channel 10.
2. The MiniLab mkII has two row of 8 rotary knobs. The 7 right-most in each row are mapped as CC. The left-most are encoded differently.
3. There are also 8 pads.

So my choice for the mapping is as follow:

* Bank of 7.
* Top row for pandirection
* Bottom row for the gain faders
* Pads for mute.
* Pads can have a different number with a shifting button. In that case, they are mapped to "solo" as I felt mute was more important.
* I coded the Oct- and Oct+ to do the bank changes, but the problem is that this also shift octaves for the keyboard so it might be an unwanted side effect.

I have not mapped the left most controls alone. Maybe I could map to the master but, but it didn't seem to work (likely my mistake)

Let me know if you have comments or concerns about these mapping.