### PR TITLE
Remove two obsolete prototypes from LV2Plugin

### DIFF
--- a/libs/ardour/ardour/lv2_plugin.h
+++ b/libs/ardour/ardour/lv2_plugin.h
@@ -138,8 +138,6 @@ class LIBARDOUR_API LV2Plugin : public ARDOUR::Plugin, public ARDOUR::Workee
 	void set_state_dir (const std::string& d = "");
 
 	int      set_state (const XMLNode& node, int version);
-	bool     save_preset (std::string uri);
-	void     remove_preset (std::string uri);
 	bool     load_preset (PresetRecord);
 	std::string current_preset () const;
 


### PR DESCRIPTION
`save_preset` and `remove_preset` were removed in 40c162d609, but the prototypes were left behind.

(Spotted while debugging another problem that turned out not to be Ardour's fault!)