### PR TITLE
VST3 prevent resize loops

### DIFF
--- a/gtk2_ardour/vst3_x11_plugin_ui.cc
+++ b/gtk2_ardour/vst3_x11_plugin_ui.cc
@@ -187,9 +187,14 @@ VST3X11PluginUI::VST3X11PluginUI (boost::shared_ptr<PluginInsert> pi, boost::sha
 	pack_start (_gui_widget, true, true);
 
 	_gui_widget.signal_realize().connect (mem_fun (this, &VST3X11PluginUI::view_realized));
-	_gui_widget.signal_size_request ().connect (mem_fun (this, &VST3X11PluginUI::view_size_request));
-	_gui_widget.signal_size_allocate ().connect (mem_fun (this, &VST3X11PluginUI::view_size_allocate));
 	_gui_widget.signal_scroll_event ().connect (sigc::mem_fun (*this, &VST3X11PluginUI::forward_scroll_event), false);
+
+	IPlugView* view = _vst3->view ();
+	if (view->canResize() == kResultFalse) {
+		// We only need to connect the resize signals if the plugin is NOT resizable on its own.
+		_gui_widget.signal_size_request ().connect (mem_fun (this, &VST3X11PluginUI::view_size_request));
+		_gui_widget.signal_size_allocate ().connect (mem_fun (this, &VST3X11PluginUI::view_size_allocate));
+	}
 
 #if 0
 	_gui_widget.add_events (Gdk::POINTER_MOTION_HINT_MASK | Gdk::SCROLL_MASK | Gdk::KEY_PRESS_MASK | Gdk::KEY_RELEASE_MASK | Gdk::BUTTON_PRESS_MASK|Gdk::BUTTON_RELEASE_MASK|Gdk::ENTER_NOTIFY_MASK|Gdk::LEAVE_NOTIFY_MASK|Gdk::SCROLL_MASK);


### PR DESCRIPTION
Hey Ardour team, this PR should fix some major performance issues I've noticed with resizable VST3 plugins on Linux. I didn't entirely understand why this worked or how the resizing logic all fits together, but based on my testing it seems to fix most of the problems.

To summarize the problem: plugin UIs were getting stuck in loops with `view_size_allocate` getting called repeatedly even though `resize_callback` and `onSize` had already successfully run. After much messing around adding print statements everywhere I found that, since resizable plugins will call `resizeView` (which forwards that to `resize_callback`), there is no need for them to be connected to the _gui_widget resize signals. These signals seem only necessary for plugin UIs that are not resizable in the drag-the-corner sense. I might have misunderstood something though.

Here are my observations from testing various plugins:
### TAL U-NO-LX v4.4.1
Completely unusable before this fix, but stable and runs well after. Earlier plugin versions still have issues, so it looks like a recent update fixed some resize logic on the plugin developer's end as well. The only remaining issue for this plugin is the initial plugin window size is a bit wider than the plugin UI, but as soon as the user resizes the window it matches up. Might be easily fixable in a follow-up.

### U-he Diva
This plugin is not by-default resizable, but it DOES have a menu to change the UI sizing to one of several fixed percentages. I noticed it does call resizeView when selecting a new size in that menu, but it returns `canResize` as false. So with this change we do still hook it up to the _gui_widget resize signals and that seems to work well for its UI.

### My own JUCE-based plugins
Similar to the TAL plugin, the UIs were not usable at all before this fix but work great with the fix. Resizable plugins now work as expected, non-resizable plugin behavior seems unchanged.