### PR TITLE
Add Alesis VI25 MIDI mappings

### DIFF
--- a/share/midi_maps/Alesis_VI25.map
+++ b/share/midi_maps/Alesis_VI25.map
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- 2021-4-10 Mathias Wøbbe: Map file creation -->
 <ArdourMIDIBindings version="1.0.0" name="Alesis VI25">
   <DeviceInfo bank-size="24"/>
 	

--- a/share/midi_maps/Alesis_VI25.map
+++ b/share/midi_maps/Alesis_VI25.map
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ArdourMIDIBindings version="1.0.0" name="Alesis VI25">
-	<DeviceInfo bank-size="24"/>
+  <DeviceInfo bank-size="24"/>
 	
-	<Binding channel="1" ctl="114" function="toggle-rec-enable"/>
+  <Binding channel="1" ctl="114" function="toggle-rec-enable"/>
   <Binding channel="1" ctl="116" function="transport-start"/>
   <Binding channel="1" ctl="117" function="transport-end"/>
 

--- a/share/midi_maps/Alesis_VI25.map
+++ b/share/midi_maps/Alesis_VI25.map
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="Alesis VI25">
+	<DeviceInfo bank-size="24"/>
+	
+	<Binding channel="1" ctl="114" function="toggle-rec-enable"/>
+  <Binding channel="1" ctl="116" function="transport-start"/>
+  <Binding channel="1" ctl="117" function="transport-end"/>
+
+  <Binding channel="1" ctl="118" function="transport-stop"/>
+  <Binding channel="1" ctl="119" function="transport-roll"/>
+  <Binding channel="1" ctl="115" function="loop-toggle"/>
+
+</ArdourMIDIBindings>


### PR DESCRIPTION
This enables the usage of Alesis VI25 buttons:

- Stop
- Play
- Toggle loop (I don't know how/if this works but I added it anyway, I didn't get any response from it)
- Toggle record enable