### PR TITLE
Fix invalid conversion from 'volatile void*' to 'void*'

### DIFF
--- a/libs/pbd/pbd/rcu.h
+++ b/libs/pbd/pbd/rcu.h
@@ -193,7 +193,7 @@ public:
 		 * XXX but how could it? we hold the freakin' lock!
 		 */
 
-		bool ret = g_atomic_pointer_compare_and_exchange (&RCUManager<T>::x.gptr,
+		bool ret = g_atomic_pointer_compare_and_exchange ((gpointer*)&RCUManager<T>::x.gptr,
 		                                                  (gpointer)_current_write_old,
 		                                                  (gpointer)new_spp);
 


### PR DESCRIPTION
The build otherwise fails on gcc 10.2.0, glib 2.68.0.

The origin of this problem is found in `gatomic.h` macros, more precisely the c++11 specific variant.
The volatile flag on `gapcae_oldval` is kept, whereas the other one would discard it.

https://github.com/GNOME/glib/blob/622b31f69e72fdb05b813820e9cd8087e88a47bf/glib/gatomic.h#L206
