### PR TITLE
Allow WebSockets surface to run on more libwebsockets configurations 

### DIFF
--- a/libs/surfaces/websockets/ardour_websockets.cc
+++ b/libs/surfaces/websockets/ardour_websockets.cc
@@ -8,7 +8,7 @@
  * Copyright (C) 2015-2018 John Emmas <john@creativepost.co.uk>
  * Copyright (C) 2015 Johannes Mueller <github@johannes-mueller.org>
  * Copyright (C) 2016-2018 Len Ovens <len@ovenwerks.net>
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/ardour_websockets.cc
+++ b/libs/surfaces/websockets/ardour_websockets.cc
@@ -39,8 +39,8 @@ ArdourWebsockets::ArdourWebsockets (Session& s)
     , AbstractUI<ArdourWebsocketsUIRequest> (name ())
     , _mixer (*this)
     , _transport (*this)
-    , _feedback (*this)
     , _server (*this)
+    , _feedback (*this)
     , _dispatcher (*this)
 {
 	_components.push_back (&_mixer);

--- a/libs/surfaces/websockets/ardour_websockets.h
+++ b/libs/surfaces/websockets/ardour_websockets.h
@@ -6,7 +6,7 @@
  * Copyright (C) 2015 Johannes Mueller <github@johannes-mueller.org>
  * Copyright (C) 2016-2018 Len Ovens <len@ovenwerks.net>
  * Copyright (C) 2016 Ben Loftis <ben@harrisonconsoles.com>
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/ardour_websockets.h
+++ b/libs/surfaces/websockets/ardour_websockets.h
@@ -95,8 +95,8 @@ protected:
 private:
 	ArdourMixer                    _mixer;
 	ArdourTransport                _transport;
-	ArdourFeedback                 _feedback;
 	WebsocketsServer               _server;
+	ArdourFeedback                 _feedback;
 	WebsocketsDispatcher           _dispatcher;
 	std::vector<SurfaceComponent*> _components;
 

--- a/libs/surfaces/websockets/client.cc
+++ b/libs/surfaces/websockets/client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/client.h
+++ b/libs/surfaces/websockets/client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/component.cc
+++ b/libs/surfaces/websockets/component.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/component.h
+++ b/libs/surfaces/websockets/component.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/dispatcher.cc
+++ b/libs/surfaces/websockets/dispatcher.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/dispatcher.h
+++ b/libs/surfaces/websockets/dispatcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/feedback.cc
+++ b/libs/surfaces/websockets/feedback.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/feedback.h
+++ b/libs/surfaces/websockets/feedback.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/feedback.h
+++ b/libs/surfaces/websockets/feedback.h
@@ -21,13 +21,26 @@
 
 #include <boost/shared_ptr.hpp>
 #include <boost/unordered_map.hpp>
-#include <glibmm/main.h>
+#include <glibmm/threads.h>
+
+#include "pbd/abstract_ui.h"
 
 #include "component.h"
 #include "typed_value.h"
 #include "mixer.h"
 
 namespace ArdourSurface {
+
+class FeedbackHelperUI : public AbstractUI<BaseUI::BaseRequestObject>
+{
+public:
+	FeedbackHelperUI ();
+	~FeedbackHelperUI () {};
+
+protected:
+	virtual void do_request (BaseUI::BaseRequestObject*);
+
+};
 
 class ArdourFeedback : public SurfaceComponent
 {
@@ -48,6 +61,9 @@ private:
 	Glib::Threads::Mutex      _client_state_lock;
 	PBD::ScopedConnectionList _transport_connections;
 	sigc::connection          _periodic_connection;
+
+	// Only needed for server event loop integration method 3
+	FeedbackHelperUI          _helper;
 
 	bool poll () const;
 

--- a/libs/surfaces/websockets/json.cc
+++ b/libs/surfaces/websockets/json.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/json.h
+++ b/libs/surfaces/websockets/json.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/manifest.cc
+++ b/libs/surfaces/websockets/manifest.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/manifest.h
+++ b/libs/surfaces/websockets/manifest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/message.cc
+++ b/libs/surfaces/websockets/message.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/message.h
+++ b/libs/surfaces/websockets/message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/mixer.cc
+++ b/libs/surfaces/websockets/mixer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/mixer.h
+++ b/libs/surfaces/websockets/mixer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/resources.cc
+++ b/libs/surfaces/websockets/resources.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/resources.h
+++ b/libs/surfaces/websockets/resources.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -195,6 +195,7 @@ WebsocketsServer::stop ()
 
 	if (_g_source) { // Method 3
 		g_source_destroy (_g_source);
+		lws_cancel_service (_lws_context);
 	}
 
 	if (_lws_context) {

--- a/libs/surfaces/websockets/server.cc
+++ b/libs/surfaces/websockets/server.cc
@@ -118,7 +118,7 @@ int
 WebsocketsServer::start ()
 {
 #ifndef NDEBUG
-	lws_set_log_level (LLL_ERR | LLL_WARN | LLL_DEBUG, 0);
+	lws_set_log_level (LLL_ERR | LLL_WARN /*| LLL_DEBUG*/, 0);
 #endif
 
 	if (_lws_context) {
@@ -235,7 +235,7 @@ WebsocketsServer::recv_client (Client wsi, void* buf, size_t len)
 		return 1;
 	}
 
-#ifndef NDEBUG
+#ifdef PRINT_TRAFFIC
 	std::cerr << "RX " << msg.state ().debug_str () << std::endl;
 #endif
 
@@ -274,7 +274,7 @@ WebsocketsServer::write_client (Client wsi)
 	int len = msg.serialize (out_buf + LWS_PRE, 1024 - LWS_PRE);
 
 	if (len > 0) {
-#ifndef NDEBUG
+#ifdef PRINT_TRAFFIC
 		std::cerr << "TX " << msg.state ().debug_str () << std::endl;
 #endif
 		if (lws_write (wsi, out_buf + LWS_PRE, len, LWS_WRITE_TEXT) != len) {

--- a/libs/surfaces/websockets/server.h
+++ b/libs/surfaces/websockets/server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/server.h
+++ b/libs/surfaces/websockets/server.h
@@ -112,8 +112,11 @@ private:
 
 	GSource* _g_source;
 
-	void            request_write ();
-	static gboolean glib_idle_callback (void *data);
+	static gboolean glib_idle_callback (void *);
+
+public:
+	bool should_request_write () { return _g_source != 0; }
+	void request_write ();
 
 };
 

--- a/libs/surfaces/websockets/state.cc
+++ b/libs/surfaces/websockets/state.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/state.h
+++ b/libs/surfaces/websockets/state.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/transport.cc
+++ b/libs/surfaces/websockets/transport.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/transport.h
+++ b/libs/surfaces/websockets/transport.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/typed_value.cc
+++ b/libs/surfaces/websockets/typed_value.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/typed_value.h
+++ b/libs/surfaces/websockets/typed_value.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/surfaces/websockets/typed_value.h
+++ b/libs/surfaces/websockets/typed_value.h
@@ -16,10 +16,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <string>
-
 #ifndef _ardour_surface_websockets_typed_value_h_
 #define _ardour_surface_websockets_typed_value_h_
+
+#include <string>
 
 namespace ArdourSurface {
 


### PR DESCRIPTION
Namely when the system has a build of libwebsockets installed which was not compiled with LWS_WITH_EXTERNAL_POLL enabled. Relevant link https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=977637

This is an issue for the combination of stock ardour and libwebsockets packages on Ubuntu 20.04, which is a popular distro. This patch should fix the issue for it and potentially for other distributions.
