### PR TITLE
Fix plugin manager build with VST3 disabled.

### DIFF
--- a/libs/ardour/plugin_manager.cc
+++ b/libs/ardour/plugin_manager.cc
@@ -87,6 +87,7 @@
 #include "ardour/search_paths.h"
 
 #if (defined WINDOWS_VST_SUPPORT || defined MACVST_SUPPORT || defined LXVST_SUPPORT)
+#include "ardour/system_exec.h"
 #include "ardour/vst2_scan.h"
 #endif
 
@@ -113,6 +114,7 @@
 
 #include "ardour/audio_unit.h"
 #include "ardour/auv2_scan.h"
+#include "ardour/system_exec.h"
 #include <Carbon/Carbon.h>
 #endif
 


### PR DESCRIPTION
`ARDOUR::SystemExec` is also used for scanning VST2 and AU plugins, yet
the corresponding header `ardour/system_exec.h` is not included when VST3
support is disabled in the build configuration.

I ran into this on FreeBSD when updating the Ardour port to 6.9.
Couldn't test for AU plugins, but the situation seems the same.