### PR TITLE
compile_commands.json is generated upon request

### DIFF
--- a/wscript
+++ b/wscript
@@ -796,6 +796,7 @@ def create_resource_file(icon):
 def options(opt):
     opt.load('compiler_c')
     opt.load('compiler_cxx')
+    opt.load('clang_compilation_database')
     autowaf.set_options(opt, debug_by_default=True)
     opt.add_option('--program-name', type='string', action='store', default='Ardour', dest='program_name',
                     help='The user-visible name of the program being built')
@@ -935,8 +936,6 @@ def configure(conf):
     conf.load('compiler_cxx')
     if Options.options.dist_target == 'mingw':
         conf.load('winres')
-    else:
-        conf.load('clang_compilation_database')
 
     if Options.options.dist_target == 'msvc':
         conf.env['MSVC_VERSIONS'] = ['msvc 10.0', 'msvc 9.0', 'msvc 8.0', 'msvc 7.1', 'msvc 7.0', 'msvc 6.0', ]


### PR DESCRIPTION
`compile_commands.json` not generated by default but upon explicit request.
Enable new waf command: `./waf clangdb`

```
$ ./waf --help
...
Main commands (example: ./waf build -j4)
  build    : executes the build
  clangdb  : generates compile_commands.json by request
  clean    : cleans the project
  configure: configures the project
...
```
```
$ ./waf clangdb
Git version: 7.0-pre0-1751-g25bd59958c

Writing revision info to libs/ardour/revision.cc using 7.0-pre0-1751-g25bd59958c, 2022-01-13
Build commands will be stored in build/compile_commands.json
'clangdb' finished successfully (0.547s)
```