### PR TITLE
double click to maximize region

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -903,6 +903,14 @@ Editor::~Editor()
 	for (std::map<ARDOUR::FadeShape, Gtk::Image*>::const_iterator i = _xfade_out_images.begin(); i != _xfade_out_images.end (); ++i) {
 		delete i->second;
 	}
+
+	for (std::list<VisualState*>::iterator it = undo_visual_stack.begin (); it != undo_visual_stack.end (); ++it) {
+		delete *it;
+	}
+
+	for (std::list<VisualState*>::iterator it = redo_visual_stack.begin (); it != redo_visual_stack.end (); ++it) {
+		delete *it;
+	}
 }
 
 XMLNode*
@@ -4475,7 +4483,8 @@ Editor::VisualState::VisualState (bool with_tracks)
 
 Editor::VisualState::~VisualState ()
 {
-	delete gui_state;
+	if (gui_state)
+		delete gui_state;
 }
 
 Editor::VisualState*
@@ -4509,6 +4518,7 @@ Editor::undo_visual_state ()
 
 	if (vs) {
 		use_visual_state (*vs);
+		delete vs;
 	}
 }
 
@@ -4527,6 +4537,7 @@ Editor::redo_visual_state ()
 
 	if (vs) {
 		use_visual_state (*vs);
+		delete vs;
 	}
 }
 

--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -252,6 +252,8 @@ Editor::Editor ()
 	, _playlist_selector (0)
 	, _time_info_box (0)
 	, no_save_visual (false)
+	, _minimized_visual_state (0)
+	, _region_is_maximized (false)
 	, _leftmost_sample (0)
 	, samples_per_pixel (2048)
 	, zoom_focus (ZoomFocusPlayhead)
@@ -887,6 +889,8 @@ Editor::~Editor()
 	delete selection;
 	delete cut_buffer;
 	delete _cursors;
+	if (_minimized_visual_state)
+		delete _minimized_visual_state;
 
 	LuaInstance::destroy_instance ();
 

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -619,6 +619,8 @@ private:
 	void swap_visual_state ();
 
 	std::vector<VisualState*> visual_states;
+	VisualState *_minimized_visual_state;
+	bool _region_is_maximized;
 	void start_visual_state_op (uint32_t n);
 	void cancel_visual_state_op (uint32_t n);
 

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -89,6 +89,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 			scroll_left_step ();
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomVerticalModifier)) {
+			_region_is_maximized = false;
 			if (!current_stepping_trackview) {
 				step_timeout = Glib::signal_timeout().connect (sigc::mem_fun(*this, &Editor::track_height_step_timeout), 500);
 				std::pair<TimeAxisView*, int> const p = trackview_by_y_position (event_coords.y, false);
@@ -114,6 +115,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 			scroll_right_step ();
 			return true;
 		} else if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomVerticalModifier)) {
+			_region_is_maximized = false;
 			if (!current_stepping_trackview) {
 				step_timeout = Glib::signal_timeout().connect (sigc::mem_fun(*this, &Editor::track_height_step_timeout), 500);
 				std::pair<TimeAxisView*, int> const p = trackview_by_y_position (event_coords.y, false);
@@ -126,6 +128,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 			current_stepping_trackview->step_height (true);
 			return true;
 		} else {
+			_region_is_maximized = false;
 			scroll_down_one_track ();
 			return true;
 		}

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -1379,8 +1379,22 @@ bool
 Editor::button_press_handler (ArdourCanvas::Item* item, GdkEvent* event, ItemType item_type)
 {
 	if (event->type == GDK_2BUTTON_PRESS) {
-		_drags->mark_double_click ();
-		gdk_pointer_ungrab (GDK_CURRENT_TIME);
+		if (Keyboard::modifier_state_equals(event->button.state, Keyboard::PrimaryModifier)) {
+			if (!_region_is_maximized) {
+				if (_minimized_visual_state)
+					delete _minimized_visual_state;
+				_minimized_visual_state = current_visual_state ();
+				temporal_zoom_selection(Both);
+				_region_is_maximized = true;
+			} else {
+				if (_minimized_visual_state)
+					use_visual_state(*_minimized_visual_state);
+				_region_is_maximized = false;
+			}
+		} else {
+			_drags->mark_double_click ();
+			gdk_pointer_ungrab (GDK_CURRENT_TIME);
+		}
 		return true;
 	}
 

--- a/libs/ardour/lv2_plugin.cc
+++ b/libs/ardour/lv2_plugin.cc
@@ -954,11 +954,12 @@ LV2Plugin::set_block_size (pframes_t nframes)
 	if (_impl->opts_iface) {
 		LV2_URID atom_Int = _uri_map.uri_to_id(LV2_ATOM__Int);
 		_impl->block_length = nframes;
-		LV2_Options_Option block_size_option = {
-			LV2_OPTIONS_INSTANCE, 0, _uri_map.uri_to_id ("http://lv2plug.in/ns/ext/buf-size#nominalBlockLength"),
-			sizeof(int32_t), atom_Int, (void*)&_impl->block_length
+		LV2_Options_Option block_size_option[] = {
+			{ LV2_OPTIONS_INSTANCE, 0, _uri_map.uri_to_id ("http://lv2plug.in/ns/ext/buf-size#nominalBlockLength"),
+			  sizeof(int32_t), atom_Int, (void*)&_impl->block_length},
+			{ LV2_OPTIONS_INSTANCE, 0, 0, 0, 0, NULL }
 		};
-		_impl->opts_iface->set (_impl->instance->lv2_handle, &block_size_option);
+		_impl->opts_iface->set (_impl->instance->lv2_handle, block_size_option);
 	}
 
 	return 0;

--- a/libs/pbd/pbd/mpmc_queue.h
+++ b/libs/pbd/pbd/mpmc_queue.h
@@ -82,7 +82,7 @@ public:
 	push_back (T const& data)
 	{
 		cell_t* cell;
-		guint   pos = g_atomic_int_get (&_enqueue_pos);
+		gint    pos = g_atomic_int_get (&_enqueue_pos);
 		for (;;) {
 			cell         = &_buffer[pos & _buffer_mask];
 			guint    seq = g_atomic_int_get (&cell->_sequence);
@@ -108,7 +108,7 @@ public:
 	pop_front (T& data)
 	{
 		cell_t* cell;
-		guint   pos = g_atomic_int_get (&_dequeue_pos);
+		gint    pos = g_atomic_int_get (&_dequeue_pos);
 		for (;;) {
 			cell         = &_buffer[pos & _buffer_mask];
 			guint    seq = g_atomic_int_get (&cell->_sequence);
@@ -138,8 +138,8 @@ private:
 	cell_t* _buffer;
 	size_t  _buffer_mask;
 
-	volatile guint _enqueue_pos;
-	volatile guint _dequeue_pos;
+	volatile gint _enqueue_pos;
+	volatile gint _dequeue_pos;
 };
 
 } /* end namespace */


### PR DESCRIPTION
- Ctrl+double click - stores the viewing state and maximizes the region. It is like viewing state is entering into the maximized region mode.
- Ctrl+double click - will restore the viewing state. This is different from Shift + z because in maximized mode if there was additional horizontal zooming, Shift+z will add new states in the stack.
- Stored viewing state will be lost when there is a vertical scroll, i.e. leaving the maximized region

Proposal: Maybe there would be better to disable vertical scrolling when the we are in this special mode of viewing, but this will change the old user exeprinece. 