### PR TITLE
Create add_cdmarker.lua

### DIFF
--- a/share/scripts/add_cdmarker.lua
+++ b/share/scripts/add_cdmarker.lua
@@ -1,0 +1,7 @@
+ardour { ["type"] = "EditorAction", name = "Add CD marker" }
+function 
+factory () 
+	return function () 
+		Editor:mouse_add_new_marker (Session:transport_sample(), true)
+	end 
+end


### PR DESCRIPTION
Allows for creation of CD markers using a keyboard shortcut (or one of the action buttons at the top right). Useful for while transport is rolling (as an alternative to TAB for generic marker) and for efficient and accurate placement at playhead without having to right-click then left-click on the ruler.