### PR TITLE
VST3 set minimum resize

### DIFF
--- a/gtk2_ardour/vst3_plugin_ui.cc
+++ b/gtk2_ardour/vst3_plugin_ui.cc
@@ -52,6 +52,16 @@ VST3PluginUI::VST3PluginUI (boost::shared_ptr<PluginInsert> pi, boost::shared_pt
 
 	pack_start (_ardour_buttons_box, false, false);
 	_ardour_buttons_box.show_all ();
+
+    // determine minimum size
+    IPlugView* view = _vst3->view ();
+    ViewRect rect;
+    if (view->checkSizeConstraint (&rect) != kResultTrue) {
+        view->getSize (&rect);
+    }
+
+    // set minimum size
+    set_size_request(rect.right - rect.left, rect.bottom - rect.top);
 }
 
 VST3PluginUI::~VST3PluginUI ()


### PR DESCRIPTION
It was previously not possible to resize a resizeable vst3 plugin to be smaller than the default initial width & height.  This PR first finds what the vst3 plugin's minimum size by calling checkSizeConstraint() with a {0,0,0,0} rectangle, which returns the vst3's minimum permitted size in that rect.  And then calls set_size_request with the width and height of that returned rect.

Here is the previous behavior on windows when trying to resize smaller than the initial size:

![sonobus-137-resise-in-ardour-windows](https://user-images.githubusercontent.com/6502474/110249273-6fca5700-7f43-11eb-8932-cb8a697d804c.gif)

Here is the previous behavior on linux when trying to resize smaller than the initial size:

![sonobus-resize-ardour6p6-bug](https://user-images.githubusercontent.com/6502474/110249310-95576080-7f43-11eb-87f5-074921a67fa6.gif)

And after applying this commit, here is the new behavior on linux (for a JUCE plugin which has a minimum size of 400x300 set with setResizeLimits):

![sonobus-after-set-size-request](https://user-images.githubusercontent.com/6502474/110249358-cd5ea380-7f43-11eb-8dfd-9cb03d147c53.gif)

I haven't tested on windows yet (and I probably don't want to set up a dev environment in windows), but I think this commit would work for windows too.