### PR TITLE
Make sure VST3 projectTimeMusic is updated

### DIFF
--- a/libs/ardour/vst3_plugin.cc
+++ b/libs/ardour/vst3_plugin.cc
@@ -629,6 +629,7 @@ VST3Plugin::connect_and_run (BufferSet&  bufs,
 		context.tempo              = t.quarter_notes_per_minute ();
 		context.timeSigNumerator   = ms.divisions_per_bar ();
 		context.timeSigDenominator = ms.note_divisor ();
+		context.projectTimeMusic   = tmap.quarter_note_at_sample_rt (start);
 	}
 
 	const double tcfps                = _session.timecode_frames_per_second ();


### PR DESCRIPTION
Although Ardour claims `kProjectTimeMusicValid`, it never actually set `context.projectTimeMusic`. This resulted in e.g. this issue in Surge https://github.com/surge-synthesizer/surge/issues/2998 . This patch fixes that.

Something similar will need to be done for LV2, this only fixes VST3 :smiley: