### PR TITLE
fix websockets toggle_roll

### DIFF
--- a/libs/surfaces/control_protocol/basic_ui.cc
+++ b/libs/surfaces/control_protocol/basic_ui.cc
@@ -623,7 +623,7 @@ BasicUI::toggle_click ()
 }
 
 void
-BasicUI::toggle_roll (bool roll_out_of_bounded_mode)
+BasicUI::toggle_roll (bool with_abort, bool roll_out_of_bounded_mode)
 {
 	/* TO BE KEPT IN SYNC WITH ARDOUR_UI::toggle_roll() */
 
@@ -672,7 +672,7 @@ BasicUI::toggle_roll (bool roll_out_of_bounded_mode)
 			}
 
 		} else {
-			session->request_stop (true, true);
+			session->request_stop (with_abort, true);
 		}
 
 	} else { /* not rolling */

--- a/libs/surfaces/control_protocol/control_protocol/basic_ui.h
+++ b/libs/surfaces/control_protocol/control_protocol/basic_ui.h
@@ -108,7 +108,7 @@ class LIBCONTROLCP_API BasicUI {
 	void quick_snapshot_stay ();
 	void quick_snapshot_switch ();
 
-	void toggle_roll(bool roll_out_of_bounded_mode=true);  //this provides the same operation as the "spacebar", it's a lot smarter than "play".
+	void toggle_roll(bool with_abort, bool roll_out_of_bounded_mode);  //this provides the same operation as the "spacebar", it's a lot smarter than "play".
 
 	void stop_forget();
 

--- a/libs/surfaces/websockets/transport.cc
+++ b/libs/surfaces/websockets/transport.cc
@@ -63,7 +63,7 @@ ArdourTransport::set_roll (bool value)
 {
 	if ((value && !roll ()) || (!value && roll ())) {
 		// this call is equivalent to hitting the spacebar
-		basic_ui ().toggle_roll (false);
+		basic_ui ().toggle_roll (false, false);
 	}
 }
 


### PR DESCRIPTION
Also fix `BasicUI::toggle_roll` which is supposed to do the same as spacebar but doesn't.
I simply added the missing parameter as for `ArdourUI::toggle_roll`.
Comments seem to suggest that `BasicUI::toggle_roll` must do the same as `ArdourUI::toggle_roll`.