### PR TITLE
Equivalent region selection (new)

### DIFF
--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -763,6 +763,7 @@ private:
 	bool set_selected_control_point_from_click (bool press, Selection::Operation op = Selection::Set);
 	void set_selected_track_from_click (bool press, Selection::Operation op = Selection::Set, bool no_remove=false);
 	void set_selected_track_as_side_effect (Selection::Operation op);
+	bool selection_contains_isolated_equivalent_region ();
 	bool set_selected_regionview_from_click (bool press, Selection::Operation op = Selection::Set);
 
 	bool set_selected_regionview_from_map_event (GdkEventAny*, StreamView*, boost::weak_ptr<ARDOUR::Region>);

--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -639,13 +639,10 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 	}
 
 	if (op == Selection::Toggle || op == Selection::Set) {
-// 		bool isolate_region = (selection->regions.empty() || selection_contains_isolated_equivalent_region());
-		
 		switch (op) {
 		case Selection::Toggle:
-			
-			
 			if (selection->selected (clicked_regionview)) {
+
 				if (press) {
 
 					/* whatever was clicked was selected already; do nothing here but allow
@@ -655,12 +652,13 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 					button_release_can_deselect = true;
 
 				} else {
+
 					if (button_release_can_deselect) {
-						
+
 						if (selection->regions.empty() || selection_contains_isolated_equivalent_region()) {
 							/* just remove this one region, but only on a permitted button release */
 							selection->remove (clicked_regionview);
-							
+
 						} else {
 							/* remove all equivalents regions, but only on a permitted button release */
 							get_equivalent_regions (clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
@@ -669,7 +667,7 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 								selection->remove((*r));
 							}
 						}
-						
+
 						commit = true;
 
 						/* no more deselect action on button release till a new press
@@ -683,15 +681,15 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 			} else {
 
 				if (press) {
-					
+
 					if (selection->regions.empty() || selection_contains_isolated_equivalent_region()) {
-						
+
 						all_equivalent_regions.push_back (clicked_regionview);
-						
+
 					} else {
 						
 						get_equivalent_regions (clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
-						
+
 					}
 
 					/* add all the equivalent regions, but only on button press */
@@ -707,14 +705,20 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 
 		case Selection::Set:
 			if (!selection->selected (clicked_regionview)) {
+
 				get_equivalent_regions (clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
 				selection->set (all_equivalent_regions);
 				commit = true;
+
 			} else {
 				/* clicked on an already selected region */
+
 				if (press)
+
 					goto out;
+
 				else {
+
 					if (selection->regions.size() > 1) {
 						/* collapse region selection down to just this one region (and its equivalents) */
 						get_equivalent_regions(clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);

--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -578,6 +578,32 @@ Editor::get_regionview_count_from_region_list (boost::shared_ptr<Region> region)
 
 
 bool
+Editor::selection_contains_isolated_equivalent_region ()
+{
+	vector<RegionView*> already_seen;
+	
+	for (RegionSelection::iterator r = selection->regions.begin(); r != selection->regions.end(); ++r) {
+		if (std::find(already_seen.begin(), already_seen.end(), (*r)) != already_seen.end()){
+			continue;
+		}
+		
+		vector<RegionView*> equivalent_regions;
+		get_equivalent_regions ((*r), equivalent_regions, ARDOUR::Properties::group_select.property_id);
+		
+		for (vector<RegionView*>::iterator er = equivalent_regions.begin() ; er != equivalent_regions.end(); ++er){
+			already_seen.push_back((*er));
+			
+			if (!selection->selected((*er))) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+		
+		
+
+bool
 Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 {
 	vector<RegionView*> all_equivalent_regions;
@@ -592,9 +618,12 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 	}
 
 	if (op == Selection::Toggle || op == Selection::Set) {
-
+// 		bool isolate_region = (selection->regions.empty() || selection_contains_isolated_equivalent_region());
+		
 		switch (op) {
 		case Selection::Toggle:
+			
+			
 			if (selection->selected (clicked_regionview)) {
 				if (press) {
 
@@ -606,10 +635,20 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 
 				} else {
 					if (button_release_can_deselect) {
-
-						/* just remove this one region, but only on a permitted button release */
-
-						selection->remove (clicked_regionview);
+						
+						if (selection->regions.empty() || selection_contains_isolated_equivalent_region()) {
+							/* just remove this one region, but only on a permitted button release */
+							selection->remove (clicked_regionview);
+							
+						} else {
+							/* remove all equivalents regions, but only on a permitted button release */
+							get_equivalent_regions (clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
+							
+							for (vector<RegionView*>::iterator r = all_equivalent_regions.begin(); r != all_equivalent_regions.end(); ++r ){
+								selection->remove((*r));
+							}
+						}
+						
 						commit = true;
 
 						/* no more deselect action on button release till a new press
@@ -623,11 +662,15 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 			} else {
 
 				if (press) {
-
-					if (selection->selected (clicked_routeview)) {
-						get_equivalent_regions (clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
-					} else {
+					
+					if (selection->regions.empty() || selection_contains_isolated_equivalent_region()) {
+						
 						all_equivalent_regions.push_back (clicked_regionview);
+						
+					} else {
+						
+						get_equivalent_regions (clicked_regionview, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
+						
 					}
 
 					/* add all the equivalent regions, but only on button press */
@@ -876,7 +919,17 @@ Editor::set_selected_regionview_from_click (bool press, Selection::Operation op)
 			RegionView* arv;
 
 			if ((arv = dynamic_cast<RegionView*>(*x)) != 0) {
-				regions.push_back (arv);
+				if (selection_contains_isolated_equivalent_region()) {
+					regions.push_back (arv);
+				} else {
+					get_equivalent_regions(arv, all_equivalent_regions, ARDOUR::Properties::group_select.property_id);
+					for (vector<RegionView*>::iterator i=all_equivalent_regions.begin(); i != all_equivalent_regions.end(); ++i){
+						if ( !(std::find(regions.begin(), regions.end(), (*i)) != regions.end()) ) {
+							regions.push_back (*i);
+						}
+					}
+				}
+				
 			}
 		}
 


### PR DESCRIPTION
Hi. This is the same PR than #391 , github made something very strange because I updated my fork, this one seems to be ok.
I've done just a little code clean, it still works fine.


--- old text ---

This is a way to resolve the problem i mention here: http://tracker.ardour.org/view.php?id=6826

It concerns selection of equivalents regions with key modifiers (on linux, Ctrl and Shift).
I saw in code that the behaviour is quite weird (maybe because of an old behaviour), if you press Ctrl + click, it select all equivalent regions only if tracks are selected. But there is no interest, because it deselect the tracks !!!

So after a long reflexion, I've done this:
if you click on a region with Primary key, it will add/remove to selection:
* Only the clicked region if there is no selected region or if selection contains isolated equivalent region(s)
* All equivalent regions in the other case

if you click on a region with Tertiary key, it will apply selection to:
* only the clicked region if selection contains isolated equivalent region(s)
* All equivalent regions in the other case
Note that a region with no equivalent is not considered as isolated region.

this way, naturally, if user want to select isolated regions, he starts his selection with Primary Key, else he starts his selection with no modifier key, and it does what user wants (I think).