### PR TITLE
Update dark-ardour.colors - outline of selected midi notes

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -229,7 +229,7 @@
     <ColorAlias name="midi note mid" alias="alert:yellow"/>
     <ColorAlias name="midi note min" alias="alert:orange"/>
     <ColorAlias name="midi note selected" alias="widget:ruddy"/>
-    <ColorAlias name="midi note selected outline" alias="alert:red"/>
+    <ColorAlias name="midi note selected outline" alias="neutral:foregroundest"/>
     <ColorAlias name="midi note velocity text" alias="theme:contrasting"/>
     <ColorAlias name="midi patch change fill" alias="theme:contrasting selection"/>
     <ColorAlias name="midi patch change outline" alias="neutral:foreground"/>


### PR DESCRIPTION
This PR changes color of the outline of the selected midi notes from the red (which is almost not noticeable especially in big amount of velocity) -> to the brightest white.

![midi_note_selected_outline](https://user-images.githubusercontent.com/19673308/152115281-411769be-2e15-4287-a0c0-5cdd1770e6e5.gif)
