### PR TITLE
Update compile.sh

### DIFF
--- a/tools/x-win/compile.sh
+++ b/tools/x-win/compile.sh
@@ -2,7 +2,7 @@
 
 # we assuem this script is <ardour-src>/tools/x-win/compile.sh
 pushd "`/usr/bin/dirname \"$0\"`" > /dev/null; this_script_dir="`pwd`"; popd > /dev/null
-cd $this_script_dir/../..
+cd "$this_script_dir/../.."
 test -f gtk2_ardour/wscript || exit 1
 
 : ${XARCH=i686} # or x86_64


### PR DESCRIPTION
cd in line 4 would not work if path has blank as it would have two arguments
Example:
run in /home/LukeChriswalker/projects to build/Ardour/tools/x-win
./compile.sh: line 4: cd: too many arguments
Then reaches line 5, and exits with code 1 (not mine to judge, but maybe change that exit code?) without explanation