### PR TITLE
Nsm switch new2 (rebased)

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,4 +1,0 @@
-[Dolphin]
-Timestamp=2021,12,2,14,28,56
-Version=4
-ViewMode=1

--- a/.directory
+++ b/.directory
@@ -1,0 +1,4 @@
+[Dolphin]
+Timestamp=2021,12,2,14,28,56
+Version=4
+ViewMode=1

--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -369,6 +369,7 @@ ARDOUR_UI::ARDOUR_UI (int *argcp, char **argvp[], const char* localedir)
 	, prefs_visibility_button (S_("Window|Prefs"))
 	, recorder_visibility_button (S_("Window|Rec"))
 	, trigger_page_visibility_button (S_("Window|Trig"))
+	, nsm_first_session_opened (false)
 {
 	Gtkmm2ext::init (localedir);
 

--- a/gtk2_ardour/ardour_ui.h
+++ b/gtk2_ardour/ardour_ui.h
@@ -238,7 +238,7 @@ public:
 	int load_session_from_startup_fsm ();
 
 	/// @return true if session was successfully unloaded.
-	int unload_session (bool hide_stuff = false);
+	int unload_session (bool hide_stuff = false, bool force_unload = false);
 	void close_session();
 
 	int  save_state_canfail (std::string state_name = "", bool switch_to_it = false);
@@ -927,6 +927,7 @@ private:
 	void action_script_changed (int i, const std::string&);
 
 	void ask_about_scratch_deletion ();
+	bool nsm_first_session_opened;
 };
 
 #endif /* __ardour_gui_h__ */

--- a/gtk2_ardour/ardour_ui_dialogs.cc
+++ b/gtk2_ardour/ardour_ui_dialogs.cc
@@ -287,7 +287,7 @@ ARDOUR_UI::set_session (Session *s)
 }
 
 int
-ARDOUR_UI::unload_session (bool hide_stuff)
+ARDOUR_UI::unload_session (bool hide_stuff, bool force_unload)
 {
 	if (_session) {
 		ARDOUR_UI::instance()->video_timeline->sync_session_state();
@@ -303,7 +303,7 @@ ARDOUR_UI::unload_session (bool hide_stuff)
 		save_ardour_state ();
 	}
 
-	if (_session && _session->dirty()) {
+	if (!force_unload && _session && _session->dirty()) {
 		std::vector<std::string> actions;
 		actions.push_back (_("Don't close"));
 		if (_session->unnamed()) {

--- a/gtk2_ardour/ardour_ui_startup.cc
+++ b/gtk2_ardour/ardour_ui_startup.cc
@@ -428,7 +428,7 @@ ARDOUR_UI::nsm_init ()
 	 * The wrapper startup script should set the environment variable 'ARDOUR_SELF'
 	 */
 	const char *process_name = g_getenv ("ARDOUR_SELF");
-	nsm->announce (PROGRAM_NAME, ":dirty:", process_name ? process_name : "ardour6");
+	nsm->announce (PROGRAM_NAME, ":dirty:switch:", process_name ? process_name : "ardour7");
 
 	unsigned int i = 0;
 	// wait for announce reply from nsm server
@@ -751,7 +751,9 @@ ARDOUR_UI::load_from_application_api (const std::string& path)
 	}
 
 	if (nsm) {
-		if (!AudioEngine::instance()->set_backend("JACK", "", "")) {
+		unload_session(false, true);
+
+		if (!AudioEngine::instance()->set_backend("JACK", ARDOUR_COMMAND_LINE::backend_client_name, "")) {
 			error << _("NSM: The JACK backend is mandatory and can not be loaded.") << endmsg;
 			return;
 		}
@@ -775,10 +777,13 @@ ARDOUR_UI::load_from_application_api (const std::string& path)
 			}
 		}
 
-		PluginScanDialog psd (true, false);
-		psd.start ();
+		if (! nsm_first_session_opened){
+			PluginScanDialog psd (true, false);
+			psd.start ();
 
-		post_engine ();
+			post_engine ();
+			_nsm_first_session_opened = true;
+		}
 	}
 
 	/* the mechanisms that can result is this being called are only

--- a/gtk2_ardour/ardour_ui_startup.cc
+++ b/gtk2_ardour/ardour_ui_startup.cc
@@ -782,7 +782,7 @@ ARDOUR_UI::load_from_application_api (const std::string& path)
 			psd.start ();
 
 			post_engine ();
-			_nsm_first_session_opened = true;
+			nsm_first_session_opened = true;
 		}
 	}
 

--- a/gtk2_ardour/nsm.cc
+++ b/gtk2_ardour/nsm.cc
@@ -50,6 +50,7 @@ NSM_Client::command_open(const char* name,
 	int r = ERR_OK;
 
 	ARDOUR_COMMAND_LINE::backend_client_name = client_id;
+	ARDOUR_COMMAND_LINE::session_name = "";
 
 	/* this appears asynchronous, but almost certainly is
 	 * synchronous. However, there's no return value available.

--- a/libs/backends/jack/jack_api.cc
+++ b/libs/backends/jack/jack_api.cc
@@ -58,6 +58,7 @@ instantiate (const std::string& arg1, const std::string& arg2)
 {
 	try {
 		jack_connection.reset (new JackConnection (arg1, arg2));
+		backend.reset ();
 	} catch (...) {
 		return -1;
 	}


### PR DESCRIPTION
This PR superseeds #650 , it enables NSM :switch: capability which allows to open an other session without closing ardour.

this is the same as #651 , with master updated because of conflicts.

Of course, the JACK client is totally removed and recreated with the new client name.

I added the private bool _nsm_first_session_opened to ARDOUR_UI, to prevent to re-scan plugins if the session to open is not the first one.

I added a bool 'force_unload' optional argument to unload_session(), to prevent warning message in cases of changes in the session while switching from NSM. At NSM switch, the ardour session is saved, and then, at a moment we can't determinate (but very few time after*), the other session is loaded.

It seems to work very well, I have not encountered any problems.