### PR TITLE
Update dark-ardour.colors - secondary clock

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -363,7 +363,7 @@
     <ColorAlias name="secondary clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary clock: cursor" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary clock: edited text" alias="theme:contrasting alt"/>
-    <ColorAlias name="secondary clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="secondary clock: text" alias="neutral:foregroundest"/>
     <ColorAlias name="secondary delta clock: background" alias="theme:bg2"/>
     <ColorAlias name="secondary delta clock: cursor" alias="theme:contrasting alt"/>
     <ColorAlias name="secondary delta clock: edited text" alias="theme:contrasting alt"/>


### PR DESCRIPTION
The PR changes the text color of the secondary clock from green -> to white. This unloads the greenish value and adds some difference from the main clock.
![secondary_clock](https://user-images.githubusercontent.com/19673308/152139707-516176be-e31b-4ce1-96d7-8fd4442d6f21.gif)
