### PR TITLE
evoral: add a couple of asserts to catch times < 0

### DIFF
--- a/libs/evoral/Note.cc
+++ b/libs/evoral/Note.cc
@@ -34,6 +34,7 @@ Note<Time>::Note(uint8_t chan, Time t, Time l, uint8_t n, uint8_t v)
 	: _on_event (MIDI_EVENT, t, 3, NULL, true)
 	, _off_event (MIDI_EVENT, t + l, 3, NULL, true)
 {
+	assert(l >= Time());
 	assert(chan < 16);
 
 	_on_event.buffer()[0] = MIDI_CMD_NOTE_ON + chan;

--- a/libs/evoral/evoral/Sequence.h
+++ b/libs/evoral/evoral/Sequence.h
@@ -278,6 +278,7 @@ public:
 		bool                               force_discrete = false,
 		const std::set<Evoral::Parameter>& f              = std::set<Evoral::Parameter>(),
 		const std::set<WeakNotePtr>*       active_notes   = NULL) const {
+		assert (t >= Time());
 		return const_iterator (*this, t, force_discrete, f, active_notes);
 	}
 


### PR DESCRIPTION
This makes an already asserting condition (due to a Note getting
constructed with a negative length) more obvious.