### PR TITLE
Fix crash if SourceFactory::createExternal fails to create a source.

### DIFF
--- a/gtk2_ardour/sfdb_ui.cc
+++ b/gtk2_ardour/sfdb_ui.cc
@@ -533,6 +533,10 @@ SoundFileBox::audition ()
 					SourceFactory::createExternal (DataType::AUDIO, *_session,
 											 path, n,
 											 Source::Flag (ARDOUR::AudioFileSource::NoPeakFile), false));
+				if (!afs) {
+					throw failed_constructor();
+				}
+
 				if (afs->sample_rate() != _session->nominal_sample_rate()) {
 					boost::shared_ptr<SrcFileSource> sfs (new SrcFileSource(*_session, afs, _src_quality));
 					srclist.push_back(sfs);


### PR DESCRIPTION
SoundFileBox::audition handles the case when
SourceFactory::createExternal throws a failed_constructor exception.
However createExternal actually signals failure in most cases by
returning a nullptr, which wasn't handled by SoundFileBox, and thus
would result in a crash.

This isn't usually a problem, since the audition UI would be disabled
unless Ardour had already successfully parsed metadata for the file
being selected, which usually means that creating an AudioFileSource for
the file will succeed as well.