### PR TITLE
Fix MIDI send latency compensation

### DIFF
--- a/libs/ardour/internal_send.cc
+++ b/libs/ardour/internal_send.cc
@@ -162,9 +162,9 @@ InternalSend::use_target (boost::shared_ptr<Route> sendto, bool update_name)
 	ensure_mixbufs ();
 	mixbufs.set_count (_send_to->internal_return ()->input_streams ());
 
-	_meter->configure_io (ChanCount (DataType::AUDIO, pan_outs ()), ChanCount (DataType::AUDIO, pan_outs ()));
+	_meter->configure_io (_send_to->internal_return ()->input_streams (), _send_to->internal_return ()->input_streams ());
 
-	_send_delay->configure_io (ChanCount (DataType::AUDIO, pan_outs ()), ChanCount (DataType::AUDIO, pan_outs ()));
+	_send_delay->configure_io (_send_to->internal_return ()->input_streams (), _send_to->internal_return ()->input_streams ());
 
 	reset_panner ();
 

--- a/libs/ardour/send.cc
+++ b/libs/ardour/send.cc
@@ -466,6 +466,9 @@ Send::can_support_io_configuration (const ChanCount& in, ChanCount& out)
 bool
 Send::configure_io (ChanCount in, ChanCount out)
 {
+	ChanCount send_count = in;
+	send_count.set(DataType::AUDIO, pan_outs());
+
 	if (!_amp->configure_io (in, out)) {
 		return false;
 	}
@@ -474,7 +477,7 @@ Send::configure_io (ChanCount in, ChanCount out)
 		return false;
 	}
 
-	if (!_meter->configure_io (ChanCount (DataType::AUDIO, pan_outs()), ChanCount (DataType::AUDIO, pan_outs()))) {
+	if (!_meter->configure_io (send_count, send_count)) {
 		return false;
 	}
 
@@ -482,7 +485,7 @@ Send::configure_io (ChanCount in, ChanCount out)
 		return false;
 	}
 
-	if (!_send_delay->configure_io (ChanCount (DataType::AUDIO, pan_outs()), ChanCount (DataType::AUDIO, pan_outs()))) {
+	if (!_send_delay->configure_io (send_count, send_count)) {
 		return false;
 	}
 


### PR DESCRIPTION
Send delays for MIDI were not working, resulting in a track setup like this:

* MIDI send -> non-latent bus
* MIDI send -> latent bus

...ending up with the non-latent bus playing earlier than it should.

This also fixes the send meters for MIDI sends, which suffered from the same problem.