### PR TITLE
prevent registering eventHandlers with multiple identical file descriptors

### DIFF
--- a/gtk2_ardour/vst3_x11_plugin_ui.cc
+++ b/gtk2_ardour/vst3_x11_plugin_ui.cc
@@ -104,6 +104,10 @@ public:
 	/* VST3 IRunLoop interface */
 	tresult registerEventHandler (Linux::IEventHandler* handler, FileDescriptor fd) SMTG_OVERRIDE
 	{
+		if (!handler || _event_handlers.find(fd) != _event_handlers.end()) {
+			return kInvalidArgument;
+		}
+
 		Glib::Threads::Mutex::Lock lm (_lock);
 		GIOChannel* gio_channel = g_io_channel_unix_new (fd);
 		guint id = g_io_add_watch (gio_channel, (GIOCondition) (G_IO_IN /*| G_IO_OUT*/ | G_IO_ERR | G_IO_HUP), event, handler);


### PR DESCRIPTION
Hey there Ardour team. This seems to robustly address some continuing issues I was seeing with VST3 plugins on Linux. I was still running into seg faults when opening/closing lots of VST3 plugin instances, even after the recent update to make sure all file descriptors were deregistered.

This should block all identical file descriptors from being registered for a plugin. The extent of my testing has been to open several instances of JUCE-based plugins, show the GUIs, close the GUIs, delete plugins, re-add them etc. I didn't try every path but I wasn't able to crash Ardour at all after this change, whereas it was pretty easy to crash Ardour previously by opening a few plugin GUIs and then deleting the plugins, re-adding them etc.

JUCE VST3 host code does the same thing here:
https://github.com/juce-framework/JUCE/blob/cc9fdc3d6a89b86ecd902c1f24258ae8cdcc5639/modules/juce_audio_processors/format_types/juce_VST3PluginFormat.cpp#L1203