### PR TITLE
Update dark-ardour.colors - loop rectangle&markers

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -168,7 +168,7 @@
     <ColorAlias name="layered button: fill" alias="widget:bg"/>
     <ColorAlias name="layered button: fill active" alias="alert:ruddy"/>
     <ColorAlias name="location cd marker" alias="theme:contrasting less"/>
-    <ColorAlias name="location loop" alias="theme:contrasting less"/>
+    <ColorAlias name="location loop" alias="alert:blue"/>
     <ColorAlias name="location marker" alias="theme:contrasting less"/>
     <ColorAlias name="location punch" alias="widget:ruddy"/>
     <ColorAlias name="location range" alias="theme:contrasting less"/>
@@ -444,7 +444,7 @@
     <ColorAlias name="transport delta clock: edited text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport delta clock: text" alias="theme:contrasting alt"/>
     <ColorAlias name="transport drag rect" alias="neutral:midground"/>
-    <ColorAlias name="transport loop rect" alias="alert:green"/>
+    <ColorAlias name="transport loop rect" alias="widget:blue"/>
     <ColorAlias name="transport marker bar" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill" alias="widget:bg"/>
     <ColorAlias name="transport option button: fill active" alias="widget:bg"/>


### PR DESCRIPTION
This PR changes location loop markers from green (which is the same of "Start&End" markers) -> to alert blue. Also the loop rectangle changes from total ubiquitous green (especially when we have a lot of automation lines opened which are all green) to calm blue.
![loop](https://user-images.githubusercontent.com/19673308/152136089-1d1f4fe8-881d-440b-bd99-356f071103a1.gif)
![loop automation](https://user-images.githubusercontent.com/19673308/152138557-36f8d91c-6ff4-4404-bb9a-831163b8648d.gif)

