### PR TITLE
Fix typos in gtk2_ardour/ directory

### DIFF
--- a/gtk2_ardour/add_route_dialog.cc
+++ b/gtk2_ardour/add_route_dialog.cc
@@ -617,7 +617,7 @@ AddRouteDialog::maybe_update_name_template_entry ()
 		name_template_entry.set_text (VCA::default_name_template());
 		break;
 	}
-	/* ignore programatic change, restore false */
+	/* ignore programmatic change, restore false */
 	reset_name_edited ();
 }
 

--- a/gtk2_ardour/ambiguous_file_dialog.cc
+++ b/gtk2_ardour/ambiguous_file_dialog.cc
@@ -29,7 +29,7 @@ using namespace Gtk;
 AmbiguousFileDialog::AmbiguousFileDialog (const string& file, const vector<string>& paths)
 	: ArdourDialog (_("Ambiguous File"), true, false)
 {
-	/* This dialog is always shown programatically. Center the window.*/
+	/* This dialog is always shown programmatically. Center the window.*/
 	set_position (Gtk::WIN_POS_CENTER);
 
 	get_vbox()->set_spacing (6);

--- a/gtk2_ardour/ardour_ui_keys.cc
+++ b/gtk2_ardour/ardour_ui_keys.cc
@@ -194,7 +194,7 @@ ARDOUR_UI::key_press_focus_accelerator_handler (Gtk::Window& window, GdkEventKey
 
 		KeyboardKey k (ev->state, ev->keyval);
 
-		/* Check heirarchy from current focus widget upwards */
+		/* Check hierarchy from current focus widget upwards */
 
 		while (focus) {
 

--- a/gtk2_ardour/ardour_ui_session.cc
+++ b/gtk2_ardour/ardour_ui_session.cc
@@ -314,7 +314,7 @@ ARDOUR_UI::load_session (const std::string& path, const std::string& snap_name, 
 	/* load_session calls flush_pending() which allows
 	 * GUI interaction and potentially loading another session
 	 * (that was easy via snapshot sidebar).
-	 * Recursing into load_session() from load_session() and recusive
+	 * Recursing into load_session() from load_session() and recursive
 	 * event loops causes all kind of crashes.
 	 */
 	assert (!session_load_in_progress);

--- a/gtk2_ardour/audio_region_view.cc
+++ b/gtk2_ardour/audio_region_view.cc
@@ -1747,7 +1747,7 @@ AudioRegionView::transients_changed ()
 void
 AudioRegionView::update_transient(float /*old_pos*/, float new_pos)
 {
-	/* Find sample at old pos, calulate new sample then update region transients*/
+	/* Find sample at old pos, calculate new sample then update region transients*/
 	list<std::pair<samplepos_t, ArdourCanvas::Line*> >::iterator l;
 
 	for (l = feature_lines.begin(); l != feature_lines.end(); ++l) {
@@ -1772,7 +1772,7 @@ AudioRegionView::remove_transient (float pos)
 	/* this is called from Editor::remove_transient () with pos == get_data ("position")
 	 * which is the item's x-coordinate inside the ARV.
 	 *
-	 * Find sample at old pos, calulate new sample then update region transients
+	 * Find sample at old pos, calculate new sample then update region transients
 	 */
 	list<std::pair<samplepos_t, ArdourCanvas::Line*> >::iterator l;
 
@@ -1816,7 +1816,7 @@ AudioRegionView::drag_end ()
 	//see comment for drag_start
 
 	if (fade_in_handle && fade_in_handle->visible()) {
-		// lenght of region or fade changed, re-check
+		// length of region or fade changed, re-check
 		// if fade_in_trim_handle or fade_out_trim_handle should
 		// be visible. -- If the fade_in_handle is visible
 		// we have focus and are not in internal edit mode.

--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -549,7 +549,7 @@ AutomationLine::ContiguousControlPoints::clamp_dx (double dx)
 
 	tx = cp->get_x() + dx; // new possible position if we just add the motion
 	tx = max (tx, before_x); // can't move later than following point
-	tx = min (tx, after_x);  // can't move earlier than preceeding point
+	tx = min (tx, after_x);  // can't move earlier than preceding point
 	return  tx - cp->get_x ();
 }
 
@@ -1098,7 +1098,7 @@ AutomationLine::reset ()
 		return;
 	}
 
-	/* TODO: abort any drags in progress, e.g. draging points while writing automation
+	/* TODO: abort any drags in progress, e.g. dragging points while writing automation
 	 * (the control-point model, used by AutomationLine::drag_motion, will be invalid).
 	 *
 	 * Note: reset() may also be called from an aborted drag (LineDrag::aborted)

--- a/gtk2_ardour/beatbox_gui.cc
+++ b/gtk2_ardour/beatbox_gui.cc
@@ -142,7 +142,7 @@ BBGUI::SwitchRow::switch_event (GdkEvent* ev, int col)
 	Switch* s = switches[col];
 
 	if (ev->type == GDK_BUTTON_PRESS) {
-		/* XXX changes hould be driven by model */
+		/* XXX changes should be driven by model */
 		if (s->button->value()) {
 			owner.bbox->remove_note (note, at);
 			s->button->set_value (0);
@@ -211,7 +211,7 @@ BBGUI::sequencer_changed (PropertyChange const &)
 
 	vertical_adjustment.set_upper (required_scroll);
 
-	/* height is 1 step_dimen larger to accomodate the "step indicator"
+	/* height is 1 step_dimen larger to accommodate the "step indicator"
 	 * line at the top
 	 */
 

--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -244,7 +244,7 @@ static const gchar *_rb_opt_strings[] = {
 };
 #endif
 
-/* Robin says: this should be odd to accomodate cairo drawing offset (width/2 rounds up to pixel boundary) */
+/* Robin says: this should be odd to accommodate cairo drawing offset (width/2 rounds up to pixel boundary) */
 #ifdef __APPLE__
 #define COMBO_TRIANGLE_WIDTH 19 // ArdourButton _diameter (11) + 2 * arrow-padding (2*2) + 2 * text-padding (2*5)
 #else

--- a/gtk2_ardour/editor_canvas.cc
+++ b/gtk2_ardour/editor_canvas.cc
@@ -1324,7 +1324,7 @@ Editor::which_canvas_cursor(ItemType type) const
 		/* We don't choose a cursor for these items on top of a region view,
 		   because this would push a new context on the enter stack which
 		   means switching the region context for things like smart mode
-		   won't actualy change the cursor. */
+		   won't actually change the cursor. */
 		// case WaveItem:
 		case StreamItem:
 		case AutomationTrackItem:

--- a/gtk2_ardour/editor_canvas_events.cc
+++ b/gtk2_ardour/editor_canvas_events.cc
@@ -876,7 +876,7 @@ Editor::canvas_region_view_name_highlight_event (GdkEvent* event, ArdourCanvas::
 		break;
 	case GDK_MOTION_NOTIFY:
 		motion_handler (item, event);
-		ret = true; // force this to avoid progagating the event into the regionview
+		ret = true; // force this to avoid propagating the event into the regionview
 		break;
 	case GDK_ENTER_NOTIFY:
 		ret = enter_handler (item, event, RegionViewNameHighlight);

--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -1479,7 +1479,7 @@ RegionMotionDrag::motion (GdkEvent* event, bool first_move)
 				 * the current position can be calculated as follows:
 				 */
 				// a well placed oofus attack can still throw this off.
-				// likley auto-scroll related, printf() debugging may tell, commented out for now.
+				// likely auto-scroll related, printf() debugging may tell, commented out for now.
 				//assert (current_pointer_time_axis_view == _time_axis_views.size() - dtz + _ddropzone + delta_time_axis_view);
 			}
 		} else {
@@ -2377,7 +2377,7 @@ RegionRippleDrag::RegionRippleDrag (Editor* e, ArdourCanvas::Item* i, RegionView
 	RegionSelection selected_regions = _editor->get_selection().regions;
 	selection_length = selected_regions.start_time().distance (selected_regions.end_time());
 
-	// Rippling accross tracks disabled. Rippling on all tracks is the way to go in the future.
+	// Rippling across tracks disabled. Rippling on all tracks is the way to go in the future.
 	allow_moves_across_tracks = false; // (selected_regions.playlists().size() == 1);
 	prev_tav = NULL;
 

--- a/gtk2_ardour/editor_drag.h
+++ b/gtk2_ardour/editor_drag.h
@@ -1224,7 +1224,7 @@ private:
 	MidiRegionView* _region_view;
 };
 
-/** A RubberbandSelectDrag for selecting MIDI notes but with no horizonal component */
+/** A RubberbandSelectDrag for selecting MIDI notes but with no horizontal component */
 class MidiVerticalSelectDrag : public RubberbandSelectDrag
 {
 public:

--- a/gtk2_ardour/editor_markers.cc
+++ b/gtk2_ardour/editor_markers.cc
@@ -1599,7 +1599,7 @@ Editor::marker_menu_remove ()
 	}
 }
 
-/* actally just resets the ts to constant using initial tempo */
+/* actually just resets the ts to constant using initial tempo */
 void
 Editor::toggle_tempo_type ()
 {

--- a/gtk2_ardour/editor_mixer.cc
+++ b/gtk2_ardour/editor_mixer.cc
@@ -206,7 +206,7 @@ Editor::set_selected_mixer_strip (TimeAxisView& view)
 		return;
 	}
 
-	// if this is an automation track, then we shold the mixer strip should
+	// if this is an automation track, then the mixer strip should
 	// show the parent
 
 	boost::shared_ptr<ARDOUR::Stripable> stripable;

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -358,7 +358,7 @@ Editor::mouse_mode_toggled (MouseMode m)
 	instant_save ();
 
 	/* this should generate a new enter event which will
-	   trigger the appropiate cursor.
+	   trigger the appropriate cursor.
 	*/
 
 	if (_track_canvas) {
@@ -2470,7 +2470,7 @@ Editor::point_trim (GdkEvent* event, timepos_t const & new_bound)
 {
 	RegionView* rv = clicked_regionview;
 
-	/* Choose action dependant on which button was pressed */
+	/* Choose action dependent on which button was pressed */
 	switch (event->button.button) {
 	case 1:
 		begin_reversible_command (_("start point trim"));

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -216,7 +216,7 @@ Editor::split_regions_at (timepos_t const & where, RegionSelection& regions)
 
 	if (regions.size() == 1) {
 		/* TODO:  if splitting a single region, and snap-to is using
-		 region boundaries, mabye we shouldn't pay attention to them? */
+		 region boundaries, maybe we shouldn't pay attention to them? */
 	} else {
 		frozen = true;
 		EditorFreeze(); /* Emit Signal */
@@ -7374,7 +7374,7 @@ Editor::split_region_at_points (boost::shared_ptr<Region> r, AnalysisFeatureList
 
 	while (x != positions.end()) {
 
-		/* deal with positons that are out of scope of present region bounds */
+		/* deal with positions that are out of scope of present region bounds */
 
 		if (*x < start_sample || *x >= end_sample) {
 			++x;
@@ -7414,7 +7414,7 @@ Editor::split_region_at_points (boost::shared_ptr<Region> r, AnalysisFeatureList
 		// TODO set transients_offset
 
 		boost::shared_ptr<Region> nr = RegionFactory::create (r->sources(), plist, false);
-		/* because we set annouce to false, manually add the new region to the
+		/* because we set announce to false, manually add the new region to the
 		 * RegionFactory map
 		 */
 		RegionFactory::map_add (nr);
@@ -7442,7 +7442,7 @@ Editor::split_region_at_points (boost::shared_ptr<Region> r, AnalysisFeatureList
 	plist.add (ARDOUR::Properties::layer, 0);
 
 	boost::shared_ptr<Region> nr = RegionFactory::create (r->sources(), plist, false);
-	/* because we set annouce to false, manually add the new region to the
+	/* because we set announce to false, manually add the new region to the
 	   RegionFactory map
 	*/
 	RegionFactory::map_add (nr);

--- a/gtk2_ardour/editor_sources.cc
+++ b/gtk2_ardour/editor_sources.cc
@@ -86,7 +86,7 @@ EditorSources::init ()
 
 	setup_col (append_col (_columns.channels, "Chans    "), 1, ALIGN_LEFT, _("# Ch"), _("# Channels in the region"));
 	setup_col (append_col (_columns.captd_for, date_width), 17, ALIGN_LEFT, _("Captured For"), _("Original Track this was recorded on"));
-	setup_col (append_col (_columns.captd_xruns, "1234567890"), 21, ALIGN_RIGHT, _("# Xruns"), _("Number of dropouts that occured during recording"));
+	setup_col (append_col (_columns.captd_xruns, "1234567890"), 21, ALIGN_RIGHT, _("# Xruns"), _("Number of dropouts that occurred during recording"));
 
 	add_tag_column ();
 

--- a/gtk2_ardour/editor_summary.cc
+++ b/gtk2_ardour/editor_summary.cc
@@ -653,7 +653,7 @@ EditorSummary::summary_zoom_step (int steps /* positive steps to zoom "out" , ne
 
 	/* for now, disallow really close zooming-in from the scroomer. (Currently it
 	 * causes the start-offset to 'walk' because of integer limitations.
-	 * To fix this, probably need to maintain float throught the get/set_editor() path.)
+	 * To fix this, probably need to maintain float through the get/set_editor() path.)
 	 */
 	if (steps<0) {
       if ((xn.second - xn.first) < 2)

--- a/gtk2_ardour/engine_dialog.cc
+++ b/gtk2_ardour/engine_dialog.cc
@@ -650,7 +650,7 @@ EngineControl::build_full_control_notebook ()
 		++row;
 	}
 
-	/* Prefere next available vertical slot, 1 row */
+	/* Prefer next available vertical slot, 1 row */
 	if (btn < row && !autostart_packed) {
 		basic_packer.attach (try_autostart_button, 3, 4, btn, btn + 1, xopt, xopt);
 		btn++;

--- a/gtk2_ardour/export_format_dialog.cc
+++ b/gtk2_ardour/export_format_dialog.cc
@@ -646,7 +646,7 @@ ExportFormatDialog::init_format_table ()
 	src_quality_combo.pack_start (src_quality_cols.label);
 	src_quality_combo.set_active (0);
 
-	/* Demo Noise Optoins */
+	/* Demo Noise Options */
 
 	demo_noise_list = Gtk::ListStore::create (demo_noise_cols);
 	demo_noise_combo.set_model (demo_noise_list);

--- a/gtk2_ardour/export_format_selector.h
+++ b/gtk2_ardour/export_format_selector.h
@@ -74,7 +74,7 @@ private:
 
 	ARDOUR::ExportProfileManager::FormatStatePtr state;
 
-	/*** GUI componenets ***/
+	/*** GUI components ***/
 
 	struct FormatCols : public Gtk::TreeModelColumnRecord
 	{

--- a/gtk2_ardour/gui_object.h
+++ b/gtk2_ardour/gui_object.h
@@ -41,7 +41,7 @@ public:
 	/** Get a string from our state.
 	 *  @param id property of Object node to look for.
 	 *  @param prop_name name of the Object property to return.
-	 *  @param empty if non-0, filled in with true if the property is currently non-existant, otherwise false.
+	 *  @param empty if non-0, filled in with true if the property is currently non-existent, otherwise false.
 	 *  @return value of property `prop_name', or empty.
 	 */
 	std::string get_string (const std::string& id, const std::string& prop_name, bool* empty = 0);

--- a/gtk2_ardour/io_button.cc
+++ b/gtk2_ardour/io_button.cc
@@ -269,7 +269,7 @@ IOButton::button_press (GdkEventButton* ev)
 			}
 		}
 
-		/* then all other bundles, including physical outs or other sofware */
+		/* then all other bundles, including physical outs or other software */
 		for (ARDOUR::BundleList::iterator i = b->begin (); i != b->end (); ++i) {
 			if (boost::dynamic_pointer_cast<UserBundle> (*i) == 0) {
 				maybe_add_bundle_to_menu (*i, current, intended_type);

--- a/gtk2_ardour/keyboard.cc
+++ b/gtk2_ardour/keyboard.cc
@@ -110,7 +110,7 @@ ArdourKeyboard::setup_keybindings ()
 
 	string lowercase_program_name = downcase (string(PROGRAM_NAME));
 
-	/* extract and append minor vesion */
+	/* extract and append minor version */
 	std::string rev (revision);
 	std::size_t pos = rev.find_first_of("-");
 	if (pos != string::npos && pos > 0) {

--- a/gtk2_ardour/lv2_external_ui.h
+++ b/gtk2_ardour/lv2_external_ui.h
@@ -53,7 +53,7 @@ extern "C" {
 struct lv2_external_ui
 {
   /**
-   * Host calls this function regulary. UI library implementing the
+   * Host calls this function regularly. UI library implementing the
    * callback may do IPC or redraw the UI.
    *
    * @param _this_ the UI context
@@ -87,7 +87,7 @@ struct lv2_external_ui_host
   /**
    * Callback that plugin UI will call
    * when UI (GUI window) is closed by user.
-   * This callback wil; be called during execution of lv2_external_ui::run()
+   * This callback will be called during execution of lv2_external_ui::run()
    * (i.e. not from background thread).
    *
    * After this callback is called, UI is defunct. Host must call

--- a/gtk2_ardour/midi_channel_selector.cc
+++ b/gtk2_ardour/midi_channel_selector.cc
@@ -749,7 +749,7 @@ MidiChannelSelectorWindow::capture_mode_changed ()
 		}
 	}
 
-	capture_mask_changed (); // udpate buttons
+	capture_mask_changed (); // update buttons
 
 	last_drawn_capture_mode = mode;
 }

--- a/gtk2_ardour/midi_time_axis.cc
+++ b/gtk2_ardour/midi_time_axis.cc
@@ -1217,7 +1217,7 @@ MidiTimeAxisView::show_all_automation (bool apply_to_selection)
 
 		md.set_title (_("Show All Automation"));
 
-		md.set_secondary_text (_("There are a total of 16 MIDI channels times 128 Control-Change parameters, not including other MIDI controls. Showing all will add more than 2000 automation lanes which is not generally useful. This will take some time and also slow down the GUI signficantly."));
+		md.set_secondary_text (_("There are a total of 16 MIDI channels times 128 Control-Change parameters, not including other MIDI controls. Showing all will add more than 2000 automation lanes which is not generally useful. This will take some time and also slow down the GUI significantly."));
 		if (md.run () != RESPONSE_YES) {
 			return;
 		}

--- a/gtk2_ardour/midi_tracer.cc
+++ b/gtk2_ardour/midi_tracer.cc
@@ -176,13 +176,13 @@ MidiTracer::port_changed ()
 		return;
 	}
 
-	/* The inheritance heirarchy makes this messy. AsyncMIDIPort has two
+	/* The inheritance hierarchy makes this messy. AsyncMIDIPort has two
 	 * available MIDI::Parsers what we could connect to, ::self_parser()
 	 * (from ARDOUR::MidiPort) and ::parser() from MIDI::Port. One day,
 	 * this mess will all go away ...
 	 */
 
-	/* Some ports have a parser avaiable (Transport Masters and ASYNC ports)
+	/* Some ports have a parser available (Transport Masters and ASYNC ports)
 	 * and some do not. If the port has a parser already, just attach to it.
 	 * If not use our local parser and tell the port that we need it to be called.
 	 */

--- a/gtk2_ardour/missing_file_dialog.cc
+++ b/gtk2_ardour/missing_file_dialog.cc
@@ -47,7 +47,7 @@ MissingFileDialog::MissingFileDialog (Gtk::Window& parent, Session* s, const std
 	, all_missing_ok (choice_group, _("Skip all missing files"), false)
 	, this_missing_ok (choice_group, _("Skip this file"), false)
 {
-	/* This dialog is always shown programatically. Center the window.*/
+	/* This dialog is always shown programmatically. Center the window.*/
 	set_position (Gtk::WIN_POS_CENTER);
 
 	set_session (s);

--- a/gtk2_ardour/missing_filesource_dialog.cc
+++ b/gtk2_ardour/missing_filesource_dialog.cc
@@ -32,7 +32,7 @@ using namespace PBD;
 MissingFileSourceDialog::MissingFileSourceDialog (Gtk::Window& parent, Session* s, list<string> const& files, DataType dt)
 	: ArdourDialog (parent, _("Missing Source Files"), true, false)
 {
-	/* This dialog is always shown programatically. Center the window.*/
+	/* This dialog is always shown programmatically. Center the window.*/
 	set_position (Gtk::WIN_POS_CENTER);
 
 	set_session (s);

--- a/gtk2_ardour/missing_plugin_dialog.cc
+++ b/gtk2_ardour/missing_plugin_dialog.cc
@@ -34,7 +34,7 @@ using namespace PBD;
 MissingPluginDialog::MissingPluginDialog (Gtk::Window& parent, Session* s, list<string> const & plugins, bool cache_valid)
 	: ArdourDialog (parent, _("Missing Plugins"), true, false)
 {
-	/* This dialog is always shown programatically. Center the window.*/
+	/* This dialog is always shown programmatically. Center the window.*/
 	set_position (Gtk::WIN_POS_CENTER);
 
 	set_session (s);

--- a/gtk2_ardour/mixer_strip.cc
+++ b/gtk2_ardour/mixer_strip.cc
@@ -2081,7 +2081,7 @@ MixerStrip::update_track_number_visibility ()
 		number_label.show ();
 		// see ArdourButton::on_size_request(), we should probably use a global size-group here instead.
 		// except the width of the number label is subtracted from the name-hbox, so we
-		// need to explictly calculate it anyway until the name-label & entry become ArdourWidgets.
+		// need to explicitly calculate it anyway until the name-label & entry become ArdourWidgets.
 		int tnw = (2 + std::max(2u, _session->track_number_decimals())) * number_label.char_pixel_width();
 		if (tnw & 1) --tnw;
 		number_label.set_size_request(tnw, -1);

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -3872,7 +3872,7 @@ Mixer_UI::screenshot (std::string const& filename)
 	Glib::RefPtr<Gdk::Pixbuf> pb = osw.get_pixbuf ();
 	pb->save (filename, "png");
 
-	/* unpack elements before destorying the Box & OffscreenWindow */
+	/* unpack elements before destroying the Box & OffscreenWindow */
 	list<Gtk::Widget*> children = b.get_children();
 	for (list<Gtk::Widget*>::iterator child = children.begin(); child != children.end(); ++child) {
 		b.remove (**child);

--- a/gtk2_ardour/mono_panner.cc
+++ b/gtk2_ardour/mono_panner.cc
@@ -113,7 +113,7 @@ MonoPanner::set_tooltip ()
 		 This is expressed as a pair of percentage values that ranges from (100,0)
 		 (hard left) through (50,50) (hard center) to (0,100) (hard right).
 
-		 This is pretty wierd, but its the way audio engineers expect it. Just remember that
+		 This is pretty weird, but its the way audio engineers expect it. Just remember that
 		 the center of the USA isn't Kansas, its (50LA, 50NY) and it will all make sense.
 		 */
 

--- a/gtk2_ardour/nag.cc
+++ b/gtk2_ardour/nag.cc
@@ -167,7 +167,7 @@ NagScreen::is_subscribed (bool& really)
 	really = false;
 
 	/* what we'd really like here is a way to query paypal
-	   for someone's subscription status. thats a bit complicated
+	   for someone's subscription status. that's a bit complicated
 	   so for now, just see if they ever told us they were
 	   subscribed. we try to trust our users :)
 	*/

--- a/gtk2_ardour/new_user_wizard.cc
+++ b/gtk2_ardour/new_user_wizard.cc
@@ -503,7 +503,7 @@ NewUserWizard::on_apply ()
 				continue;
 			}
 			/* skip sessions that are already in 'recent'.
-			 * eg. a new user changed <session-default-dir> shorly after installation
+			 * eg. a new user changed <session-default-dir> shortly after installation
 			 */
 			for (ARDOUR::RecentSessions::iterator r = rs.begin(); r != rs.end(); ++r) {
 				if ((*r).first == name) {

--- a/gtk2_ardour/playlist_selector.cc
+++ b/gtk2_ardour/playlist_selector.cc
@@ -441,7 +441,7 @@ PlaylistSelector::on_key_press_event (GdkEventKey* ev)
 			break;
 	}
 
-	/* Don't just forward the key press ... make it act as if it occured in
+	/* Don't just forward the key press ... make it act as if it occurred in
 	 * whatever the main window currently is.
 	 */
 	Gtk::Window& main_window (ARDOUR_UI::instance ()->main_window ());

--- a/gtk2_ardour/plugin_manager_ui.cc
+++ b/gtk2_ardour/plugin_manager_ui.cc
@@ -50,7 +50,7 @@ using namespace ARDOUR_PLUGIN_UTILS;
 PluginManagerUI::PluginManagerUI ()
 	: ArdourWindow (_("Plugin Manager"))
 	, _btn_reindex (_("Update Index Only"))
-	, _btn_discover (_("Disover New/Updated"))
+	, _btn_discover (_("Discover New/Updated"))
 	, _btn_rescan_all (_("Re-scan All"))
 	, _btn_rescan_err (_("Re-scan Faulty"))
 	, _btn_rescan_sel (_("Re-scan Selected"))

--- a/gtk2_ardour/plugin_pin_dialog.cc
+++ b/gtk2_ardour/plugin_pin_dialog.cc
@@ -508,7 +508,7 @@ PluginPinWidget::refill_output_presets ()
 
 	PluginOutputConfiguration ppc (_pi->plugin (0)->possible_output ());
 	if (ppc.find (0) != ppc.end ()) {
-		// anyting goes
+		// anything goes
 		ppc.clear ();
 		if (n_audio != 0) {
 			ppc.insert (n_audio);

--- a/gtk2_ardour/plugin_setup_dialog.cc
+++ b/gtk2_ardour/plugin_setup_dialog.cc
@@ -122,7 +122,7 @@ PluginSetupDialog::setup_output_presets ()
 	_out_presets.AddMenuElem (MenuElem (_("Automatic"), sigc::bind (sigc::mem_fun (*this, &PluginSetupDialog::select_output_preset), 0)));
 
 	if (ppc.find (0) != ppc.end ()) {
-		// anyting goes
+		// anything goes
 		ppc.clear ();
 		ppc.insert (1);
 		ppc.insert (2);

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -1884,7 +1884,7 @@ ProcessorBox::~ProcessorBox ()
 	 * pointer to a widget owned by the UI Manager, and has potentially
 	 * be returned to many other ProcessorBoxes. GTK doesn't really make
 	 * clear the ownership of this widget, which is a menu and thus is
-	 * never packed into any container other than an implict GtkWindow.
+	 * never packed into any container other than an implicit GtkWindow.
 	 *
 	 * For now, until or if we ever get clarification over the ownership
 	 * story just let it continue to exist. At worst, its a small memory leak.

--- a/gtk2_ardour/rc_option_editor.cc
+++ b/gtk2_ardour/rc_option_editor.cc
@@ -2012,7 +2012,7 @@ class ColumVisibilityOption : public Option
 };
 
 
-/** A class which allows control of visibility of some editor components usign
+/** A class which allows control of visibility of some editor components using
  *  a VisibilityGroup.  The caller should pass in a `dummy' VisibilityGroup
  *  which has the correct members, but with null widget pointers.  This
  *  class allows the user to set visibility of the members, the details

--- a/gtk2_ardour/region_view.cc
+++ b/gtk2_ardour/region_view.cc
@@ -592,7 +592,7 @@ RegionView::update_cue_markers ()
 		if (existing == _cue_markers.end()) {
 
 			if (c->position() < start || c->position() >= end) {
-				/* not withing this region */
+				/* not within this region */
 				continue;
 			}
 
@@ -618,7 +618,7 @@ RegionView::update_cue_markers ()
 		} else {
 
 			if (c->position() < start || c->position() >= end) {
-				/* not withing this region */
+				/* not within this region */
 				delete (*existing);
 				_cue_markers.erase (existing);
 				continue;

--- a/gtk2_ardour/route_group_dialog.cc
+++ b/gtk2_ardour/route_group_dialog.cc
@@ -229,7 +229,7 @@ RouteGroupDialog::gain_toggled ()
 	_relative.set_sensitive (_gain.get_active ());
 }
 
-/** @return true if the current group's name is unique accross the session */
+/** @return true if the current group's name is unique across the session */
 bool
 RouteGroupDialog::unique_name (std::string const name) const
 {

--- a/gtk2_ardour/route_time_axis.cc
+++ b/gtk2_ardour/route_time_axis.cc
@@ -469,7 +469,7 @@ RouteTimeAxisView::update_track_number_visibility ()
 		}
 		// see ArdourButton::on_size_request(), we should probably use a global size-group here instead.
 		// except the width of the number label is subtracted from the name-hbox, so we
-		// need to explictly calculate it anyway until the name-label & entry become ArdourWidgets.
+		// need to explicitly calculate it anyway until the name-label & entry become ArdourWidgets.
 		int tnw = (2 + std::max(2u, _session->track_number_decimals())) * number_label.char_pixel_width();
 		if (tnw & 1) --tnw;
 		number_label.set_size_request(tnw, -1);

--- a/gtk2_ardour/selection.cc
+++ b/gtk2_ardour/selection.cc
@@ -166,7 +166,7 @@ Selection::clear_regions (bool with_signal)
 void
 Selection::clear_midi_notes (bool with_signal)
 {
-	/* Remmeber: MIDI notes are only stored here if we're using a Selection
+	/* Remember: MIDI notes are only stored here if we're using a Selection
 	   object as a cut buffer.
 	*/
 
@@ -536,7 +536,7 @@ Selection::add (boost::shared_ptr<Evoral::ControlList> cl)
 
 	/* The original may change so we must store a copy (not a pointer) here.
 	 * e.g AutomationLine rewrites the list with gain mapping.
-	 * the downside is that we can't perfom duplicate checks.
+	 * the downside is that we can't perform duplicate checks.
 	 * This code was changed in response to #6842
 	 */
 	lines.push_back (boost::shared_ptr<ARDOUR::AutomationList> (new ARDOUR::AutomationList(*al)));
@@ -1509,7 +1509,7 @@ Selection::set (const TrackViewList& track_list)
 
 	CoreSelection& selection (editor->session()->selection());
 
-#if 1 // crazy optmization hack
+#if 1 // crazy optimization hack
 	/* check is the selection actually changed, ignore NO-OPs
 	 *
 	 * There are excessive calls from EditorRoutes::selection_changed():

--- a/gtk2_ardour/session_metadata_dialog.h
+++ b/gtk2_ardour/session_metadata_dialog.h
@@ -270,7 +270,7 @@ private:
 
 /// Metadata dialog interface
 /**
- * The DataSets are initalized in this class so that all
+ * The DataSets are initialized in this class so that all
  * Dialogs have the same sets of data in the same order.
  */
 template <typename DataSet>

--- a/gtk2_ardour/session_option_editor.cc
+++ b/gtk2_ardour/session_option_editor.cc
@@ -182,7 +182,7 @@ SessionOptionEditor::SessionOptionEditor (Session* s)
 		sigc::mem_fun (*_session_config, &SessionConfiguration::set_native_file_data_format)
 		);
 	add_option (_("Media"), _sf);
-	/* refill available sample-formats, depening on file-format */
+	/* refill available sample-formats, depending on file-format */
 	parameter_changed ("native-file-header-format");
 
 	ComboOption<HeaderFormat>* hf = new ComboOption<HeaderFormat> (

--- a/gtk2_ardour/startup_fsm.cc
+++ b/gtk2_ardour/startup_fsm.cc
@@ -658,7 +658,7 @@ StartupFSM::get_session_parameters_from_path (string const & path, string const 
 		}
 
 		if (!have_resolved_template_name) {
-			/* this will produce a more or less meaninful error later:
+			/* this will produce a more or less meaningful error later:
 			 * "ERROR: Could not open session template [abs-path to user-config dir]"
 			 */
 			session_template = Glib::build_filename (ARDOUR::user_template_directory (), template_name);
@@ -687,7 +687,7 @@ StartupFSM::get_session_parameters_from_path (string const & path, string const 
 /** return values:
  * -1: failure
  *  1: failure but user can retry
- *  0: success, seesion parameters ready for use
+ *  0: success, session parameters ready for use
  */
 int
 StartupFSM::check_session_parameters (bool must_be_new)
@@ -729,7 +729,7 @@ StartupFSM::check_session_parameters (bool must_be_new)
 	/* check for ".ardour" in statefile name, because we don't want
 	 * it
 	 *
-	 * XXX Note this wierd conflation of a
+	 * XXX Note this weird conflation of a
 	 * file-name-without-a-suffix and the session name. It's not
 	 * really a session name at all, but rather the suffix-free
 	 * name of a statefile (snapshot).
@@ -871,7 +871,7 @@ StartupFSM::copy_demo_sessions ()
 				continue;
 			}
 			/* skip sessions that are already in 'recent'.
-			 * eg. a new user changed <session-default-dir> shorly after installation
+			 * eg. a new user changed <session-default-dir> shortly after installation
 			 */
 			for (ARDOUR::RecentSessions::iterator r = rs.begin(); r != rs.end(); ++r) {
 				if ((*r).first == name) {

--- a/gtk2_ardour/stereo_panner.cc
+++ b/gtk2_ardour/stereo_panner.cc
@@ -126,7 +126,7 @@ StereoPanner::set_tooltip ()
 	   This is expressed as a pair of percentage values that ranges from (100,0)
 	   (hard left) through (50,50) (hard center) to (0,100) (hard right).
 
-	   This is pretty wierd, but its the way audio engineers expect it. Just remember that
+	   This is pretty weird, but its the way audio engineers expect it. Just remember that
 	   the center of the USA isn't Kansas, its (50LA, 50NY) and it will all make sense.
 	*/
 

--- a/gtk2_ardour/strip_silence_dialog.cc
+++ b/gtk2_ardour/strip_silence_dialog.cc
@@ -187,8 +187,8 @@ StripSilenceDialog::silences (AudioIntervalMap& m)
 void
 StripSilenceDialog::drop_rects ()
 {
-	// called by parent when starting to progess (dialog::run returned),
-	// but before the dialog is destoyed.
+	// called by parent when starting to progress (dialog::run returned),
+	// but before the dialog is destroyed.
 
 	_interthread_info.cancel = true;
 

--- a/gtk2_ardour/time_axis_view.cc
+++ b/gtk2_ardour/time_axis_view.cc
@@ -977,7 +977,7 @@ TimeAxisView::order_selection_trims (ArdourCanvas::Item *item, bool put_start_on
 	}
 }
 
-// retuned rect is pushed back into the used_selection_rects list
+// returned rect is pushed back into the used_selection_rects list
 // in TimeAxisView::show_selection() which is the only caller.
 SelectionRect *
 TimeAxisView::get_selection_rect (uint32_t id)

--- a/gtk2_ardour/time_axis_view.h
+++ b/gtk2_ardour/time_axis_view.h
@@ -275,7 +275,7 @@ protected:
 
 	virtual bool name_entry_changed (std::string const&);
 
-	/** Handle mouse relaese on our LHS control name ebox.
+	/** Handle mouse release on our LHS control name ebox.
 	 *
 	 *@ param ev the event
 	 */

--- a/gtk2_ardour/time_axis_view_item.cc
+++ b/gtk2_ardour/time_axis_view_item.cc
@@ -902,7 +902,7 @@ TimeAxisViewItem::manage_name_text ()
 
 /**
  * Callback used to remove this time axis item during the gtk idle loop.
- * This is used to avoid deleting the obejct while inside the remove_this_item
+ * This is used to avoid deleting the object while inside the remove_this_item
  * method.
  *
  * @param item the TimeAxisViewItem to remove.

--- a/gtk2_ardour/time_axis_view_item.h
+++ b/gtk2_ardour/time_axis_view_item.h
@@ -131,7 +131,7 @@ public:
 	/** Emitted when the name of this item is changed */
 	sigc::signal<void,std::string,std::string,void*> NameChanged;
 
-	/** Emiited when the position of this item changes */
+	/** Emitted when the position of this item changes */
 	sigc::signal<void,Temporal::timepos_t,void*> PositionChanged;
 
 	/** Emitted when the position lock of this item is changed */

--- a/gtk2_ardour/transport_control.h
+++ b/gtk2_ardour/transport_control.h
@@ -24,7 +24,7 @@
 
 #include "ardour/session_handle.h"
 
-/* This is an API implemenetd by AROUR_UI,
+/* This is an API implemented by AROUR_UI,
  * and made available to transport-control-UIs
  */
 class TransportControlProvider

--- a/gtk2_ardour/trigger_clip_picker.cc
+++ b/gtk2_ardour/trigger_clip_picker.cc
@@ -286,7 +286,7 @@ TriggerClipPicker::maybe_add_dir (std::string const& dir)
 	_dir.AddMenuElem (Gtkmm2ext::MenuElemNoMnemonic (display_name (dir), sigc::bind (sigc::mem_fun (*this, &TriggerClipPicker::list_dir), dir, (Gtk::TreeNodeChildren*)0)));
 
 	/* check if a parent path of the given dir already exists,
-	 * or if this new path is parent to any exising ones.
+	 * or if this new path is parent to any existing ones.
 	 */
 	bool insert = true;
 	auto it = _root_paths.begin ();

--- a/gtk2_ardour/trigger_page.cc
+++ b/gtk2_ardour/trigger_page.cc
@@ -421,7 +421,7 @@ TriggerPage::add_routes (RouteList& rl)
 			continue;
 		}
 #if 0
-		/* TODO, only subscribe to PropertyChanged, create (and destory) TriggerStrip as needed.
+		/* TODO, only subscribe to PropertyChanged, create (and destroy) TriggerStrip as needed.
 		 * For now we just hide non trigger strips.
 		 */
 		if (!(*r)->presentation_info ().trigger_track ()) {

--- a/gtk2_ardour/trigger_source_list.cc
+++ b/gtk2_ardour/trigger_source_list.cc
@@ -31,7 +31,7 @@ TriggerSourceList::TriggerSourceList ()
 	setup_col (append_col (_columns.channels, "Chans    "), 1, ALIGN_LEFT, _("# Ch"), _("# Channels in the region"));
 	add_tag_column ();
 
-	setup_col (append_col (_columns.captd_xruns, "1234567890"), 21, ALIGN_RIGHT, _("# Xruns"), _("Number of dropouts that occured during recording"));
+	setup_col (append_col (_columns.captd_xruns, "1234567890"), 21, ALIGN_RIGHT, _("# Xruns"), _("Number of dropouts that occurred during recording"));
 	setup_col (append_col (_columns.take_id, "2021-01-19 02:34:03"), 18, ALIGN_LEFT, _("Take ID"), _("Take ID"));
 	_display.get_column (0)->set_resizable (true);
 }

--- a/gtk2_ardour/ui_config.h
+++ b/gtk2_ardour/ui_config.h
@@ -31,7 +31,7 @@
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
 
-#include "ardour/types.h" // required for opeators used in pbd/configuration_variable.h
+#include "ardour/types.h" // required for operators used in pbd/configuration_variable.h
 #include "ardour/types_convert.h"
 
 #include "pbd/stateful.h"

--- a/gtk2_ardour/vca_time_axis.cc
+++ b/gtk2_ardour/vca_time_axis.cc
@@ -303,7 +303,7 @@ VCATimeAxisView::update_track_number_visibility ()
 
 		// see ArdourButton::on_size_request(), we should probably use a global size-group here instead.
 		// except the width of the number label is subtracted from the name-hbox, so we
-		// need to explictly calculate it anyway until the name-label & entry become ArdourWidgets.
+		// need to explicitly calculate it anyway until the name-label & entry become ArdourWidgets.
 
 		int tnw = (2 + std::max(2u, _session->track_number_decimals())) * number_label.char_pixel_width();
 		if (tnw & 1) --tnw;

--- a/gtk2_ardour/video_timeline.cc
+++ b/gtk2_ardour/video_timeline.cc
@@ -329,7 +329,7 @@ VideoTimeLine::update_video_timeline()
 		/* high-zoom: need space between successive video-frames */
 		vtl_dist = rint(apv);
 	} else {
-		/* continous timeline: skip video-frames */
+		/* continuous timeline: skip video-frames */
 		vtl_dist = ceil(display_vframe_width * samples_per_pixel / apv) * apv;
 	}
 

--- a/gtk2_ardour/video_timeline.h
+++ b/gtk2_ardour/video_timeline.h
@@ -41,7 +41,7 @@ class PublicEditor;
  *
  *  The video-timeline can be displayed in a canvas-group. Given a filename
  *  it queries the video-server about file-information and
- *  creates \ref VideoImageFrame as neccesary (which
+ *  creates \ref VideoImageFrame as necessary (which
  *  query the server for image-data).
  *
  *  This class contains the algorithm to position the single frames
@@ -49,7 +49,7 @@ class PublicEditor;
  *  attributes. see \ref update_video_timeline()
  *
  *  The VideoTimeLine class includes functionality to launch a video-monitor
- *  corresponding to its currently diplayed file.
+ *  corresponding to its currently displayed file.
  */
 class VideoTimeLine : public sigc::trackable, public ARDOUR::SessionHandlePtr, public PBD::ScopedConnectionList, public PBD::StatefulDestructible
 {

--- a/libs/ardour/ardour/port_engine.h
+++ b/libs/ardour/ardour/port_engine.h
@@ -283,7 +283,7 @@ public:
 	 */
 	virtual bool  connected_to (PortHandle port, const std::string& name, bool process_callback_safe = true) = 0;
 
-	/** Test if given \p port is is connected to physical I/O ports.
+	/** Test if given \p port is connected to physical I/O ports.
 	 *
 	 * @param port \ref PortHandle of source port to test
 	 * @param process_callback_safe true if this method is not called from rt-context of backend callbacks

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -1101,7 +1101,7 @@ public:
 	 * Test if any undo commands were added since the
 	 * call to begin_reversible_command ()
 	 *
-	 * This is is useful to determine if an undoable
+	 * This is useful to determine if an undoable
 	 * action was performed before adding additional
 	 * information (e.g. selection changes) to the
 	 * undo transaction.

--- a/libs/ardour/ardour/worker.h
+++ b/libs/ardour/ardour/worker.h
@@ -97,7 +97,7 @@ private:
 	/**
 	   Peek in RB, get size and check if a block of 'size' is available.
 
-	   Handle the unlikley edge-case, if we're called in between the
+	   Handle the unlikely edge-case, if we're called in between the
 	   responder writing 'size' and 'data'.
 
 	   @param rb the ringbuffer to check

--- a/libs/ardour/mute_control.cc
+++ b/libs/ardour/mute_control.cc
@@ -198,7 +198,7 @@ MuteControl::automation_run (samplepos_t start, pframes_t len)
 
 	if (muted_by_masters ()) {
 		/* already muted, no need to check further,
-		 * except we need to up update implicit/explict mute
+		 * except we need to up update implicit/explicit mute
 		 */
 		if (muted_by_self () != mute) {
 			set_value_unchecked (mute ? 1. : 0.);

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -2105,7 +2105,7 @@ Route::apply_processor_order (const ProcessorList& new_order)
 	 * (note though that  ::processors_reorder_needs_configure() ensured that
 	 * this function will only ever be called from the rt-thread if no processor were removed)
 	 *
-	 * either way, I can't proove it, but an xrun due to re-order here is less likley
+	 * either way, I can't proove it, but an xrun due to re-order here is less likely
 	 * than an xrun-less 'ardour-silent cycle' both of which effectively "click".
 	 */
 


### PR DESCRIPTION
This commit only includes typos in the `gtk2_ardour/` directory very easier review. 

Found via `codespell -q 3 -S *.po,./share/patchfiles,./libs -L ba,buss,busses,doubleclick,hsi,ontop,ro,seh,siz,sur,te,trough,ue`