### PR TITLE
Update dark-ardour.colors - G&E difference

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -484,7 +484,7 @@
     <Modifier name="loop rectangle" modifier="= alpha:0.5"/>
     <Modifier name="marker bar" modifier="= alpha:0.5"/>
     <Modifier name="grid line" modifier="= alpha:1.0"/>
-    <Modifier name="midi frame base" modifier="= alpha:0.4"/>
+    <Modifier name="midi frame base" modifier="= alpha:0.79"/>
     <Modifier name="midi note" modifier="= alpha:0.8"/>
     <Modifier name="midi note velocity text" modifier="= alpha:0.4666"/>
     <Modifier name="midi patch change fill" modifier="= alpha:0.6274"/>


### PR DESCRIPTION
This PR changes (increases ) the opacity of midi regions in "G" mode. This makes more noticeable the difference between "G&E" modes.
![G_E_difference](https://user-images.githubusercontent.com/19673308/152119361-5ae79d5d-d5fb-475b-99e4-caf181253254.gif)
