### PR TITLE
Fix midi maps

### DIFF
--- a/share/midi_maps/AKAI_MIDIMix_EQ_Mode.map
+++ b/share/midi_maps/AKAI_MIDIMix_EQ_Mode.map
@@ -105,5 +105,5 @@
 
   <Binding channel="1" note="25" function="prev-bank"/>
   <Binding channel="1" note="26" function="next-bank"/>
-  <Binding channel="1" ctl="62"   uri="/bus/gain master"/>
+  <Binding channel="1" ctl="62"   uri="/bus/gain Master"/>
  </ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MIDIMix_Normal_Mode.map
+++ b/share/midi_maps/AKAI_MIDIMix_Normal_Mode.map
@@ -57,5 +57,5 @@
 
   <Binding channel="1" note="25" function="prev-bank"/>
   <Binding channel="1" note="26" function="next-bank"/>
-  <Binding channel="1" ctl="62"   uri="/bus/gain master"/>
+  <Binding channel="1" ctl="62"   uri="/bus/gain Master"/>
  </ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MPK249.MAP
+++ b/share/midi_maps/AKAI_MPK249.MAP
@@ -42,7 +42,7 @@
   <Binding channel="1" ctl="104" uri="/route/gain 23"/>
 
 <!-- Last Fader Binding On Control Bank C reserved for Master Bus  -->
-  <Binding channel="1" ctl="105" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="105" uri="/bus/gain Master"/>
 
 <!-- Encoder Knob bindings to Pan Direction -->
 
@@ -82,7 +82,7 @@
 <!-- Last Encoder Knob Binding On Control Bank C reserved for Master Bus  -->
 <!-- *Note Pan Direction doesn't work on Master Bus, mapped anyway for consistency  -->
 
-  <Binding channel="1" ctl="91" uri="/bus/pandirection master"/>
+  <Binding channel="1" ctl="91" uri="/bus/pandirection Master"/>
 
 
 <!-- MPK61 Solo Buttons mapped to Ardour track Solo -->
@@ -125,7 +125,7 @@
 <!-- Last Button Binding On Control Bank C reserved for Master Bus  -->
 <!-- This binding will mute the Master Bus since it has no Solo Function  -->
 
-  <Binding channel="1" ctl="113" uri="/bus/mute master"/>
+  <Binding channel="1" ctl="113" uri="/bus/mute Master"/>
 
 
 </ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MPK61.map
+++ b/share/midi_maps/AKAI_MPK61.map
@@ -40,7 +40,7 @@
   <Binding channel="1" ctl="104" uri="/route/gain 23"/>
 
 <!-- Last Fader Binding On Control Bank C reserved for Master Bus  -->
-  <Binding channel="1" ctl="105" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="105" uri="/bus/gain Master"/>
 
 <!-- Encoder Knob bindings to Pan Direction -->
 
@@ -80,7 +80,7 @@
 <!-- Last Encoder Knob Binding On Control Bank C reserved for Master Bus  -->
 <!-- *Note Pan Direction doesn't work on Master Bus, mapped anyway for consistency  -->
 
-  <Binding channel="1" ctl="91" uri="/bus/pandirection master"/>
+  <Binding channel="1" ctl="91" uri="/bus/pandirection Master"/>
 
 
 <!-- MPK61 Solo Buttons mapped to Ardour track Solo -->
@@ -123,7 +123,7 @@
 <!-- Last Button Binding On Control Bank C reserved for Master Bus  -->
 <!-- This binding will mute the Master Bus since it has no Solo Function  -->
 
-  <Binding channel="1" ctl="113" uri="/bus/mute master"/>
+  <Binding channel="1" ctl="113" uri="/bus/mute Master"/>
 
 
 </ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MPKmini.map
+++ b/share/midi_maps/AKAI_MPKmini.map
@@ -13,8 +13,8 @@
 
 <!-- Knobs mapped to Ardour Faders - Control Bank A  -->
 
-	<Binding channel="16" ctl="1" uri="/bus/gain master"/>
-	<Binding channel="16" ctl="5" uri="/bus/panwidth master"/>
+	<Binding channel="16" ctl="1" uri="/bus/gain Master"/>
+	<Binding channel="16" ctl="5" uri="/bus/panwidth Master"/>
 
 	<Binding channel="16" ctl="2" uri="/route/gain B1"/>
 	<Binding channel="16" ctl="3" uri="/route/gain B2"/>

--- a/share/midi_maps/Arturia_KeyLab49.map
+++ b/share/midi_maps/Arturia_KeyLab49.map
@@ -13,7 +13,7 @@
   <Binding channel="1" ctl="81" uri="/route/gain B6"/>
   <Binding channel="1" ctl="82" uri="/route/gain B7"/>
   <Binding channel="1" ctl="83" uri="/route/gain B8"/>
-  <Binding channel="1" ctl="85" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="85" uri="/bus/gain Master"/>
 
 <!-- Pan controls. All encoders except the 2 on the right are mapped to pan direction. -->
   <Binding channel="1" enc-b="74" uri="/route/pandirection B1"/>

--- a/share/midi_maps/DDX3216.map
+++ b/share/midi_maps/DDX3216.map
@@ -87,7 +87,7 @@
 
 <!-- Master bus controlled by the "MAIN" fader on the DDX3216 -->
 
-  <Binding channel="1"  ctl="61"  uri="/bus/gain master"  />
+  <Binding channel="1"  ctl="61"  uri="/bus/gain Master"  />
 
 <!-- Pan commented out for now - the 16 Busses have no pan controls on ddx3216 -->
 

--- a/share/midi_maps/Korg_nanoKONTROL2_With_Master.map
+++ b/share/midi_maps/Korg_nanoKONTROL2_With_Master.map
@@ -80,10 +80,10 @@
   <!--the "Mute" as intended and the "REC" is not used 		 -->
   
   
-  <Binding channel="1" ctl="23" uri="/bus/panwidth master"/>
+  <Binding channel="1" ctl="23" uri="/bus/panwidth Master"/>
   <Binding channel="1" ctl="39" action="Common/toggle-editor-and-mixer"/>
-  <Binding channel="1" ctl="55" uri="/bus/mute master"/>
-  <Binding channel="1" ctl="7"  uri="/bus/gain master"/>
+  <Binding channel="1" ctl="55" uri="/bus/mute Master"/>
+  <Binding channel="1" ctl="7"  uri="/bus/gain Master"/>
 
 
 </ArdourMIDIBindings>

--- a/share/midi_maps/Korg_nanoKONTROL_Master.map
+++ b/share/midi_maps/Korg_nanoKONTROL_Master.map
@@ -88,10 +88,10 @@
   <Binding channel="1" ctl="12" uri="/route/gain B8"/>
 
 <!-- Strip 9 : Master -->
-  <Binding channel="1" ctl="22" uri="/bus/panwidth master"/>
+  <Binding channel="1" ctl="22" uri="/bus/panwidth Master"/>
   <Binding channel="1" ctl="31" action="Common/toggle-mixer-on-top"/>
-  <Binding channel="1" ctl="41" uri="/bus/mute master"/>
-  <Binding channel="1" ctl="13" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="41" uri="/bus/mute Master"/>
+  <Binding channel="1" ctl="13" uri="/bus/gain Master"/>
 
 
 </ArdourMIDIBindings>

--- a/share/midi_maps/Korg_nanoKONTROL_Studio.map
+++ b/share/midi_maps/Korg_nanoKONTROL_Studio.map
@@ -110,12 +110,12 @@ AH8A//8QADwAfwD//xAAPQB/AP///////////////////////wAEAlJTVVYAf///////////////
 <!-- Select unassigned														-->
 <!-- Rotary encoder assigned to Master Pan Width (easy to audition in mono!)-->
 <!-- Fader assigned to Master Gain 											-->
-	<Binding channel="1" ctl="21" uri="/bus/mute master"/>
+	<Binding channel="1" ctl="21" uri="/bus/mute Master"/>
 	<Binding channel="1" ctl="29" function="transport-start"/>
 	<Binding channel="1" ctl="38" function="transport-end"/>	
 	<Binding channel="1" ctl="46" action="Transport/RecordCountIn"/>
-	<Binding channel="1" ctl="13" uri="/bus/panwidth master"/>
-	<Binding channel="1" ctl="2" uri="/bus/gain master"/>
+	<Binding channel="1" ctl="13" uri="/bus/panwidth Master"/>
+	<Binding channel="1" ctl="2" uri="/bus/gain Master"/>
 
 <!-- Strip 2 : Selected track -->
 <!-- Mute assigned to Mute							                        -->

--- a/share/midi_maps/M-Audio_Axiom61.map
+++ b/share/midi_maps/M-Audio_Axiom61.map
@@ -14,7 +14,7 @@
   <Binding channel="1" ctl="72" uri="/route/gain 6"/>
   <Binding channel="1" ctl="5" uri="/route/gain 7"/>
   <Binding channel="1" ctl="84" uri="/route/gain 8"/>
-  <Binding channel="1" ctl="7" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="7" uri="/bus/gain Master"/>
 
 <!-- Zone/Group buttons, below the faders -->
 <!-- these toggle Mute for the corresponding tracks (1-8) and Master -->
@@ -27,7 +27,7 @@
   <Binding channel="1" pgm="5" uri="/route/mute 6"/>
   <Binding channel="1" pgm="6" uri="/route/mute 7"/>
   <Binding channel="1" pgm="7" uri="/route/mute 8"/>
-  <Binding channel="1" pgm="8" uri="/bus/mute master"/>"
+  <Binding channel="1" pgm="8" uri="/bus/mute Master"/>"
 
 <!-- Encoders, mapped to pan direction. -->
 

--- a/share/midi_maps/M-Audio_Axiom_AIR_Mini_32.map
+++ b/share/midi_maps/M-Audio_Axiom_AIR_Mini_32.map
@@ -54,7 +54,7 @@
 -->
 
   <!-- Knob, mapped to gain faders -->
-  <Binding channel="1" ctl="1" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="1" uri="/bus/gain Master"/>
   <Binding channel="1" ctl="2" uri="/route/gain 1"/>
   <Binding channel="1" ctl="3" uri="/route/gain 2"/>
   <Binding channel="1" ctl="4" uri="/route/gain 3"/>

--- a/share/midi_maps/M-Audio_Oxygen49.map
+++ b/share/midi_maps/M-Audio_Oxygen49.map
@@ -20,7 +20,7 @@
   <Binding channel="16" ctl="38" uri="/route/gain 6"/>
   <Binding channel="16" ctl="39" uri="/route/gain 7"/>
   <Binding channel="16" ctl="40" uri="/route/gain 8"/>
-  <Binding channel="16" ctl="41" uri="/bus/gain master"/>
+  <Binding channel="16" ctl="41" uri="/bus/gain Master"/>
 
 <!-- Pan controls. Encoders are mapped to pan direction. -->
   <Binding channel="16" ctl="21" uri="/route/pandirection 1"/>
@@ -43,7 +43,7 @@
   <Binding channel="16" ctl="54" uri="/route/solo 6"/>
   <Binding channel="16" ctl="55" uri="/route/solo 7"/>
   <Binding channel="16" ctl="56" uri="/route/solo 8"/>
-  <Binding channel="16" ctl="57" uri="/bus/mute master"/>"
+  <Binding channel="16" ctl="57" uri="/bus/mute Master"/>"
   
 </ArdourMIDIBindings>
 

--- a/share/midi_maps/M-Audio_Oxygen61v3.map
+++ b/share/midi_maps/M-Audio_Oxygen61v3.map
@@ -12,7 +12,7 @@
   <Binding channel="1" ctl="72" uri="/route/gain 6"/>
   <Binding channel="1" ctl="5" uri="/route/gain 7"/>
   <Binding channel="1" ctl="84" uri="/route/gain 8"/>
-  <Binding channel="1" ctl="7" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="7" uri="/bus/gain Master"/>
 
   <!-- Buttons below the faders, mapped to track mute 1-8 and Master -->
   <Binding channel="1" pgm="0" uri="/route/mute 1"/>
@@ -23,7 +23,7 @@
   <Binding channel="1" pgm="5" uri="/route/mute 6"/>
   <Binding channel="1" pgm="6" uri="/route/mute 7"/>
   <Binding channel="1" pgm="7" uri="/route/mute 8"/>
-  <Binding channel="1" pgm="8" uri="/bus/mute master"/>
+  <Binding channel="1" pgm="8" uri="/bus/mute Master"/>
 
   <!-- Encoders, mapped to pan direction -->
   <Binding channel="1" ctl="75" uri="/route/pandirection 1"/>

--- a/share/midi_maps/Nektar_Panorama.map
+++ b/share/midi_maps/Nektar_Panorama.map
@@ -16,7 +16,7 @@
   <Binding channel="1" ctl="45" uri="/route/gain B6"/>
   <Binding channel="1" ctl="46" uri="/route/gain B7"/>
   <Binding channel="1" ctl="47" uri="/route/gain B8"/>
-  <Binding channel="1" ctl="3" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="3" uri="/bus/gain Master"/>
 
 <!-- Buttons below the faders mapped to Mute-->
   <Binding channel="1" ctl="56" uri="/route/mute B1" momentary="yes"/>

--- a/share/midi_maps/Novation Impulse 49.map
+++ b/share/midi_maps/Novation Impulse 49.map
@@ -22,7 +22,7 @@
   <Binding channel="1" ctl="114" uri="/route/gain 6"/>
   <Binding channel="1" ctl="115" uri="/route/gain 7"/>
   <Binding channel="1" ctl="116" uri="/route/gain 8"/>
-  <Binding channel="1" ctl="117" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="117" uri="/bus/gain Master"/>
 
 <!-- Pan controls. Encoders are mapped to pan direction. -->
 <!-- There doesn't seem to be a way to map encoders to pan width. -->

--- a/share/midi_maps/Novation_Impulse61.map
+++ b/share/midi_maps/Novation_Impulse61.map
@@ -23,7 +23,7 @@
   <Binding channel="1" ctl="46" uri="/route/gain 6"/>
   <Binding channel="1" ctl="47" uri="/route/gain 7"/>
   <Binding channel="1" ctl="48" uri="/route/gain 8"/>
-  <Binding channel="1" ctl="49" uri="/bus/gain master"/>
+  <Binding channel="1" ctl="49" uri="/bus/gain Master"/>
 
 <!-- Pan controls. Encoders are mapped to pan direction. -->
 <!-- There doesn't seem to be a way to map encoders to pan width. -->
@@ -49,7 +49,7 @@
   <Binding channel="1" ctl="56" uri="/route/mute 6"/>
   <Binding channel="1" ctl="57" uri="/route/mute 7"/>
   <Binding channel="1" ctl="58" uri="/route/mute 8"/>
-  <Binding channel="1" ctl="59" uri="/bus/mute master"/>"
+  <Binding channel="1" ctl="59" uri="/bus/mute Master"/>"
 
 
 </ArdourMIDIBindings>

--- a/share/midi_maps/Novation_LaunchKey49.map
+++ b/share/midi_maps/Novation_LaunchKey49.map
@@ -25,7 +25,7 @@
 <Binding channel="1" ctl="46" uri="/route/gain B6"/>
 <Binding channel="1" ctl="47" uri="/route/gain B7"/>
 <Binding channel="1" ctl="48" uri="/route/gain B8"/>
-<Binding channel="1" ctl="7" uri="/bus/gain master"/>
+<Binding channel="1" ctl="7" uri="/bus/gain Master"/>
 
 <!-- Pan controls. Encoders are mapped to pan direction. -->
 <!-- There doesn't seem to be a way to map encoders to pan width. -->
@@ -54,7 +54,7 @@
 <Binding channel="1" ctl="56" uri="/route/solo B6"/>
 <Binding channel="1" ctl="57" uri="/route/solo B7"/>
 <Binding channel="1" ctl="58" uri="/route/solo B8"/>
-<Binding channel="1" ctl="59" uri="/bus/mute master"/>"
+<Binding channel="1" ctl="59" uri="/bus/mute Master"/>"
 
 <!-- Bank Control -->
 

--- a/share/midi_maps/Roland_SI-24.map
+++ b/share/midi_maps/Roland_SI-24.map
@@ -18,7 +18,7 @@
 	<Binding channel="1" ctl="9" uri="/route/gain B10"/>
 	<Binding channel="1" ctl="10" uri="/route/gain B11"/>
 	<Binding channel="1" ctl="11" uri="/route/gain B12"/>
-	<Binding channel="1" ctl="12" uri="/bus/gain master"/>
+	<Binding channel="1" ctl="12" uri="/bus/gain Master"/>
 
 <!--	<Binding channel="1" ctl="13" uri=""/>		SURROUND PAN left/right (0 through 127, respectively)	-->
 <!--	<Binding channel="1" ctl="14" uri=""/>		SURROUND PAN up/down (127 through 0, respectively)	-->

--- a/share/midi_maps/Roland_V_Studio_20.map
+++ b/share/midi_maps/Roland_V_Studio_20.map
@@ -35,6 +35,6 @@
 <Binding channel="8" pb="0"   uri="/route/gain B8"/>
 
 <!-- Gain controls -->
-<Binding channel="9" pb="0" uri="/bus/gain master"/>
+<Binding channel="9" pb="0" uri="/bus/gain Master"/>
 
 </ArdourMIDIBindings>

--- a/share/midi_maps/akai-mpd-32.map
+++ b/share/midi_maps/akai-mpd-32.map
@@ -22,7 +22,7 @@
 
   <!-- Unused
   Set master volume fader
-  <Binding channel="16" ctl="41" uri="/bus/gain master"/>
+  <Binding channel="16" ctl="41" uri="/bus/gain Master"/>
   -->
 
   <!-- Set faders -->
@@ -79,7 +79,7 @@
 
   <!-- Unused
   Set master mute button
-  <Binding channel="16" ctl="57" uri="/bus/mute master"/>
+  <Binding channel="16" ctl="57" uri="/bus/mute Master"/>
   -->
 
   <!-- Set mute buttons beneath faders to correspond to banks --> 

--- a/share/midi_maps/bcf2000.map
+++ b/share/midi_maps/bcf2000.map
@@ -119,7 +119,7 @@
 <Binding channel="11" pgm="48"                   uri="/route/recenable B8"/>
 
 <!-- expression pedal to master bus gain -->
-<Binding channel="11" ctl="7"                    uri="/bus/gain master"/>
+<Binding channel="11" ctl="7"                    uri="/bus/gain Master"/>
 <!-- footswitch pedal to rec-enable; this will work for punch-in, but not punch-out -->
 <Binding sysex="f0 7f 7f 6 6 f7"                 function="rec-enable"/>
 

--- a/share/midi_maps/bcf2000_mackie.map
+++ b/share/midi_maps/bcf2000_mackie.map
@@ -94,7 +94,7 @@
 <Binding channel="1"  note="39"                  uri="/route/recenable B8"/>
 
 <!-- expression pedal to master bus gain -->
-<!-- <Binding channel="11" ctl="7"                    uri="/bus/gain master"/> -->
+<!-- <Binding channel="11" ctl="7"                    uri="/bus/gain Master"/> -->
 <!-- footswitch pedal to rec-enable; this will work for punch-in, but not punch-out -->
 <!-- <Binding sysex="f0 7f 7f 6 6 f7"                 function="rec-enable"/> -->
 

--- a/share/midi_maps/m-audio-oxygen61v3.map
+++ b/share/midi_maps/m-audio-oxygen61v3.map
@@ -20,7 +20,7 @@
   <Binding channel="16" ctl="118" function="rec-disable"/>
 
   <!-- Set master volume fader, this is far right most fader labelled C9 and is master volume on all banks by default -->
-  <Binding channel="16" ctl="41" uri="/bus/gain master"/>
+  <Binding channel="16" ctl="41" uri="/bus/gain Master"/>
 
   <!-- Set faders 1-8 to corresponding banks -->
   <Binding channel="16" ctl="33" uri="/route/gain 1"/>
@@ -43,7 +43,7 @@
   <Binding channel="16" ctl="24" uri="/route/plugin/parameter B1 1 8"/>
  
   <!-- Set master mute button -->
-  <Binding channel="16" ctl="57" uri="/bus/mute master"/>
+  <Binding channel="16" ctl="57" uri="/bus/mute Master"/>
 
   <!-- Set mute buttons beneath faders to correspond to banks --> 
   <Binding channel="16" ctl="49" uri="/route/mute B1"/>    

--- a/share/midi_maps/xboard-61.map
+++ b/share/midi_maps/xboard-61.map
@@ -29,11 +29,11 @@ NOTE:	I have assumed that the top row knobs are mapped to midi
 <!--
 	Xboard data entry slider / master vol  #!! or FF/REV? bank select?
 -->
-	<!--Binding sysex="f0 7f 7f 4 1 75 2b f7" uri="/bus/gain master" /-->
+	<!--Binding sysex="f0 7f 7f 4 1 75 2b f7" uri="/bus/gain Master" /-->
 
 <!-- 
 -->
-	<Binding channel="1" ctl="1" uri="/bus/gain master" />
+	<Binding channel="1" ctl="1" uri="/bus/gain Master" />
 
 <!-- 
 	Xboard knobs 1-8 top row


### PR DESCRIPTION
Master bus reference was incorrect (lowercased), so connections between control surface and DAW controls didn't work for master bus. This pull request fixes all the predefined configurations. Tested for nanoKONTROL2 with Master preset.