### PR TITLE
Next/Previous preset buttons

### DIFF
--- a/gtk2_ardour/lv2_plugin_ui.cc
+++ b/gtk2_ardour/lv2_plugin_ui.cc
@@ -319,6 +319,8 @@ LV2PluginUI::LV2PluginUI(boost::shared_ptr<PluginInsert> pi,
 	_ardour_buttons_box.pack_end (delete_button, false, false);
 	_ardour_buttons_box.pack_end (save_button, false, false);
 	_ardour_buttons_box.pack_end (add_button, false, false);
+	_ardour_buttons_box.pack_end (next_button, false, false);
+	_ardour_buttons_box.pack_end (prev_button, false, false);
 	_ardour_buttons_box.pack_end (_preset_combo, false, false);
 	_ardour_buttons_box.pack_end (_preset_modified, false, false);
 	_ardour_buttons_box.pack_end (pin_management_button, false, false);

--- a/gtk2_ardour/plugin_ui.h
+++ b/gtk2_ardour/plugin_ui.h
@@ -126,6 +126,10 @@ protected:
 	ArdourWidgets::ArdourDropdown _preset_combo;
 	/** a label which has a * in if the current settings are different from the preset being shown */
 	Gtk::Label _preset_modified;
+	/** a button to load previous preset */
+	ArdourWidgets::ArdourButton prev_button;
+	/** a button to load next preset */
+	ArdourWidgets::ArdourButton next_button;
 	/** a button to add a preset */
 	ArdourWidgets::ArdourButton add_button;
 	/** a button to save the current settings as a new user preset */
@@ -175,6 +179,8 @@ protected:
 	int _no_load_preset;
 
 	virtual void preset_selected (ARDOUR::Plugin::PresetRecord preset);
+	void next_preset ();
+	void prev_preset ();
 	void add_plugin_setting ();
 	void save_plugin_setting ();
 	void delete_plugin_setting ();

--- a/gtk2_ardour/vst_plugin_ui.cc
+++ b/gtk2_ardour/vst_plugin_ui.cc
@@ -51,6 +51,8 @@ VSTPluginUI::VSTPluginUI (boost::shared_ptr<ARDOUR::PluginInsert> insert, boost:
 	box->pack_end (delete_button, false, false);
 	box->pack_end (save_button, false, false);
 	box->pack_end (add_button, false, false);
+	box->pack_end (next_button, false, false);
+	box->pack_end (prev_button, false, false);
 	box->pack_end (_preset_combo, false, false);
 	box->pack_end (_preset_modified, false, false);
 	box->pack_end (pin_management_button, false, false);


### PR DESCRIPTION
Hi, 
Many plugins do not have a convenient UI for quickly changing presets (some don't have UI like noize maker). In case of a long list, turning presets in a combo takes a long time. This PR adds the next/previous preset buttons to plugin window. 

Often when I'm looking for inspiration, I set up loop (L) and change presets in plugin window. Thanks to this buttons, this way of working is very convenient and fast. I used `ArdourIcon::NudgeRight` and `ArdourIcon::NudgeLeft` for icons maybe should be changed.

This is my first contribution for Ardour, so maybe should be done in other way.

![noizemaker_next_prev_plugin](https://user-images.githubusercontent.com/63190361/88849042-9411c880-d1e9-11ea-98e0-ffb634078cb8.png)
