### PR TITLE
double click to expand / contract the track

### DIFF
--- a/gtk2_ardour/time_axis_view.cc
+++ b/gtk2_ardour/time_axis_view.cc
@@ -426,6 +426,14 @@ TimeAxisView::controls_ebox_button_press (GdkEventButton* event)
 
 	}
 
+	if (event->button == 1 && event->type == GDK_2BUTTON_PRESS) {
+		if (_effective_height < preset_height (HeightLargest)) {
+			set_height_enum (HeightLargest);
+		} else {
+			set_height_enum (HeightNormal);
+		}
+	}
+
 	_ebox_release_can_act = true;
 
 	if (maybe_set_cursor (event->y) > 0) {


### PR DESCRIPTION
Issue: https://tracker.ardour.org/view.php?id=8297

Double click to expand / contract the track. When is minimized I set it to normal height. Ideally to be able to set it to small height. But small height has little area that is not related to name editing.

Ideally I would like double click to do this:

Return the track to smallest height, or make it maximum (the same as F shortcut is doing for expansion).

Proposal: maybe to add more space to the track header or left side, so there will be easy to double click when the track is small

