### PR TITLE
Check for MIDI buffer overflow when merging into an empty buffer

### DIFF
--- a/libs/ardour/midi_buffer.cc
+++ b/libs/ardour/midi_buffer.cc
@@ -442,13 +442,13 @@ MidiBuffer::merge_in_place (const MidiBuffer &other)
 		return true;
 	}
 
+	if (size() + other.size() > _capacity) {
+		return false;
+	}
+
 	if (size() == 0) {
 		copy (other);
 		return true;
-	}
-
-	if (size() + other.size() > _capacity) {
-		return false;
 	}
 
 	const_iterator them = other.begin();

--- a/libs/ardour/midi_buffer.cc
+++ b/libs/ardour/midi_buffer.cc
@@ -252,6 +252,7 @@ MidiBuffer::insert_event(const Evoral::Event<TimeType>& ev)
 	}
 
 	uint8_t* const write_loc = _data + insert_offset;
+	assert((insert_offset + stamp_size + etype_size + ev.size()) <= _capacity);
 	*(reinterpret_cast<TimeType*>((uintptr_t)write_loc)) = t;
 	*(reinterpret_cast<Evoral::EventType*>((uintptr_t)(write_loc + stamp_size))) = ev.event_type ();
 	memcpy(write_loc + stamp_size + etype_size, ev.buffer(), ev.size());

--- a/libs/ardour/midi_buffer.cc
+++ b/libs/ardour/midi_buffer.cc
@@ -136,7 +136,10 @@ MidiBuffer::merge_from (const Buffer& src, samplecnt_t /*nframes*/, sampleoffset
 	assert (mbuf != this);
 
 	/* XXX use nframes, and possible offsets */
-	merge_in_place (*mbuf);
+	if (!merge_in_place (*mbuf)) {
+		cerr << string_compose ("MidiBuffer::merge_in_place failed (buffer is full: size: %1 capacity %2 new bytes %3)", _size, _capacity, mbuf->size()) << endl;
+		PBD::stacktrace (cerr, 20);
+	}
 }
 
 /** Push an event into the buffer.


### PR DESCRIPTION
This can happen if the buffers have different sizes.
This fixes crashes that bisected to 7c37a18, but it is not the root cause; it just happened to make things worse.

Also including two extra related commits; the second commit ensures we complain when buffers are full like this (but not crash), and the third is just a missing assert in a different MIDI buffer write codepath (that the other codepaths have), for sanity.