### PR TITLE
Add option to set note range in MIDI editor to one note.

### DIFF
--- a/gtk2_ardour/midi_streamview.cc
+++ b/gtk2_ardour/midi_streamview.cc
@@ -376,12 +376,19 @@ MidiStreamView::draw_note_lines()
 void
 MidiStreamView::set_note_range(VisibleNoteRange r)
 {
-	if (r == FullRange) {
+	switch (r) {
+	case FullRange:
 		_lowest_note = 0;
 		_highest_note = 127;
-	} else {
+		break;
+	case OneNoteRange:
+		_lowest_note = _data_note_min;
+		_highest_note = _data_note_min;
+		break;
+	default:
 		_lowest_note = _data_note_min;
 		_highest_note = _data_note_max;
+		break;
 	}
 
 	apply_note_range(_lowest_note, _highest_note, true);

--- a/gtk2_ardour/midi_streamview.cc
+++ b/gtk2_ardour/midi_streamview.cc
@@ -401,11 +401,11 @@ MidiStreamView::apply_note_range(uint8_t lowest, uint8_t highest, bool to_region
 	_lowest_note = lowest;
 
 	int const max_note_height = 20;  // This should probably be based on text size...
-	int const range = _highest_note - _lowest_note;
+	int const range = _highest_note == _lowest_note ? 1 : _highest_note - _lowest_note;
 	int const pixels_per_note = floor (child_height () / range);
 
-	/* do not grow note height beyond 10 pixels */
-	if (pixels_per_note > max_note_height) {
+	/* do not grow note height beyond 10 pixels (except when we want one note) */
+	if (pixels_per_note > max_note_height && range > 1) {
 
 		int const available_note_range = floor (child_height() / max_note_height);
 		int additional_notes = available_note_range - range;

--- a/gtk2_ardour/midi_streamview.h
+++ b/gtk2_ardour/midi_streamview.h
@@ -68,7 +68,8 @@ public:
 
 	enum VisibleNoteRange {
 		FullRange,
-		ContentsRange
+		ContentsRange,
+		OneNoteRange
 	};
 
 	Gtk::Adjustment note_range_adjustment;

--- a/gtk2_ardour/midi_streamview.h
+++ b/gtk2_ardour/midi_streamview.h
@@ -134,6 +134,7 @@ private:
 	void draw_note_lines();
 	bool update_data_note_range(uint8_t min, uint8_t max);
 	void update_contents_metrics(boost::shared_ptr<ARDOUR::Region> r);
+	void read_data_note_range_from_regions();
 
 	void color_handler ();
 

--- a/gtk2_ardour/midi_time_axis.cc
+++ b/gtk2_ardour/midi_time_axis.cc
@@ -628,6 +628,11 @@ MidiTimeAxisView::append_extra_display_menu_items ()
 		          sigc::bind (sigc::mem_fun(*this, &MidiTimeAxisView::set_note_range),
 		                      MidiStreamView::ContentsRange, true)));
 
+	range_items.push_back (
+		MenuElem (_("One Note"),
+		          sigc::bind (sigc::mem_fun(*this, &MidiTimeAxisView::set_note_range),
+		                      MidiStreamView::OneNoteRange, true)));
+
 	items.push_back (MenuElem (_("Note Range"), *range_menu));
 	items.push_back (MenuElem (_("Note Mode"), *build_note_mode_menu()));
 	items.push_back (MenuElem (_("Channel Selector..."),

--- a/gtk2_ardour/piano_roll_header.cc
+++ b/gtk2_ardour/piano_roll_header.cc
@@ -460,13 +460,16 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 			Cairo::TextExtents te;
 			cr->get_text_extents(note_name, te);
 
-			if (is_white_key)
-				cr->set_source_rgb(0.0f, 0.0f, 0.0f);
-			else
-				cr->set_source_rgb(1.0f, 1.0f, 1.0f);
+			double r, g, b;
 
+			if (is_white_key)
+				note_name_color(white, r, g, b);
+			else
+				note_name_color(black, r, g, b);
+
+			cr->set_source_rgb(r, g, b);
 			cr->move_to(2.0f + font_size , y + note_height - 1.0f - (note_height - te.width) / 2.0f);
-			cr->rotate(-1.5707); // -90 degrees
+			cr->rotate(M_PI / -2.0); // -90 degrees
 			cr->show_text(note_name);
 		}
 		else if (oct_rel == 0) {
@@ -474,7 +477,10 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 			double y = floor(_view.note_to_y(i)) - 0.5f;
 			double note_height = floor(_view.note_to_y(i - 1)) - y;
 
-			cr->set_source_rgb(0.0f, 0.0f, 0.0f);
+			double r, g, b;
+			note_name_color(white, r, g, b);
+
+			cr->set_source_rgb(r, g, b);
 			cr->move_to(2.0f, y + note_height - 1.0f - (note_height - font_size) / 2.0f);
 			cr->show_text(ParameterDescriptor::midi_note_name(i));
 		}
@@ -483,7 +489,15 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 	return true;
 }
 
+void
+PianoRollHeader::note_name_color(const PianoRollHeader::Color& key_color, double& r, double& g, double& b)
+{
+	Gtkmm2ext::Color text_color = Gtkmm2ext::rgba_to_color(key_color.r, key_color.g, key_color.b, 1.0f);
+	text_color = Gtkmm2ext::contrasting_text_color(text_color);
 
+	double a;
+	Gtkmm2ext::color_to_rgba(text_color, r, g, b, a);
+}
 
 bool
 PianoRollHeader::on_motion_notify_event (GdkEventMotion* ev)

--- a/gtk2_ardour/piano_roll_header.cc
+++ b/gtk2_ardour/piano_roll_header.cc
@@ -22,6 +22,7 @@
 #include <iostream>
 #include "evoral/midi_events.h"
 #include "ardour/midi_track.h"
+#include "ardour/parameter_descriptor.h"
 
 #include "gtkmm2ext/keyboard.h"
 
@@ -34,6 +35,7 @@
 
 using namespace std;
 using namespace Gtkmm2ext;
+using namespace ARDOUR;
 
 PianoRollHeader::Color PianoRollHeader::white = PianoRollHeader::Color(0.77f, 0.78f, 0.76f);
 PianoRollHeader::Color PianoRollHeader::white_highlight = PianoRollHeader::Color(1.00f, 0.40f, 0.40f);
@@ -302,6 +304,7 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 	int oct_rel;
 	int y1 = max(rect.y, 0);
 	int y2 = min(rect.y + rect.height, (int) floor(_view.contents_height() - 1.0f));
+	bool is_white_key;
 
 	//Cairo::TextExtents te;
 	lowest = max(_view.lowest_note(), _view.y_to_note(y2));
@@ -313,7 +316,6 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 
 	cr->select_font_face ("Georgia", Cairo::FONT_SLANT_NORMAL, Cairo::FONT_WEIGHT_BOLD);
 	font_size = min((double) 10.0f, _note_height - 4.0f);
-	cr->set_font_size(font_size);
 
 	/* fill the entire rect with the color for non-highlighted white notes.
 	 * then we won't have to draw the background for those notes,
@@ -348,6 +350,8 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 		case 8:
 		case 10:
 			/* black note */
+			is_white_key = false;
+
 			if (i == _highlighted_note) {
 				bg.set(black_highlight);
 			} else {
@@ -378,6 +382,8 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 
 		default:
 			/* white note */
+			is_white_key = true;
+
 			if (i == _highlighted_note) {
 				bg.set(white_highlight);
 			} else {
@@ -443,24 +449,41 @@ PianoRollHeader::on_expose_event (GdkEventExpose* ev)
 
 		}
 
-		/* render the name of which C this is */
-		if (oct_rel == 0) {
-			std::stringstream s;
+		/* if only one note visible render note name vertical (because A#3 don't fit on key) */
+		if (lowest == highest) {
+			string const note_name = ParameterDescriptor::midi_note_name(i);
 			double y = floor(_view.note_to_y(i)) - 0.5f;
 			double note_height = floor(_view.note_to_y(i - 1)) - y;
 
-			int cn = i / 12 - 1;
-			s << "C" << cn;
+			cr->set_font_size(font_size);
 
-			//cr->get_text_extents(s.str(), te);
-			cr->set_source_rgb(0.30f, 0.30f, 0.30f);
+			Cairo::TextExtents te;
+			cr->get_text_extents(note_name, te);
+
+			if (is_white_key)
+				cr->set_source_rgb(0.0f, 0.0f, 0.0f);
+			else
+				cr->set_source_rgb(1.0f, 1.0f, 1.0f);
+
+			cr->move_to(2.0f + font_size , y + note_height - 1.0f - (note_height - te.width) / 2.0f);
+			cr->rotate(-1.5707); // -90 degrees
+			cr->show_text(note_name);
+		}
+		else if (oct_rel == 0) {
+			/* render the name of which C this is */
+			double y = floor(_view.note_to_y(i)) - 0.5f;
+			double note_height = floor(_view.note_to_y(i - 1)) - y;
+
+			cr->set_source_rgb(0.0f, 0.0f, 0.0f);
 			cr->move_to(2.0f, y + note_height - 1.0f - (note_height - font_size) / 2.0f);
-			cr->show_text(s.str());
+			cr->show_text(ParameterDescriptor::midi_note_name(i));
 		}
 	}
 
 	return true;
 }
+
+
 
 bool
 PianoRollHeader::on_motion_notify_event (GdkEventMotion* ev)

--- a/gtk2_ardour/piano_roll_header.h
+++ b/gtk2_ardour/piano_roll_header.h
@@ -75,6 +75,8 @@ private:
 	static Color black_shade_light;
 	static Color black_shade_dark;
 
+	static void note_name_color(const Color& key_color, double& r, double& g, double& b);
+
 	PianoRollHeader(const PianoRollHeader&);
 
 	enum ItemType {


### PR DESCRIPTION
Hi!
That tiny change makes working with MIDI percussion tracks a lot more convenient. It allows you to use the midi editor as a simple pattern editor by simply set note range to one note:

![onenoterange](https://user-images.githubusercontent.com/63190361/89106333-66b35d80-d429-11ea-8409-f6214b5df561.png)

Useful for kick, snare, hihat etc. Allows faster editing and saves screen space.