### PR TITLE
maximized region mode

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -252,6 +252,7 @@ Editor::Editor ()
 	, _playlist_selector (0)
 	, _time_info_box (0)
 	, no_save_visual (false)
+	, _minimized_visual_state (0)
 	, _leftmost_sample (0)
 	, samples_per_pixel (2048)
 	, zoom_focus (ZoomFocusPlayhead)
@@ -4535,6 +4536,32 @@ Editor::swap_visual_state ()
 	} else {
 		undo_visual_state ();
 	}
+}
+
+bool
+Editor::is_maximized_region_mode() const
+{
+	return _minimized_visual_state != 0;
+}
+
+void
+Editor::enter_maximized_region_mode(bool maximize)
+{
+	if (maximize) {
+		delete _minimized_visual_state;
+		_minimized_visual_state = current_visual_state ();
+		temporal_zoom_selection(Both);
+	} else if (_minimized_visual_state) {
+		use_visual_state(*_minimized_visual_state);
+		clear_maximized_region_mode();
+	}
+}
+
+void
+Editor::clear_maximized_region_mode()
+{
+	delete _minimized_visual_state;
+	_minimized_visual_state = 0;
 }
 
 void

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -622,6 +622,25 @@ private:
 	void swap_visual_state ();
 
 	std::vector<VisualState*> visual_states;
+
+	// Visual state that was just before entering in the maximized region mode.
+	VisualState *_minimized_visual_state;
+
+	/**
+         * Returns true if the current visual state is in maximized region mode.
+         *
+	 * If the current visual state contains a maximized region (the same as key f does),
+         * and in this visual state editor entered by "Ctrl + double click" on the region,
+         * let's call this special viewing state "maximized region mode".
+         */
+	bool is_maximized_region_mode() const;
+
+	// Set the viewing state to be in the state of maximized region mode.
+	void enter_maximized_region_mode(bool maximize = true);
+
+	// Clear the region maximized mode (without changing the visual state).
+	void clear_maximized_region_mode();
+
 	void start_visual_state_op (uint32_t n);
 	void cancel_visual_state_op (uint32_t n);
 

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -82,6 +82,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 
 	switch (direction) {
 	case GDK_SCROLL_UP:
+		clear_maximized_region_mode();
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
 			temporal_zoom_step_mouse_focus (false);
 			return true;
@@ -107,6 +108,7 @@ Editor::track_canvas_scroll (GdkEventScroll* ev)
 		break;
 
 	case GDK_SCROLL_DOWN:
+		clear_maximized_region_mode();
 		if (Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollZoomHorizontalModifier)) {
 			temporal_zoom_step_mouse_focus (true);
 			return true;

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -1379,8 +1379,12 @@ bool
 Editor::button_press_handler (ArdourCanvas::Item* item, GdkEvent* event, ItemType item_type)
 {
 	if (event->type == GDK_2BUTTON_PRESS) {
-		_drags->mark_double_click ();
-		gdk_pointer_ungrab (GDK_CURRENT_TIME);
+		if (Keyboard::modifier_state_equals(event->button.state, Keyboard::PrimaryModifier)) {
+			enter_maximized_region_mode(!is_maximized_region_mode());
+		} else {
+			_drags->mark_double_click ();
+			gdk_pointer_ungrab (GDK_CURRENT_TIME);
+		}
 		return true;
 	}
 


### PR DESCRIPTION
When the user makes "Ctrl + double click" on the region
the region view will be maximized and the visual state just before this will be kept.
This will make like entering into a maximized region mode.
The next "Ctrl + double click" will return visual state to the kept one,
i.e. leaving the maximized region mode.
When the visual state is in maximized mode and there vertical scroll is done
than the mode will be just cleared and the visual state will not be changed.