### PR TITLE
Fix crash in mackie strip code when hiding a track

### DIFF
--- a/libs/surfaces/mackie/strip.cc
+++ b/libs/surfaces/mackie/strip.cc
@@ -389,6 +389,10 @@ Strip::notify_processor_changed (bool force_update)
 void
 Strip::notify_property_changed (const PropertyChange& what_changed)
 {
+	if (!_stripable) {
+		return;
+	}
+
 	if (what_changed.contains (ARDOUR::Properties::name)) {
 		show_stripable_name ();
 	}


### PR DESCRIPTION
`ArdourSurface::Mackie::Strip::notify_property_changed` accesses `_stripable`
without verifying that is not null. However it is possible for this to be null, so
add a null check, mirroring similar checks in most other methods in this class.

To reproduce this crash, right-click a track that isn't currently selected while in Edit mode,
and pick "hide". The selected property change notification for the just-hidden track is
delivered to `Mackie::Strip` after the `stripable_` property has been reset to null. `Strip`
does disconnect all signals that were attached to `stripable_` when setting it to null, but
`PBD::Connection` doesn't guarantee that previously scheduled (cross-thread) signals aren't
emitted even after the signal has been disconnected (as happens here).