### PR TITLE
Update dark-ardour.colors - tooltip bg

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -119,7 +119,7 @@
     <ColorAlias name="gtk_background" alias="theme:bg"/>
     <ColorAlias name="gtk_bases" alias="theme:bg2"/>
     <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
-    <ColorAlias name="gtk_bg_tooltip" alias="neutral:backgroundest"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="theme:contrasting clock"/>
     <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
     <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
@@ -130,7 +130,7 @@
     <ColorAlias name="gtk_darkest" alias="theme:bg2"/>
     <ColorAlias name="gtk_entry_cursor" alias="alert:red"/>
     <ColorAlias name="gtk_fg_selected" alias="theme:bg2"/>
-    <ColorAlias name="gtk_fg_tooltip" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_fg_tooltip" alias="neutral:background"/>
     <ColorAlias name="gtk_foldback_bg" alias="theme:bg1"/>
     <ColorAlias name="gtk_foreground" alias="neutral:foreground"/>
     <ColorAlias name="gtk_light_text_on_dark" alias="neutral:foreground2"/>


### PR DESCRIPTION
This PR changes the background of tool-tip notifications from current **black&white** (Robin's commit) (I think it makes some mess in grid and ruler's areas, which are already black&white) **->** to the theme's general **green**. The old one (pale-blue) also looks too boring/// Again it's all on my subjective taste.))
![tooltip_bg](https://user-images.githubusercontent.com/19673308/152127121-04e8893b-6051-4685-9aef-630dbd41cba8.gif)
