### PR TITLE
Fix Upsampler new/delete mismatch

### DIFF
--- a/libs/audiographer/private/limiter/limiter.cc
+++ b/libs/audiographer/private/limiter/limiter.cc
@@ -77,9 +77,9 @@ void
 Limiter::Upsampler::fini ()
 {
 	for (int i = 0; i < _nchan; ++i) {
-		delete _z[i];
+		delete[] _z[i];
 	}
-	delete _z;
+	delete[] _z;
 	_nchan = 0;
 	_z     = 0;
 }


### PR DESCRIPTION
This fixes a small new[]/delete[] mismatch that occurs when exporting a project. 