### PR TITLE
WS: crash bugfix related to missing strip panner

### DIFF
--- a/libs/surfaces/websockets/dispatcher.cc
+++ b/libs/surfaces/websockets/dispatcher.cc
@@ -65,19 +65,16 @@ WebsocketsDispatcher::update_all_nodes (Client client)
 		
 		ValueVector strip_desc = ValueVector ();
 		strip_desc.push_back (strip.name ());
-		strip_desc.push_back (strip.is_vca ());
+		strip_desc.push_back (strip.has_pan ());
 		
 		update (client, Node::strip_description, strip_addr, strip_desc);
 		
 		update (client, Node::strip_gain, strip_id, strip.gain ());
 		update (client, Node::strip_mute, strip_id, strip.mute ());
 
-		// Pan and plugins not available in VCAs
-		if (strip.is_vca ()) {
-			continue;
+		if (strip.has_pan ()) {
+			update (client, Node::strip_pan, strip_id, strip.pan ());
 		}
-
-		update (client, Node::strip_pan, strip_id, strip.pan ());
 
 		for (ArdourMixerStrip::PluginMap::iterator it = strip.plugins ().begin (); it != strip.plugins ().end (); ++it) {
 			uint32_t plugin_id                     = it->first;

--- a/libs/surfaces/websockets/mixer.cc
+++ b/libs/surfaces/websockets/mixer.cc
@@ -121,11 +121,6 @@ ArdourMixerPlugin::param_value (boost::shared_ptr<ARDOUR::AutomationControl> con
 ArdourMixerStrip::ArdourMixerStrip (boost::shared_ptr<ARDOUR::Stripable> stripable, PBD::EventLoop* event_loop)
 	: _stripable (stripable)
 {
-	if (is_vca ()) {
-		/* no plugins to handle */
-		return;
-	}
-
 	boost::shared_ptr<Route> route = boost::dynamic_pointer_cast<Route> (_stripable);
 
 	if (!route) {
@@ -188,6 +183,12 @@ ArdourMixerStrip::set_gain (double db)
 	_stripable->gain_control ()->set_value (from_db (db), PBD::Controllable::NoGroup);
 }
 
+bool
+ArdourMixerStrip::has_pan () const
+{
+	return _stripable->pan_azimuth_control () != 0;
+}
+
 double
 ArdourMixerStrip::pan () const
 {
@@ -222,12 +223,6 @@ void
 ArdourMixerStrip::set_mute (bool mute)
 {
 	_stripable->mute_control ()->set_value (mute ? 1.0 : 0.0, PBD::Controllable::NoGroup);
-}
-
-bool
-ArdourMixerStrip::is_vca () const
-{
-	return _stripable->presentation_info ().flags () & ARDOUR::PresentationInfo::VCA;
 }
 
 float

--- a/libs/surfaces/websockets/mixer.h
+++ b/libs/surfaces/websockets/mixer.h
@@ -83,13 +83,12 @@ public:
 	double gain () const;
 	void   set_gain (double);
 
+	bool   has_pan () const;
 	double pan () const;
 	void   set_pan (double);
 
 	bool mute () const;
 	void set_mute (bool);
-
-	bool is_vca () const;
 
 	std::string name () const;
 

--- a/share/web_surfaces/builtin/mixer/js/main.js
+++ b/share/web_surfaces/builtin/mixer/js/main.js
@@ -88,8 +88,9 @@ import { createRootContainer, Container, Dialog, Label, Button, Toggle,
         plugins.classList.add('strip-plugins');
         plugins.appendTo(container);
 
-        if (strip.isVca || (strip.plugins.length == 0)) {
+        if (strip.plugins.length == 0) {
             plugins.classList.add('disabled');
+            plugins.element.style.visibility = 'hidden';
         } else {
             plugins.callback = () => openPlugins (strip);
         }
@@ -97,8 +98,10 @@ import { createRootContainer, Container, Dialog, Label, Button, Toggle,
         const pan = new PanKnob();
         pan.appendTo(container);
 
-        if (!strip.isVca) {
+        if (strip.hasPan) {
             pan.bindTo(strip, 'pan');
+        } else {
+            pan.element.style.visibility = 'hidden';
         }
 
         const mute = new Toggle();
@@ -123,12 +126,6 @@ import { createRootContainer, Container, Dialog, Label, Button, Toggle,
         label.text = strip.name;
         label.classList.add('strip-label');
         label.appendTo(container);
-
-        if (strip.isVca) {
-            // hide plugins and pan keeping layout
-            pan.element.style.visibility = 'hidden';
-            plugins.element.style.visibility = 'hidden';
-        }
     }
 
     function openPlugins (strip) {

--- a/share/web_surfaces/shared/components/strip.js
+++ b/share/web_surfaces/shared/components/strip.js
@@ -33,7 +33,7 @@ export default class Strip extends AddressableComponent {
 		super(parent, addr);
 		this._plugins = {};
 		this._name = desc[0];
-		this._isVca = desc[1];
+		this._hasPan = desc[1];
 		this._meter = 0;
 		this._gain = 0;
 		this._pan = 0;
@@ -48,8 +48,8 @@ export default class Strip extends AddressableComponent {
 		return this._name;
 	}
 
-	get isVca () {
-		return this._isVca;
+	get hasPan () {
+		return this._hasPan;
 	}
 
 	get meter () {


### PR DESCRIPTION
Replaced internal mixer strip method `is_vca()` for `has_pan()`. Checking `has_pan()` before `pan()` when building the initial state for a recently connected client to avoid try/catch.

In the current state of things the GUI does not really need to know a low level detail like a track being a VCA to determine if a pan control and/or plugins should be presented. Revealing track types can be a future enhancement, ie. exposing the `PresentationInfo` flags.

Now the availability of a pan control is explicit through the second boolean arg value in the WS `strip_description` message (previously indicated if the track was VCA). For the plugins check it is enough to check if the plugins array returned by the JS client for a certain strip is empty or not.

Side note, MIDI tracks (unsurprisingly) use a linear scale for the level fader and the demo mixer strips are hardcoded to dB. Since mixing audio and MIDI is common practice exposing the track type could be the next update, replacing the has_pan field and expecting the client to be smarter.
