### PR TITLE
Freedesktop install

### DIFF
--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -941,6 +941,14 @@ def build(bld):
         set_subst_dict(obj, freedesktop_subst_dict)
         bld.install_files (os.path.join (bld.env['PREFIX'], 'share/appdata'), obj.target)
 
+        # install desktop icon files
+        bld.install_as('${PREFIX}/share/icons/hicolor/16x16/apps/ardour6.png', 'resources/Ardour-icon_16px.png')
+        bld.install_as('${PREFIX}/share/icons/hicolor/22x22/apps/ardour6.png', 'resources/Ardour-icon_22px.png')
+        bld.install_as('${PREFIX}/share/icons/hicolor/32x32/apps/ardour6.png', 'resources/Ardour-icon_32px.png')
+        bld.install_as('${PREFIX}/share/icons/hicolor/48x48/apps/ardour6.png', 'resources/Ardour-icon_48px.png')
+        bld.install_as('${PREFIX}/share/icons/hicolor/256x256/apps/ardour6.png', 'resources/Ardour-icon_256px.png')
+        bld.install_as('${PREFIX}/share/icons/hicolor/512x512/apps/ardour6.png', 'resources/Ardour-icon_512px.png')
+
     # Keybindings
 
     # NATIVE ARDOUR BINDING FILES

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -922,11 +922,13 @@ def build(bld):
         obj.chmod        = Utils.O644
         obj.dict         = freedesktop_subst_dict
         set_subst_dict(obj, freedesktop_subst_dict)
+        bld.install_files (os.path.join (bld.env['PREFIX'], 'share/applications'), obj.target)
 
         obj              = bld(features = 'subst')
         obj.source       = 'ardour-mime-info.xml'
         obj.target       = 'ardour.xml'
         obj.chmod        = Utils.O644
+        bld.install_files (os.path.join (bld.env['PREFIX'], 'share/mime/application'), 'ardour' + '.xml')
 
         # build appdata with translations
         appdata_i18n_mo(bld)
@@ -937,6 +939,7 @@ def build(bld):
         obj.chmod        = Utils.O644
         obj.dict         = freedesktop_subst_dict
         set_subst_dict(obj, freedesktop_subst_dict)
+        bld.install_files (os.path.join (bld.env['PREFIX'], 'share/appdata'), obj.target)
 
     # Keybindings
 


### PR DESCRIPTION
I realized that a locally compiled and installed ardour6 does not show up in KDE application menu, even when configured with --freedesktop

This PR adds install instructions for freedesktop files (.desktop, mimeinfo xml, appdata xml and application icons) to gtk2_ardour/wscript.

I don't know python well, nor the waf ecosystem, so I've tried and deduced my changes from other content in wscript. I'm not sure if this is in any way complete, e.g. doing this only for Ardour. Mixbus and Tracks to my knowledge don't get packaged by linux distros anyway, so it might be sufficient.

This change would also make it possible to simplify the package building process (RPM spec and similar build scripts), even if that is of zero interest for Paul, for obvious reasons. But as he told me on IRC, contributions are welcome, so I thought I'd give it a go.