### PR TITLE
Update dark-ardour.colors - spicy green

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -13,7 +13,7 @@
     <Color name="theme:bg1" value="373737ff"/>  <!--gtk_audio_track-->
     <Color name="theme:bg2" value="101010ff"/>  <!--ruler base-->
     <Color name="theme:contrasting" value="0xf10000ff"/>  <!--play head-->
-    <Color name="theme:contrasting clock" value="4BCD2FFF"/>  <!--clock: text-->
+    <Color name="theme:contrasting clock" value="78cd2fff"/>  <!--clock: text-->
     <Color name="theme:contrasting less" value="46B357FF"/>
     <Color name="theme:contrasting selection" value="5da3c1ff"/>  <!--gtk_bg_selected-->
     <Color name="theme:contrasting alt" value="CCA336ff"/>  <!--delta clock , clock edit-->


### PR DESCRIPTION
**&&&**....As a spicy cherry on the cake: this PR adds some yellow -> to the default contrasting clock green. (it was inspired by:
https://discourse.ardour.org/t/opencolor-based-ardour-color-theme/106691)
![contrasting_green_spice](https://user-images.githubusercontent.com/19673308/152141833-a2107573-5e2e-42bd-baaa-b6715cc539c3.gif)

Here's the summary result theme to test:

https://github.com/cooltehno/ardour6_themes/blob/master/dark_02_02_2022/dark_02_02_2022-ardour.colors
