### PR TITLE
Update clear_gray-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -111,7 +111,7 @@
     <ColorAlias name="ghost track zero line" alias="neutral:foreground2"/>
     <ColorAlias name="grid line major" alias="neutral:backgroundest"/>
     <ColorAlias name="grid line micro" alias="neutral:midground"/>
-    <ColorAlias name="grid line minor" alias="neutral:foreground2"/>
+    <ColorAlias name="grid line minor" alias="neutral:backgroundest"/>
     <ColorAlias name="gtk_arm" alias="alert:red"/>
     <ColorAlias name="gtk_audio_bus" alias="widget:blue darker"/>
     <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>


### PR DESCRIPTION
This PR changes grid line minor from light to noticeable black color:
![Clear Gray change 230321](https://user-images.githubusercontent.com/19673308/112202202-286de700-8c22-11eb-92b7-7b4c1f7e47bd.png)
