### PR TITLE
Midi maps for Akai MPK225

### DIFF
--- a/share/midi_maps/AKAI_MPK225_Normal.map
+++ b/share/midi_maps/AKAI_MPK225_Normal.map
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="Akai MPK 225 (Normal) : preset 6">
+<DeviceInfo bank-size="12"/>
+
+<!-- NOTE : use preset 6 to enable these -->
+
+<!-- solos -->
+<Binding channel="2" ctl="28" uri="/route/solo B1"/>
+<Binding channel="2" ctl="29" uri="/route/solo B2"/>
+<Binding channel="2" ctl="30" uri="/route/solo B3"/>
+<Binding channel="2" ctl="31" uri="/route/solo B4"/>
+<Binding channel="2" ctl="75" uri="/route/solo B5"/>
+<Binding channel="2" ctl="76" uri="/route/solo B6"/>
+<Binding channel="2" ctl="77" uri="/route/solo B7"/>
+<Binding channel="2" ctl="78" uri="/route/solo B8"/>
+<Binding channel="2" ctl="106" uri="/route/solo B9"/>
+<Binding channel="2" ctl="107" uri="/route/solo B10"/>
+<Binding channel="2" ctl="108" uri="/route/solo B11"/>
+<Binding channel="2" ctl="109" uri="/route/solo B12"/>
+
+<!-- pandirection -->
+<Binding channel="2" enc-2="50" uri="/route/pandirection B1"/>
+<Binding channel="2" enc-2="51" uri="/route/pandirection B2"/>
+<Binding channel="2" enc-2="52" uri="/route/pandirection B3"/>
+<Binding channel="2" enc-2="53" uri="/route/pandirection B4"/>
+<Binding channel="3" enc-2="50" uri="/route/pandirection B5"/>
+<Binding channel="3" enc-2="51" uri="/route/pandirection B6"/>
+<Binding channel="3" enc-2="52" uri="/route/pandirection B7"/>
+<Binding channel="3" enc-2="53" uri="/route/pandirection B8"/>
+<Binding channel="4" enc-2="50" uri="/route/pandirection B9"/>
+<Binding channel="4" enc-2="51" uri="/route/pandirection B10"/>
+<Binding channel="4" enc-2="52" uri="/route/pandirection B11"/>
+<Binding channel="4" enc-2="53" uri="/route/pandirection B12"/>
+
+<!-- gain -->
+<Binding channel="2" enc-2="54" uri="/route/gain B1"/>
+<Binding channel="2" enc-2="55" uri="/route/gain B2"/>
+<Binding channel="2" enc-2="56" uri="/route/gain B3"/>
+<Binding channel="2" enc-2="57" uri="/route/gain B4"/>
+<Binding channel="3" enc-2="54" uri="/route/gain B5"/>
+<Binding channel="3" enc-2="55" uri="/route/gain B6"/>
+<Binding channel="3" enc-2="56" uri="/route/gain B7"/>
+<Binding channel="3" enc-2="57" uri="/route/gain B8"/>
+<Binding channel="4" enc-2="54" uri="/route/gain B9"/>
+<Binding channel="4" enc-2="55" uri="/route/gain B10"/>
+<Binding channel="4" enc-2="56" uri="/route/gain B11"/>
+<Binding channel="4" enc-2="57" uri="/route/gain B12"/>
+
+
+<!-- Transport -->
+<Binding channel="1" ctl="115" action="Transport/Rewind"/>
+<Binding channel="1" ctl="116" action="Transport/Forward"/>
+<Binding channel="1" ctl="117" function="transport-stop"/>
+<Binding channel="1" ctl="118" function="transport-roll"/>
+<Binding channel="1" ctl="119" function="toggle-rec-enable"/>
+
+</ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MPK225_Plugins.map
+++ b/share/midi_maps/AKAI_MPK225_Plugins.map
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="Akai MPK 225 (with plugins) : preset 6">
+<DeviceInfo bank-size="8"/>
+
+<!-- NOTE : use preset 6 to enable these -->
+
+<Binding channel="2" ctl="28" uri="/route/mute S1"/>
+<Binding channel="2" ctl="75" uri="/route/mute S1"/>
+<Binding channel="2" ctl="106" uri="/route/mute S1"/>
+<Binding channel="2" ctl="29" uri="/route/solo S1"/>
+<Binding channel="2" ctl="76" uri="/route/solo S1"/>
+<Binding channel="2" ctl="107" uri="/route/solo S1"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S1"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S1"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S1"/>
+
+<!-- Bank A : Miscellaneous -->
+<!-- K1 : Tape Drive -->
+<Binding channel="2" enc-2="50" uri="/route/plugin/parameter S1 0 0"/>
+<!-- K3 : Pan width -->
+<Binding channel="2" enc-2="52" uri="/route/panwidth S1"/>
+<!-- K4 : High -->
+<Binding channel="2" enc-2="53" uri="/route/filter/hi/freq S1"/>
+<!-- K5 : Gain -->
+<Binding channel="2" enc-2="54" uri="/route/gain S1"/>
+<!-- K6 : Trim -->
+<Binding channel="2" enc-2="55" uri="/route/trim S1"/>
+<!-- K7 : Pan direction -->
+<Binding channel="2" enc-2="56" uri="/route/pandirection S1"/>
+<!-- K8 : Low -->
+<Binding channel="2" enc-2="57" uri="/route/filter/low/freq S1"/>
+
+<!-- Bank B : Equalizer -->
+<Binding channel="3" enc-2="50" uri="/route/eq/freq/0 S1"/>
+<Binding channel="3" enc-2="51" uri="/route/eq/freq/1 S1"/>
+<Binding channel="3" enc-2="52" uri="/route/eq/freq/2 S1"/>
+<Binding channel="3" enc-2="53" uri="/route/eq/freq/3 S1"/>
+<Binding channel="3" enc-2="54" uri="/route/eq/gain/0 S1"/>
+<Binding channel="3" enc-2="55" uri="/route/eq/gain/1 S1"/>
+<Binding channel="3" enc-2="56" uri="/route/eq/gain/2 S1"/>
+<Binding channel="3" enc-2="57" uri="/route/eq/gain/3 S1"/>
+
+<!-- Bank C : Compressor & Sends -->
+<Binding channel="4" enc-2="50" uri="/route/send/gain S1 1"/>
+<Binding channel="4" enc-2="51" uri="/route/send/gain S1 2"/>
+<Binding channel="4" enc-2="52" uri="/route/send/gain S1 3"/>
+<Binding channel="4" enc-2="53" uri="/route/send/gain S1 4"/>
+<Binding channel="4" enc-2="54" uri="/route/compressor/speed S1"/>
+<Binding channel="4" enc-2="55" uri="/route/compressor/threshold S1"/>
+<Binding channel="4" enc-2="56" uri="/route/compressor/makeup S1"/>
+
+<!-- Transport -->
+<Binding channel="1" ctl="115" action="Transport/Rewind"/>
+<Binding channel="1" ctl="116" action="Transport/Forward"/>
+<Binding channel="1" ctl="117" function="transport-stop"/>
+<Binding channel="1" ctl="118" function="transport-roll"/>
+<Binding channel="1" ctl="119" function="toggle-rec-enable"/>
+
+</ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MPK225_Plugins.map
+++ b/share/midi_maps/AKAI_MPK225_Plugins.map
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ArdourMIDIBindings version="1.0.0" name="Akai MPK 225 (with plugins) : preset 6">
+<ArdourMIDIBindings version="1.0.0" name="Akai MPK 225 (Eq mode) : preset 6">
 <DeviceInfo bank-size="8"/>
 
 <!-- NOTE : use preset 6 to enable these -->
-
-<Binding channel="2" ctl="28" uri="/route/mute S1"/>
-<Binding channel="2" ctl="75" uri="/route/mute S1"/>
-<Binding channel="2" ctl="106" uri="/route/mute S1"/>
-<Binding channel="2" ctl="29" uri="/route/solo S1"/>
-<Binding channel="2" ctl="76" uri="/route/solo S1"/>
-<Binding channel="2" ctl="107" uri="/route/solo S1"/>
-<Binding channel="2" ctl="30" uri="/route/recenable S1"/>
-<Binding channel="2" ctl="77" uri="/route/recenable S1"/>
-<Binding channel="2" ctl="108" uri="/route/recenable S1"/>
 
 <!-- Bank A : Miscellaneous -->
 <!-- K1 : Tape Drive -->
@@ -55,5 +45,97 @@
 <Binding channel="1" ctl="117" function="transport-stop"/>
 <Binding channel="1" ctl="118" function="transport-roll"/>
 <Binding channel="1" ctl="119" function="toggle-rec-enable"/>
+
+<!-- Any bank : button 1 mute, button 2 solo, button 3 rec, up to 10 selected tracks -->
+<Binding channel="2" ctl="28" uri="/route/mute S1"/>
+<Binding channel="2" ctl="75" uri="/route/mute S1"/>
+<Binding channel="2" ctl="106" uri="/route/mute S1"/>
+<Binding channel="2" ctl="29" uri="/route/solo S1"/>
+<Binding channel="2" ctl="76" uri="/route/solo S1"/>
+<Binding channel="2" ctl="107" uri="/route/solo S1"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S1"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S1"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S1"/>
+<Binding channel="2" ctl="28" uri="/route/mute S2"/>
+<Binding channel="2" ctl="75" uri="/route/mute S2"/>
+<Binding channel="2" ctl="106" uri="/route/mute S2"/>
+<Binding channel="2" ctl="29" uri="/route/solo S2"/>
+<Binding channel="2" ctl="76" uri="/route/solo S2"/>
+<Binding channel="2" ctl="107" uri="/route/solo S2"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S2"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S2"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S2"/>
+<Binding channel="2" ctl="28" uri="/route/mute S3"/>
+<Binding channel="2" ctl="75" uri="/route/mute S3"/>
+<Binding channel="2" ctl="106" uri="/route/mute S3"/>
+<Binding channel="2" ctl="29" uri="/route/solo S3"/>
+<Binding channel="2" ctl="76" uri="/route/solo S3"/>
+<Binding channel="2" ctl="107" uri="/route/solo S3"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S3"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S3"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S3"/>
+<Binding channel="2" ctl="28" uri="/route/mute S4"/>
+<Binding channel="2" ctl="75" uri="/route/mute S4"/>
+<Binding channel="2" ctl="106" uri="/route/mute S4"/>
+<Binding channel="2" ctl="29" uri="/route/solo S4"/>
+<Binding channel="2" ctl="76" uri="/route/solo S4"/>
+<Binding channel="2" ctl="107" uri="/route/solo S4"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S4"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S4"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S4"/>
+<Binding channel="2" ctl="28" uri="/route/mute S5"/>
+<Binding channel="2" ctl="75" uri="/route/mute S5"/>
+<Binding channel="2" ctl="106" uri="/route/mute S5"/>
+<Binding channel="2" ctl="29" uri="/route/solo S5"/>
+<Binding channel="2" ctl="76" uri="/route/solo S5"/>
+<Binding channel="2" ctl="107" uri="/route/solo S5"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S5"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S5"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S5"/>
+<Binding channel="2" ctl="28" uri="/route/mute S6"/>
+<Binding channel="2" ctl="75" uri="/route/mute S6"/>
+<Binding channel="2" ctl="106" uri="/route/mute S6"/>
+<Binding channel="2" ctl="29" uri="/route/solo S6"/>
+<Binding channel="2" ctl="76" uri="/route/solo S6"/>
+<Binding channel="2" ctl="107" uri="/route/solo S6"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S6"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S6"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S6"/>
+<Binding channel="2" ctl="28" uri="/route/mute S7"/>
+<Binding channel="2" ctl="75" uri="/route/mute S7"/>
+<Binding channel="2" ctl="106" uri="/route/mute S7"/>
+<Binding channel="2" ctl="29" uri="/route/solo S7"/>
+<Binding channel="2" ctl="76" uri="/route/solo S7"/>
+<Binding channel="2" ctl="107" uri="/route/solo S7"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S7"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S7"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S7"/>
+<Binding channel="2" ctl="28" uri="/route/mute S8"/>
+<Binding channel="2" ctl="75" uri="/route/mute S8"/>
+<Binding channel="2" ctl="106" uri="/route/mute S8"/>
+<Binding channel="2" ctl="29" uri="/route/solo S8"/>
+<Binding channel="2" ctl="76" uri="/route/solo S8"/>
+<Binding channel="2" ctl="107" uri="/route/solo S8"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S8"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S8"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S8"/>
+<Binding channel="2" ctl="28" uri="/route/mute S9"/>
+<Binding channel="2" ctl="75" uri="/route/mute S9"/>
+<Binding channel="2" ctl="106" uri="/route/mute S9"/>
+<Binding channel="2" ctl="29" uri="/route/solo S9"/>
+<Binding channel="2" ctl="76" uri="/route/solo S9"/>
+<Binding channel="2" ctl="107" uri="/route/solo S9"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S9"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S9"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S9"/>
+<Binding channel="2" ctl="28" uri="/route/mute S10"/>
+<Binding channel="2" ctl="75" uri="/route/mute S10"/>
+<Binding channel="2" ctl="106" uri="/route/mute S10"/>
+<Binding channel="2" ctl="29" uri="/route/solo S10"/>
+<Binding channel="2" ctl="76" uri="/route/solo S10"/>
+<Binding channel="2" ctl="107" uri="/route/solo S10"/>
+<Binding channel="2" ctl="30" uri="/route/recenable S10"/>
+<Binding channel="2" ctl="77" uri="/route/recenable S10"/>
+<Binding channel="2" ctl="108" uri="/route/recenable S10"/>
 
 </ArdourMIDIBindings>


### PR DESCRIPTION
I have written two maps for the Akai MPK225.
AKAI_MPK225_Normal.map is a map mainly controlling solos, pandirections and gain for 12 tracks, and transport controls.
AKAI_MPK225_Plugins.map is a map controlling pandirection, gain and various plugins (equalizer, compressor...) for 1 selected track, and transport controls.