### PR TITLE
Allow track views to be more than 1000 pixels tall

### DIFF
--- a/gtk2_ardour/streamview.cc
+++ b/gtk2_ardour/streamview.cc
@@ -122,7 +122,7 @@ StreamView::set_height (double h)
 {
 	/* limit the values to something sane-ish */
 
-	if (h < 10.0 || h > 1000.0) {
+	if (h < 10.0 || h > 2500.0) {
 		return -1;
 	}
 


### PR DESCRIPTION
People have 4K displays these days; having a single maximized track is
not unusual.