### PR TITLE
fix NSM wrong behavior, now ardour JACK client name is named as the N…

### DIFF
--- a/gtk2_ardour/ardour_ui_startup.cc
+++ b/gtk2_ardour/ardour_ui_startup.cc
@@ -733,7 +733,7 @@ ARDOUR_UI::load_from_application_api (const std::string& path)
 	}
 
 	if (nsm) {
-		if (!AudioEngine::instance()->set_backend("JACK", "", "")) {
+		if (!AudioEngine::instance()->set_backend("JACK", ARDOUR_COMMAND_LINE::backend_client_name, "")) {
 			error << _("NSM: The JACK backend is mandatory and can not be loaded.") << endmsg;
 			return;
 		}

--- a/libs/backends/jack/jack_api.cc
+++ b/libs/backends/jack/jack_api.cc
@@ -58,7 +58,7 @@ instantiate (const std::string& arg1, const std::string& arg2)
 {
 	try {
 		jack_connection.reset (new JackConnection (arg1, arg2));
-        backend.reset ();
+		backend.reset ();
 	} catch (...) {
 		return -1;
 	}

--- a/libs/backends/jack/jack_api.cc
+++ b/libs/backends/jack/jack_api.cc
@@ -58,6 +58,7 @@ instantiate (const std::string& arg1, const std::string& arg2)
 {
 	try {
 		jack_connection.reset (new JackConnection (arg1, arg2));
+        backend.reset ();
 	} catch (...) {
 		return -1;
 	}


### PR DESCRIPTION
…SM server asks to in /nsm/client/open message

Very very few code compared to search time ;)

There was a problem in the ardour jack backend lib, reset a new JackConnection in jack_api (connection to jack server, nothing to see with a jack connection between jack ports) didn't update the jack_connection in jack_audiobackend.
I am not sure that backend.reset() is the right thing to do, but it works, please say.