### PR TITLE
show name when audio track is inactive

### DIFF
--- a/gtk2_ardour/audio_time_axis.cc
+++ b/gtk2_ardour/audio_time_axis.cc
@@ -296,10 +296,17 @@ AudioTimeAxisView::route_active_changed ()
 		controls_table.hide();
 		inactive_table.show();
 		RouteTimeAxisView::hide_all_automation();
+		name_label.show();
 	} else {
 		inactive_table.hide();
 		controls_table.show();
 	}
+}
+
+bool
+AudioTimeAxisView::can_edit_name () const
+{
+	return _route->active();
 }
 
 void

--- a/gtk2_ardour/audio_time_axis.h
+++ b/gtk2_ardour/audio_time_axis.h
@@ -87,6 +87,9 @@ public:
 	void show_existing_automation (bool apply_to_selection = false);
 	void hide_all_automation (bool apply_to_selection = false);
 
+ protected:
+	bool can_edit_name () const override;
+
 private:
 	friend class AudioStreamView;
 	friend class AudioRegionView;


### PR DESCRIPTION
For now it fixes for audio tracks only. I hope I am going in the right direction. Ideally would to be able to re-attache the label from control table to inactive table somehow.
Fixing issue : https://tracker.ardour.org/view.php?id=8298