### PR TITLE
Allow latency measurements even if inverted wiring is detected

### DIFF
--- a/gtk2_ardour/engine_dialog.cc
+++ b/gtk2_ardour/engine_dialog.cc
@@ -3056,9 +3056,10 @@ EngineControl::check_audio_latency_measurement ()
 	}
 
 	if (mtdm->inv ()) {
+                // Even though the signal is inverted, the latency is measured
+                // So warn, but allow
 		strcat (buf, " ");
 		strcat (buf, _("(inverted - bad wiring)"));
-		solid = false;
 	}
 
 	lm_results.set_markup (string_compose (results_markup, buf));


### PR DESCRIPTION
Inverted wiring is important to call out when detected, but the measured
latency is still valid and should be applicable.
