### PR TITLE
Updates to #625

### DIFF
--- a/libs/surfaces/websockets/component.h
+++ b/libs/surfaces/websockets/component.h
@@ -53,7 +53,7 @@ public:
 	}
 
 	BasicUI&                     basic_ui () const;
-	PBD::EventLoop*              event_loop () const;
+	virtual PBD::EventLoop*      event_loop () const;
 	Glib::RefPtr<Glib::MainLoop> main_loop () const;
 	ARDOUR::Session&             session () const;
 	ArdourMixer&                 mixer () const;

--- a/libs/surfaces/websockets/feedback.cc
+++ b/libs/surfaces/websockets/feedback.cc
@@ -100,8 +100,11 @@ struct PluginParamValueObserver {
 };
 
 FeedbackHelperUI::FeedbackHelperUI()
-	: AbstractUI<BaseUI::BaseRequestObject> ("feedback_helper")
+	: AbstractUI<BaseUI::BaseRequestObject> ("WS_FeedbackHelperUI")
 {
+	char name[16];
+ 	snprintf (name, sizeof(name), "WS-%p", (void*)pthread_self ());
+ 	pthread_set_name (name);
 	set_event_loop_for_thread (this);
 }
 

--- a/libs/surfaces/websockets/feedback.cc
+++ b/libs/surfaces/websockets/feedback.cc
@@ -102,10 +102,7 @@ struct PluginParamValueObserver {
 FeedbackHelperUI::FeedbackHelperUI()
 	: AbstractUI<BaseUI::BaseRequestObject> ("feedback_helper")
 {
-	pthread_set_name ("test_ui_thread"); // FIXME - needed?
-	run_loop_thread = Glib::Threads::Thread::self ();
 	set_event_loop_for_thread (this);
-	ARDOUR::SessionEvent::create_per_thread_pool ("test", 512); // FIXME - needed?
 }
 
 void

--- a/libs/surfaces/websockets/feedback.cc
+++ b/libs/surfaces/websockets/feedback.cc
@@ -30,19 +30,8 @@
 // TO DO: make this configurable
 #define POLL_INTERVAL_MS 100
 
-#define OPTIONAL_CONNECT_HELPER(s,c) if (server ().should_request_write ()) \
-											s.connect (c, MISSING_INVALIDATOR, boost::bind<void> \
-											(ServerWriteObserver (), &server ()), &_helper);
-
 using namespace ARDOUR;
 using namespace ArdourSurface;
-
-struct ServerWriteObserver {
-	void operator() (WebsocketsServer *server)
-	{
-		server->request_write ();
-	}
-};
 
 struct TransportObserver {
 	void operator() (ArdourFeedback* p)
@@ -141,11 +130,11 @@ ArdourFeedback::start ()
 
 	// server must be started before feedback otherwise
 	// should_request_write() will always return false
-	if (!server ().should_request_write ()) {
-		periodic_timeout->attach (main_loop ()->get_context ());
-	} else {
+	if (server ().read_blocks_event_loop ()) {
 		_helper.run();
 		periodic_timeout->attach (_helper.main_loop()->get_context ());
+	} else {
+		periodic_timeout->attach (main_loop ()->get_context ());
 	}
 
 	return 0;
@@ -154,7 +143,7 @@ ArdourFeedback::start ()
 int
 ArdourFeedback::stop ()
 {
-	if (server ().should_request_write ()) {
+	if (server ().read_blocks_event_loop ()) {
 		_helper.quit();
 	}
 
@@ -207,6 +196,16 @@ ArdourFeedback::update_all (std::string node, uint32_t strip_id, uint32_t plugin
 	server ().update_all_clients (NodeState (node, addr, val), false);
 }
 
+PBD::EventLoop*
+ArdourFeedback::event_loop () const
+{
+	if (server ().read_blocks_event_loop ()) {
+		return static_cast<PBD::EventLoop*> (&_helper);
+	} else {
+		return SurfaceComponent::event_loop ();
+	}
+}
+
 bool
 ArdourFeedback::poll () const
 {
@@ -219,10 +218,6 @@ ArdourFeedback::poll () const
 		update_all (Node::strip_meter, it->first, db);
 	}
 
-	if (server ().should_request_write ()) {
-		server ().request_write ();
-	}
-
 	return true;
 }
 
@@ -232,15 +227,10 @@ ArdourFeedback::observe_transport ()
 	ARDOUR::Session& sess = session ();
 	sess.TransportStateChange.connect (_transport_connections, MISSING_INVALIDATOR,
 	                                   boost::bind<void> (TransportObserver (), this), event_loop ());
-	OPTIONAL_CONNECT_HELPER(sess.TransportStateChange, _transport_connections);
-
 	sess.RecordStateChanged.connect (_transport_connections, MISSING_INVALIDATOR,
 	                                 boost::bind<void> (RecordStateObserver (), this), event_loop ());
-	OPTIONAL_CONNECT_HELPER(sess.RecordStateChanged, _transport_connections);
-
 	sess.tempo_map ().PropertyChanged.connect (_transport_connections, MISSING_INVALIDATOR,
 	                                 boost::bind<void> (TempoObserver (), this), event_loop ());
-	OPTIONAL_CONNECT_HELPER(sess.tempo_map ().PropertyChanged, _transport_connections);
 }
 
 void
@@ -254,17 +244,14 @@ ArdourFeedback::observe_mixer ()
 
 		stripable->gain_control ()->Changed.connect (*it->second, MISSING_INVALIDATOR,
 		                                         boost::bind<void> (StripGainObserver (), this, strip_id), event_loop ());
-		OPTIONAL_CONNECT_HELPER(stripable->gain_control ()->Changed, *it->second);
 
 		if (stripable->pan_azimuth_control ()) {
 			stripable->pan_azimuth_control ()->Changed.connect (*it->second, MISSING_INVALIDATOR,
 			                                                boost::bind<void> (StripPanObserver (), this, strip_id), event_loop ());
-			OPTIONAL_CONNECT_HELPER(stripable->pan_azimuth_control ()->Changed, *it->second);
 		}
 
 		stripable->mute_control ()->Changed.connect (*it->second, MISSING_INVALIDATOR,
 		                                         boost::bind<void> (StripMuteObserver (), this, strip_id), event_loop ());
-		OPTIONAL_CONNECT_HELPER(stripable->mute_control ()->Changed, *it->second);
 	
 		observe_strip_plugins (strip_id, strip->plugins ());
 	}
@@ -284,7 +271,6 @@ ArdourFeedback::observe_strip_plugins (uint32_t strip_id, ArdourMixerStrip::Plug
 		if (control) {
 			control->Changed.connect (*plugin, MISSING_INVALIDATOR,
 			                          boost::bind<void> (PluginBypassObserver (), this, strip_id, plugin_id), event_loop ());
-			OPTIONAL_CONNECT_HELPER(control->Changed, *plugin);
 		}
 
 		for (uint32_t param_id = 0; param_id < plugin->param_count (); ++param_id) {
@@ -295,7 +281,6 @@ ArdourFeedback::observe_strip_plugins (uint32_t strip_id, ArdourMixerStrip::Plug
 				                          boost::bind<void> (PluginParamValueObserver (), this, strip_id, plugin_id, param_id,
 				                                             boost::weak_ptr<AutomationControl>(control)),
 				                          event_loop ());
-				OPTIONAL_CONNECT_HELPER(control->Changed, *plugin);
 			} catch (ArdourMixerNotFoundException& e) {
 				/* ignore */
 			}

--- a/libs/surfaces/websockets/feedback.h
+++ b/libs/surfaces/websockets/feedback.h
@@ -62,8 +62,10 @@ private:
 	PBD::ScopedConnectionList _transport_connections;
 	sigc::connection          _periodic_connection;
 
-	// Only needed for server event loop integration method 3
-	FeedbackHelperUI          _helper;
+	// Only needed for server event loop integration method #3
+	mutable FeedbackHelperUI  _helper;
+
+	PBD::EventLoop* event_loop () const override;
 
 	bool poll () const;
 

--- a/libs/surfaces/websockets/server.h
+++ b/libs/surfaces/websockets/server.h
@@ -75,6 +75,8 @@ private:
 	int send_availsurf_hdr (Client);
 	int send_availsurf_body (Client);
 
+	void request_write (Client);
+
 	static int lws_callback (struct lws*, enum lws_callback_reasons, void*, void*, size_t);
 
 	/* Glib event loop integration that requires LWS_WITH_EXTERNAL_POLL */
@@ -115,8 +117,7 @@ private:
 	static gboolean glib_idle_callback (void *);
 
 public:
-	bool should_request_write () { return _g_source != 0; }
-	void request_write ();
+	bool read_blocks_event_loop () { return _g_source != 0; }
 
 };
 

--- a/share/web_surfaces/builtin/mixer/js/main.js
+++ b/share/web_surfaces/builtin/mixer/js/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/mixer/js/main.js
+++ b/share/web_surfaces/builtin/mixer/js/main.js
@@ -22,8 +22,8 @@ import { createRootContainer, Container, Dialog, Label, Button, Toggle,
             AudioStripGainFader, MidiStripGainFader,
             AudioStripMeter, MidiStripMeter  } from './tkwidget.js';
 
-(() => {
-    
+{
+
     const ardour = new ArdourClient();
 
     async function main () {
@@ -223,4 +223,4 @@ import { createRootContainer, Container, Dialog, Label, Button, Toggle,
 
     main();
 
-})();
+}

--- a/share/web_surfaces/builtin/mixer/js/scale.js
+++ b/share/web_surfaces/builtin/mixer/js/scale.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/mixer/js/tkloader.js
+++ b/share/web_surfaces/builtin/mixer/js/tkloader.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/mixer/js/tkwidget.js
+++ b/share/web_surfaces/builtin/mixer/js/tkwidget.js
@@ -167,7 +167,7 @@ export class Dialog extends BaseDialog {
 
     show () {
         // opening a TK.Dialog with auto_close=true from a TK.Button callback 
-        // fails otherwise ev.stopPropagation() is called in the button event
+        // fails unless ev.stopPropagation() is called in the button event
         // handler or setTimeout() is used here
         setTimeout(() => {
             this.tk.set('display_state', 'show');

--- a/share/web_surfaces/builtin/mixer/js/tkwidget.js
+++ b/share/web_surfaces/builtin/mixer/js/tkwidget.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/mixer/js/widget.js
+++ b/share/web_surfaces/builtin/mixer/js/widget.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/protocol/main.js
+++ b/share/web_surfaces/builtin/protocol/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/protocol/main.js
+++ b/share/web_surfaces/builtin/protocol/main.js
@@ -18,7 +18,7 @@
 
 import ArdourClient from '/shared/ardour.js';
 
-(() => {
+{
 
     const MAX_LOG_LINES = 1000;
     
@@ -65,4 +65,4 @@ import ArdourClient from '/shared/ardour.js';
 
     main();
 
-})();
+}

--- a/share/web_surfaces/builtin/transport/main.js
+++ b/share/web_surfaces/builtin/transport/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/builtin/transport/main.js
+++ b/share/web_surfaces/builtin/transport/main.js
@@ -18,7 +18,7 @@
 
 import ArdourClient from '/shared/ardour.js';
 
-(() => {
+{
 
     const dom = {
         main       : document.getElementById('main'),
@@ -126,4 +126,4 @@ import ArdourClient from '/shared/ardour.js';
 
     main();
 
-})();
+}

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright (C) 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/index/main.js
+++ b/share/web_surfaces/index/main.js
@@ -18,7 +18,7 @@
 
 import ArdourClient from '/shared/ardour.js';
 
-(() => {
+{
 
     async function main () {
         try {
@@ -81,4 +81,4 @@ import ArdourClient from '/shared/ardour.js';
 
     main();
 
-})();
+}

--- a/share/web_surfaces/shared/ardour.js
+++ b/share/web_surfaces/shared/ardour.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/base/channel.js
+++ b/share/web_surfaces/shared/base/channel.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/base/component.js
+++ b/share/web_surfaces/shared/base/component.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/base/observable.js
+++ b/share/web_surfaces/shared/base/observable.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/base/protocol.js
+++ b/share/web_surfaces/shared/base/protocol.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/components/mixer.js
+++ b/share/web_surfaces/shared/components/mixer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/components/parameter.js
+++ b/share/web_surfaces/shared/components/parameter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/components/plugin.js
+++ b/share/web_surfaces/shared/components/plugin.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/components/strip.js
+++ b/share/web_surfaces/shared/components/strip.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/share/web_surfaces/shared/components/transport.js
+++ b/share/web_surfaces/shared/components/transport.js
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Luciano Iam <lucianito@gmail.com>
+ * Copyright © 2020 Luciano Iam <oss@lucianoiam.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Most importantly, 5407232 can be done without connecting twice to each Ardour signal. This now means a minor patch to the original (pre #625)`ArdourSurface::ArdourFeedback` class. Just overload `event_loop()` for that surface component and return the "helper UI" loop when the main surface loop is unsuitable due to the server component periodically blocking on it. Code is easier to follow and also marginally more efficient.

Also include some minor forgotten updates like updating the surface author email also for the JS file headers.
