### PR TITLE
Fix mime package install location

### DIFF
--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -882,7 +882,7 @@ def build(bld):
         obj.source       = 'ardour-mime-info.xml'
         obj.target       = 'ardour.xml'
         obj.chmod        = Utils.O644
-        bld.install_files (os.path.join (bld.env['PREFIX'], 'share/mime/application'), 'ardour' + '.xml')
+        bld.install_files (os.path.join (bld.env['PREFIX'], 'share/mime/packages'), obj.target)
 
         # build appdata with translations
         appdata_i18n_mo(bld)


### PR DESCRIPTION
`<prefix>/share/mime/applications` gets clobbered with data from `<prefix>/share/mime/packages/*.xml` every time "update-mime-database" is run.