### PR TITLE
Update dark-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -239,7 +239,7 @@
     <ColorAlias name="midi sysex outline" alias="theme:contrasting alt"/>
     <ColorAlias name="midi track base" alias="widget:green darker"/>
     <ColorAlias name="mixer strip button: fill" alias="widget:bg"/>
-    <ColorAlias name="mixer strip button: fill active" alias="theme:bg1"/>
+    <ColorAlias name="mixer strip button: fill active" alias="alert:orange"/>
     <ColorAlias name="mixer strip button: led active" alias="alert:green"/>
     <ColorAlias name="mixer strip name button: fill active" alias="theme:bg2"/>
     <ColorAlias name="mixer strip name button: led active" alias="alert:green"/>


### PR DESCRIPTION
Hi! A little propose to change a "Fader automation mode" button active color from gray to noticeable alert orange.
![dark theme - Fader automation mode button](https://user-images.githubusercontent.com/19673308/95991310-4a726a80-0e35-11eb-85b0-b95e072b028c.png)
