### PR TITLE
Typo in code and comments paramater

### DIFF
--- a/gtk2_ardour/plugin_eq_gui.cc
+++ b/gtk2_ardour/plugin_eq_gui.cc
@@ -407,7 +407,7 @@ PluginEqGui::run_impulse_analysis ()
 	/* run at most at session's block size chunks.
 	 *
 	 * This is important since VSTs may call audioMasterGetBlockSize
-	 * or access various other /real/ session paramaters using the
+	 * or access various other /real/ session parameters using the
 	 * audioMasterCallback
 	 */
 	samplecnt_t block_size = ARDOUR_UI::instance()->the_session()->get_block_size();

--- a/libs/surfaces/mackie/strip.cc
+++ b/libs/surfaces/mackie/strip.cc
@@ -682,7 +682,7 @@ Strip::handle_button (Button& button, ButtonState bs)
 }
 
 std::string
-Strip::format_paramater_for_display(
+Strip::format_parameter_for_display(
 		ARDOUR::ParameterDescriptor const& desc,
 		float val,
 		boost::shared_ptr<ARDOUR::Stripable> stripable_for_non_mixbus_azimuth_automation,
@@ -736,7 +736,7 @@ Strip::format_paramater_for_display(
 void
 Strip::do_parameter_display (ARDOUR::ParameterDescriptor const& desc, float val, bool screen_hold)
 {
-	pending_display[1] = format_paramater_for_display(desc, val, _stripable, screen_hold);
+	pending_display[1] = format_parameter_for_display(desc, val, _stripable, screen_hold);
 
 	if (screen_hold) {
 		/* we just queued up a parameter to be displayed.

--- a/libs/surfaces/mackie/strip.h
+++ b/libs/surfaces/mackie/strip.h
@@ -94,7 +94,7 @@ public:
 	MidiByteArray display (uint32_t lcd_number, uint32_t line_number, const std::string&);
 	MidiByteArray blank_display (uint32_t lcd_number, uint32_t line_number);
 	
-	static std::string format_paramater_for_display(
+	static std::string format_parameter_for_display(
 		ARDOUR::ParameterDescriptor const& desc, 
 		float val, 
 		boost::shared_ptr<ARDOUR::Stripable> stripable_for_non_mixbus_azimuth_automation, 

--- a/libs/surfaces/mackie/subview.cc
+++ b/libs/surfaces/mackie/subview.cc
@@ -225,7 +225,7 @@ Subview::retrieve_pointers(Strip** strip, Pot** vpot, std::string** pending_disp
 
 void Subview::do_parameter_display(std::string& display, const ParameterDescriptor& pd, float param_val, Strip* strip, bool screen_hold)
 {
-	display = Strip::format_paramater_for_display(
+	display = Strip::format_parameter_for_display(
 			pd,
 			param_val,
 			strip->stripable(),

--- a/share/scripts/s_thin_automation.lua
+++ b/share/scripts/s_thin_automation.lua
@@ -2,7 +2,7 @@ ardour { ["type"] = "Snippet", name = "Thin Fader Automation" }
 
 -- --TODO--
 -- For a fully fledged EditorAction this script should
--- offer a dropdown to select automation of all paramaters
+-- offer a dropdown to select automation of all parameters
 -- (not just the fader)
 -- see scripts/midi_cc_to_automation.lua and
 -- scripts/mixer_settings_store.lua

--- a/share/scripts/s_track_props.lua
+++ b/share/scripts/s_track_props.lua
@@ -32,7 +32,7 @@ function factory () return function ()
 
 			-- unmute the track, this also examplifies how one could use lists to modify
 			-- multiple controllables at the same time (they should be of the same
-			-- paramater type - e.g. mute_control() of multiple tracks, they'll all
+			-- parameter type - e.g. mute_control() of multiple tracks, they'll all
 			-- change simultaneously in rt-context)
 			local ctrls = ARDOUR.ControlListPtr ()
 			ctrls:push_back (t:mute_control()) -- we could add more controls to change via push_back


### PR DESCRIPTION
paramater / parameter
In C code, Lua code and comments.  Searched through the whole repo, but not tested ...
It is a tiny subset of #627 !  Eventually, I could slowly distill #627 in separate PR as they are merged. If code is impacted I could build the thing but I guess some kind of automation rebuilds Ardour for each commit
