### PR TITLE
Fix an incorrect method call that prevents transport from being started

### DIFF
--- a/libs/ardour/session_transport.cc
+++ b/libs/ardour/session_transport.cc
@@ -791,7 +791,7 @@ void
 Session::request_roll (TransportRequestSource origin)
 {
 	if (synced_to_engine()) {
-		_engine.transport_stop ();
+		_engine.transport_start ();
 		return;
 	}
 


### PR DESCRIPTION
I noticed that when external positional sync source (JACK) is being used, the transport could not be started through Ardour. Pressing the play button or trying to start it through the menus resulted in nothing happening. Starting the JACK transport through QJackCtl or something else worked as expected.

Calling `transport_start` instead of `transport_stop` when synced to engine in the `request_roll` method fixed the issue and made it possible to start the transport through Ardour. 