### PR TITLE
Fix various typos

### DIFF
--- a/doc/source_tree_layout.txt
+++ b/doc/source_tree_layout.txt
@@ -28,7 +28,7 @@ libs/
 
  - libs/ardouralsautil/
    Utility Class for device-listing (used by the jack and  ALSA backends).
-   Device-reservation comandline tool (linked against libdbus), which is
+   Device-reservation commandline tool (linked against libdbus), which is
    also available from https://github.com/x42/alsa_request_device
 
  - libs/clearlooks-newer/
@@ -70,7 +70,7 @@ libs/
    VAMP plugins for audio analysis and offline processing (uses qm-dsp)
 
  - libs/vamp-pyin/
-   VAMP plugins for pitch and note-tracking (uses qm-dsp), offline analyis
+   VAMP plugins for pitch and note-tracking (uses qm-dsp), offline analysis
 
  - libs/vfork/
    A exec-wrapper which redirects file-descriptors to be used with vfork(2)
@@ -85,10 +85,10 @@ libs/
    independent (a-fluidsynth uses libfluidsynth).
    Most of them are custom version of existing plugins (zamaudio, x42),
    that have been customized to be bundled with Ardour on all platforms
-   tha ardour runs on.
+   that ardour runs on.
 
  - libs/zita-convolver/
-   convolution kernel, so far only avialable to Lua scripts.
+   convolution kernel, so far only available to Lua scripts.
 
  - libs/zita-resampler/
    Efficient resampler with variable rate, useful for adaptive resampling.

--- a/gtk2_ardour/au_pluginui.mm
+++ b/gtk2_ardour/au_pluginui.mm
@@ -364,7 +364,7 @@ static void interposed_drawIfNeeded (id receiver, SEL selector, NSRect rect)
 
 - (void)auViewResized:(NSNotification *)notification
 {
-	(void) notification; // stop complaints about unusued argument
+	(void) notification; // stop complaints about unused argument
 	plugin_ui->cocoa_view_resized();
 }
 

--- a/gtk2_ardour/recorder_ui.cc
+++ b/gtk2_ardour/recorder_ui.cc
@@ -692,7 +692,7 @@ RecorderUI::update_meters ()
 {
 	PortManager::AudioInputPorts const aip (AudioEngine::instance ()->audio_input_ports ());
 
-	/* scope data needs to be read contiously */
+	/* scope data needs to be read continuously */
 	for (PortManager::AudioInputPorts::const_iterator i = aip.begin (); i != aip.end (); ++i) {
 		InputPortMap::iterator im = _input_ports.find (i->first);
 		if (im != _input_ports.end()) {

--- a/gtk2_ardour/region_view.h
+++ b/gtk2_ardour/region_view.h
@@ -196,8 +196,8 @@ protected:
 
 	boost::shared_ptr<ARDOUR::Region> _region;
 
-	ArdourCanvas::Polygon* sync_mark; ///< polgyon for sync position
-	ArdourCanvas::Line* sync_line; ///< polgyon for sync position
+	ArdourCanvas::Polygon* sync_mark; ///< polygon for sync position
+	ArdourCanvas::Line* sync_line; ///< polygon for sync position
 
 	RegionEditor* editor;
 

--- a/gtk2_ardour/sfdb_freesound_mootcher.cc
+++ b/gtk2_ardour/sfdb_freesound_mootcher.cc
@@ -16,7 +16,7 @@
 
 	Includes:
 		curl.h    (version 7.14.0)
-	Librarys:
+	Libraries:
 		libcurl.lib
 
 	-----------------------------------------------------------------

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -1115,7 +1115,7 @@ public:
 	}
 
 	/**
-	 * Abort reversible commend IFF no undo changes
+	 * Abort reversible command IFF no undo changes
 	 * have been collected.
 	 * @return true if undo operation was aborted.
 	 */

--- a/libs/ardour/clip_library.cc
+++ b/libs/ardour/clip_library.cc
@@ -91,7 +91,7 @@ ARDOUR::clip_library_dir (bool create_if_missing)
 		XMLTree tree;
 		tree.set_root (root);
 		if (!tree.write (Glib::build_filename (p, ".daw-meta.xml"))) {
-			error << string_compose (_("Could not save Clip Libary meta-data in '%1'"), p) << endmsg;
+			error << string_compose (_("Could not save Clip Library meta-data in '%1'"), p) << endmsg;
 		}
 
 	} else if (!Glib::file_test (p, Glib::FILE_TEST_IS_DIR)) {

--- a/libs/backends/alsa/alsa_audiobackend.cc
+++ b/libs/backends/alsa/alsa_audiobackend.cc
@@ -2455,7 +2455,7 @@ AlsaDeviceReservation::acquire_device (const char* device_name)
 		return false;
 	}
 
-	/* wait to check if reservation suceeded. */
+	/* wait to check if reservation succeeded. */
 	int timeout = 500; // 5 sec
 	while (_device_reservation && !_reservation_succeeded && --timeout > 0) {
 		Glib::usleep (10000);

--- a/libs/gtkmm2ext/actions.cc
+++ b/libs/gtkmm2ext/actions.cc
@@ -359,7 +359,7 @@ ActionManager::create_action_group (void * owner, string const & name)
 	   has to touch the GTK one, because we want the GtkUIManager to
 	   be able to create widgets (particularly Menus) from our actions.
 
-	   This is a a necessary step for that to happen.
+	   This is a necessary step for that to happen.
 	*/
 
 	if (g) {

--- a/msvc_extra_headers/immintrin.h.input
+++ b/msvc_extra_headers/immintrin.h.input
@@ -1,4 +1,4 @@
 /*
-** Emtpy file to prevent Win32 compiler from complaining that the
+** Empty file to prevent Win32 compiler from complaining that the
 ** file doesn't exist.
 */

--- a/msvc_extra_headers/unistd.h.input
+++ b/msvc_extra_headers/unistd.h.input
@@ -1,4 +1,4 @@
 /*
-** Emtpy file to prevent Win32 compiler from complaining that the
+** Empty file to prevent Win32 compiler from complaining that the
 ** file doesn't exist.
 */

--- a/nutemp/t.cc
+++ b/nutemp/t.cc
@@ -635,7 +635,7 @@ TempoMap::set_tempo_and_meter (Tempo const & tempo, Meter const & meter, supercl
 	}
 
 	if (e->metric().ramped()) {
-		/* need to adjust ramp constants for preceding explict point, since the new point will be positioned right after it
+		/* need to adjust ramp constants for preceding explicit point, since the new point will be positioned right after it
 		   and thus defines the new ramp distance.
 		*/
 		e->compute_c_superclock (_sample_rate, tempo.superclocks_per_quarter_note (), sc);
@@ -726,7 +726,7 @@ TempoMap::set_tempo (Tempo const & t, superclock_t sc, bool ramp)
 	}
 
 	if (e->metric().ramped()) {
-		/* need to adjust ramp constants for preceding explict point, since the new point will be positioned right after it
+		/* need to adjust ramp constants for preceding explicit point, since the new point will be positioned right after it
 		   and thus defines the new ramp distance.
 		*/
 		e->compute_c_superclock (_sample_rate, t.superclocks_per_quarter_note (), sc);

--- a/session_utils/copy-mixer.cc
+++ b/session_utils/copy-mixer.cc
@@ -265,7 +265,7 @@ static void usage () {
 This utility copies mixer-settings from the src-session to the dst-session.\n\
 Both <src> and <dst> are paths to .ardour session files.\n\
 If --snapshot is not given, the <dst> session file is overwritten.\n\
-When --snapshot is set, a new snaphot in the <dst> session is created.\n\
+When --snapshot is set, a new snapshot in the <dst> session is created.\n\
 \n");
 
 	printf ("Report bugs to <http://tracker.ardour.org/>\n"

--- a/share/scripts/HiAndLowPass.lua
+++ b/share/scripts/HiAndLowPass.lua
@@ -254,7 +254,7 @@ function dsp_run (ins, outs, n_samples)
 				hp[c][ho+1]:run (mem:to_float (off), siz)
 				ARDOUR.DSP.mix_buffers_with_gain (outs[c]:offset (off), mem:to_float (off), siz, xfade)
 				-- also run the next biquad because it needs to have the correct state
-				-- in case it start affecting the next chunck of output. Higher order
+				-- in case it start affecting the next chunk of output. Higher order
 				-- ones are guaranteed not to be needed for the next run because the
 				-- interpolated order won't increase more than 0.86 in one step thanks
 				-- to the choice of the value of |lpf|.
@@ -283,7 +283,7 @@ function dsp_run (ins, outs, n_samples)
 				lp[c][lo+1]:run (mem:to_float (off), siz)
 				ARDOUR.DSP.mix_buffers_with_gain (outs[c]:offset (off), mem:to_float (off), siz, xfade)
 				-- also run the next biquad in case it start affecting the next
-				-- chunck of output.
+				-- chunk of output.
 				if lo + 2 <= 4 then lp[c][lo+2]:run (mem:to_float (off), siz) end
 			elseif lo + 1 <= 4 then
 				-- run the next biquad in case it is used next chunk

--- a/share/scripts/_midi_rec_start.lua
+++ b/share/scripts/_midi_rec_start.lua
@@ -24,7 +24,7 @@ function factory ()
 				if (e:buffer():array()[1] & 0xf0) == 0x90 then -- note on
 					Session:maybe_enable_record (true) -- global record-enable from rt-context
 					-- maybe-enable may fail if there are no tracks or step-entry is active
-					-- roll transport if record-enable suceeded:
+					-- roll transport if record-enable succeeded:
 					if ARDOUR.Session.RecordState.Enabled == Session:record_status() then
 						Session:request_roll (ARDOUR.TransportRequestSource.TRS_UI) -- ...and go.
 					end

--- a/share/scripts/_rawmidi.lua
+++ b/share/scripts/_rawmidi.lua
@@ -18,7 +18,7 @@ function dsp_configure (ins, outs)
 	n_out = outs
 end
 
--- "dsp_runmap" uses Ardour's internal processor API, eqivalent to
+-- "dsp_runmap" uses Ardour's internal processor API, equivalent to
 -- 'connect_and_run()". There is no overhead (mapping, translating buffers).
 -- The lua implementation is responsible to map all the buffers directly.
 function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
@@ -76,7 +76,7 @@ function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 	end
 	-- Clear unconnected output buffers.
 	-- In case we're processing in-place some buffers may be identical,
-	-- so this must be done *after* copying relvant data from that port.
+	-- so this must be done *after* copying relevant data from that port.
 	for c = 1, audio_outs do
 		local ib = in_map:get (ARDOUR.DataType ("audio"), c - 1)
 		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1)

--- a/share/scripts/_route_template_generic_audio.lua
+++ b/share/scripts/_route_template_generic_audio.lua
@@ -29,7 +29,7 @@ function route_setup ()
 end
 
 -- The Script can be used as EditorAction in which case it *could*
--- optionally provide instantiation parmaters..
+-- optionally provide instantiation parameters..
 --[[
 function action_params ()
 	return

--- a/share/scripts/_route_template_generic_midi.lua
+++ b/share/scripts/_route_template_generic_midi.lua
@@ -27,7 +27,7 @@ function route_setup ()
 end
 
 -- The Script can be used as EditorAction in which case it can
--- optionally provide instantiation parmaters
+-- optionally provide instantiation parameters
 function action_params ()
 	return
 	{

--- a/share/scripts/_vamp_onset_example.lua
+++ b/share/scripts/_vamp_onset_example.lua
@@ -65,7 +65,7 @@ function factory () return function ()
 		--     f = vamp:plugin ():process (); callback (f)
 		vamp:analyze (r:to_readable (), 0, callback)
 
-		-- get remaining features (end of analyis)
+		-- get remaining features (end of analysis)
 		callback (vamp:plugin ():getRemainingFeatures ())
 
 		-- reset the plugin (prepare for next iteration)

--- a/share/scripts/_vamp_tempomap_example.lua
+++ b/share/scripts/_vamp_tempomap_example.lua
@@ -61,7 +61,7 @@ function factory () return function ()
 
 		-- run the plugin, analyze the first channel of the audio-region
 		vamp:analyze (r:to_readable (), 0, callback)
-		-- get remaining features (end of analyis)
+		-- get remaining features (end of analysis)
 		callback (vamp:plugin ():getRemainingFeatures ())
 		-- reset the plugin (prepare for next iteration)
 		vamp:reset ()

--- a/share/scripts/lfo_automation.lua
+++ b/share/scripts/lfo_automation.lua
@@ -153,7 +153,7 @@ function factory (unused_params)
             if k > 1 or v ~= last then
                -- Create automation point re-scaled to parameter target range. Do not create a new point
                -- at cycle start if the last cycle ended on the same value. Using al:add seems to lead
-               -- to unwanted extranous events. al:editor_add does not exhibit these side effects.
+               -- to unwanted extraneous events. al:editor_add does not exhibit these side effects.
                al:editor_add(pos, lower + v * (upper - lower), false)
             end
             last = v
@@ -161,7 +161,7 @@ function factory (unused_params)
       end
 
       -- remove dense events
-      al:thin (20) -- threashold of area below curve
+      al:thin (20) -- threshold of area below curve
 
       -- TODO: display the modified automation lane in the time line in order to make the change visible!
 

--- a/share/scripts/midi_cc_to_automation.lua
+++ b/share/scripts/midi_cc_to_automation.lua
@@ -55,7 +55,7 @@ function factory () return function ()
 		{ type = "heading", title = "Target Track and Plugin", align = "left"},
 		{ type = "dropdown", key = "param", title = "Target Parameter", values = targets }
 	}
-	local rv = LuaDialog.Dialog ("Select Taget", dialog_options):run ()
+	local rv = LuaDialog.Dialog ("Select Target", dialog_options):run ()
 
 	targets = nil -- drop references (the table holds shared-pointer references to all plugins)
 	collectgarbage () -- and release the references immediately

--- a/share/scripts/midi_remap.lua
+++ b/share/scripts/midi_remap.lua
@@ -8,7 +8,7 @@ ardour {
 }
 
 -- The number of remapping pairs to allow. Increasing this (at least in theory)
--- decreases performace, so it's set fairly low as a default. The user can
+-- decreases performance, so it's set fairly low as a default. The user can
 -- increase this if they have a need to.
 N_REMAPINGS = 10
 

--- a/share/scripts/notch_bank.lua
+++ b/share/scripts/notch_bank.lua
@@ -4,7 +4,7 @@ ardour {
 	category    = "Filter",
 	license     = "MIT",
 	author      = "Ardour Community",
-	description = [[Notch Filter Bank; useful to remove noise with a harmonic spectum (e.g, mains hum, GSM signals, charge-pump noise, etc).
+	description = [[Notch Filter Bank; useful to remove noise with a harmonic spectrum (e.g, mains hum, GSM signals, charge-pump noise, etc).
 Note: this plugin is not suitable to be automated, it is intended for static noise only.]]
 }
 

--- a/share/scripts/preare_record_example.lua
+++ b/share/scripts/preare_record_example.lua
@@ -13,8 +13,8 @@ following settings have to be ensured.
 * The last (failed) capture has to be cleared
 * Location markers have to be cleared
 
-So this script automizes away the task and lets the podcast moderator by just one
-action (for example triggerd by a Wiimote) prepare the session for recording.
+So this script automates away the task and lets the podcast moderator by just one
+action (for example triggered by a Wiimote) prepare the session for recording.
 
 It can be used for example with the python script of the Linux podcasting hacks:
 https://github.com/linux-podcasting-hacks/wiimote-recording-control

--- a/share/scripts/reset_mixer.lua
+++ b/share/scripts/reset_mixer.lua
@@ -196,7 +196,7 @@ function factory() return function()
 		if pref["sends"] then 
 			reset_send_controls(route, disp, auto)
 
-			-- Can't use reset() on this becuase ctrl:desc().normal 
+			-- Can't use reset() on this because ctrl:desc().normal 
 			-- for master_send_enable_controllable is 0, and we really 
 			-- want 1.
 			local msec = route:master_send_enable_controllable()

--- a/share/scripts/rubberband_swing.lua
+++ b/share/scripts/rubberband_swing.lua
@@ -75,7 +75,7 @@ function factory () return function ()
 		local beat_map = {}
 		local prev_beat = 0
 
-		-- construct a progress-dialog with cancle button
+		-- construct a progress-dialog with cancel button
 		local pdialog = LuaDialog.ProgressWindow ("Rubberband", true)
 		-- progress dialog callbacks
 		function vamp_callback (_, pos)

--- a/share/scripts/s_fader_automation.lua
+++ b/share/scripts/s_fader_automation.lua
@@ -50,7 +50,7 @@ function factory () return function ()
 
 	-- all done, commit the combined Undo Operation
 	if add_undo then
-		-- the 'nil' Commend here mean to use the collected diffs added above
+		-- the 'nil' Command here means to use the collected diffs added above
 		Session:commit_reversible_command (nil)
 	else
 		Session:abort_reversible_command ()

--- a/share/scripts/s_thin_automation.lua
+++ b/share/scripts/s_thin_automation.lua
@@ -27,7 +27,7 @@ function factory () return function ()
 		local before = al:get_state ()
 
 		-- remove dense events
-		al:thin (50) -- threashold of area below curve
+		al:thin (50) -- threshold of area below curve
 
 		-- save undo
 		local after = al:get_state ()
@@ -39,7 +39,7 @@ function factory () return function ()
 
 	-- all done, commit the combined Undo Operation
 	if add_undo then
-		-- the 'nil' Commend here mean to use the collected diffs added above
+		-- the 'nil' Command here means to use the collected diffs added above
 		Session:commit_reversible_command (nil)
 	else
 		Session:abort_reversible_command ()

--- a/share/scripts/s_track_props.lua
+++ b/share/scripts/s_track_props.lua
@@ -30,7 +30,7 @@ function factory () return function ()
 			-- event using the session realtime-event dispatch mechanism:
 			Session:set_control (t:solo_control(), 1, PBD.GroupControlDisposition.NoGroup)
 
-			-- unmute the track, this also examplifies how one could use lists to modify
+			-- unmute the track, this also exemplifies how one could use lists to modify
 			-- multiple controllables at the same time (they should be of the same
 			-- parameter type - e.g. mute_control() of multiple tracks, they'll all
 			-- change simultaneously in rt-context)

--- a/share/scripts/scl_to_mts.lua
+++ b/share/scripts/scl_to_mts.lua
@@ -74,7 +74,7 @@ function factory () return function ()
 		{ type = "dropdown", key = "tx", title = "MIDI SysEx Target", values = midi_targets () }
 	}
 
-	local rv = LuaDialog.Dialog ("Select Scala File and MIDI Taget", dialog_options):run ()
+	local rv = LuaDialog.Dialog ("Select Scala File and MIDI Target", dialog_options):run ()
 	dialog_options = nil -- drop references (track, plugins, shared ptr)
 	collectgarbage () -- and release the references immediately
 

--- a/share/scripts/scope.lua
+++ b/share/scripts/scope.lua
@@ -42,7 +42,7 @@ function dsp_configure (ins, outs)
 	-- store configuration in global variable
 	audio_ins = ins:n_audio ()
 	-- allocate shared memory area
-	-- this is used to speed up DSP computaton (using a C array)
+	-- this is used to speed up DSP computation (using a C array)
 	-- and to share data with the GUI
 	self:shmem ():allocate (4 + bufsiz * audio_ins)
 	self:shmem ():clear ()

--- a/share/scripts/session_template_record.lua
+++ b/share/scripts/session_template_record.lua
@@ -13,7 +13,7 @@ ardour {
 -- (e.g. ~/.config/ardour5/templates/Template-Name/template.lua)
 --
 --
----- For use as meta-session (specic session-setup scripts)
+---- For use as meta-session (specific session-setup scripts)
 --
 -- Every Lua script in the script-folder of type "SessionInit"
 -- is listed as implicit template in the new-session dialog.

--- a/share/scripts/spectrogram.lua
+++ b/share/scripts/spectrogram.lua
@@ -48,7 +48,7 @@ local SHMEM_AUDIO = 2
 -- a C memory area.
 -- It needs to be in global scope.
 -- When the variable is set to nil, the allocated memory is free()ed.
--- the memory can be interpeted as float* for use in DSP, or read/write
+-- the memory can be interpreted as float* for use in DSP, or read/write
 -- to a C++ Ringbuffer instance.
 -- http://manual.ardour.org/lua-scripting/class_reference/#ARDOUR:DSP:DspShm
 local cmem = nil
@@ -70,7 +70,7 @@ function dsp_init (rate)
 	cmem = ARDOUR.DSP.DspShm (8192)
 end
 
--- "dsp_runmap" uses Ardour's internal processor API, eqivalent to
+-- "dsp_runmap" uses Ardour's internal processor API, equivalent to
 -- 'connect_and_run()". There is no overhead (mapping, translating buffers).
 -- The lua implementation is responsible to map all the buffers directly.
 function dsp_runmap (bufs, in_map, out_map, n_samples, offset)

--- a/share/scripts/split_all_markers.lua
+++ b/share/scripts/split_all_markers.lua
@@ -71,7 +71,7 @@ end end
 
 
 -- render an icon for the toolbar action-button
--- this is genrally square width == height.
+-- this is generally square width == height.
 -- The background is set according to the theme (leave transparent when drawing).
 -- A foreground color is passed as parameter 'fg'
 --

--- a/share/scripts/tx_raw_midi_from_file.lua
+++ b/share/scripts/tx_raw_midi_from_file.lua
@@ -27,7 +27,7 @@ function factory () return function ()
 		{ type = "dropdown", key = "port", title = "Target Port", values = portlist () }
 	}
 
-	local rv = LuaDialog.Dialog ("Select Taget", dialog_options):run ()
+	local rv = LuaDialog.Dialog ("Select Target", dialog_options):run ()
 	dialog_options = nil -- drop references (ports, shared ptr)
 	collectgarbage () -- and release the references immediately
 

--- a/tools/autowaf.py
+++ b/tools/autowaf.py
@@ -32,7 +32,7 @@ def include_config_h(self):
     self.env.append_value('INCPATHS', self.bld.bldnode.abspath())
 
 def set_options(opt, debug_by_default=False):
-    "Add standard autowaf options if they havn't been added yet"
+    "Add standard autowaf options if they haven't been added yet"
     global g_step
     if g_step > 0:
         return

--- a/tools/cstyle.py
+++ b/tools/cstyle.py
@@ -37,7 +37,7 @@ class Preprocessor:
 
 	def comment_nesting (self):
 		"""
-		Return the currect comment nesting. At the start and end of the file,
+		Return the correct comment nesting. At the start and end of the file,
 		this value should be zero. Inside C comments it should be 1 or
 		(possibly) more.
 		"""

--- a/tools/fmt-luadoc.php
+++ b/tools/fmt-luadoc.php
@@ -193,7 +193,7 @@ function canonical_ctor ($b) {
 function canonical_decl ($b) {
 	$rv = '';
 	$pfx = '';
-	# match clang's declatation format
+	# match clang's declaration format
 	if (preg_match('/[^(]*\(([^)*]*)\*\)\((.*)\)/', $b['decl'], $matches)) {
 		if (strpos ($b['type'], 'Free Function') !== false) {
 			$pfx = str_replace (':', '::', luafn2class ($b['lua'])) . '::';
@@ -473,7 +473,7 @@ foreach ($classlist as $ns => $cl) {
 # step 4c: merge free functions into classlist
 foreach ($funclist as $ns => $fl) {
 	if (isset ($classlist[$ns])) {
-		my_die ('Free Funcion in existing namespace: '.$ns.' '. print_r ($ns, true));
+		my_die ('Free Function in existing namespace: '.$ns.' '. print_r ($ns, true));
 	}
 	$classlist[$ns]['func'] = $fl;
 	$classlist[$ns]['free'] = true;
@@ -509,7 +509,7 @@ foreach (json_decode ($json, true) as $a) {
 $dox_found = 0;
 $dox_miss = 0;
 
-# retrive a value from $api
+# retrieve a value from $api
 function doxydoc ($canonical_declaration) {
 	global $api;
 	global $dox_found;
@@ -563,7 +563,7 @@ function varname ($a) {
 	return array_keys ($a)[0];
 }
 
-# recusively collect class parents (derived classes)
+# recursively collect class parents (derived classes)
 function traverse_parent ($ns, &$inherited) {
 	global $classlist;
 	$rv = '';
@@ -657,7 +657,7 @@ function name_sort_cb ($a, $b) {
 # main output function for every class
 function format_class_members ($ns, $cl, &$dups) {
 	$rv = '';
-	# print contructor - if any
+	# print constructor - if any
 	if (isset ($cl['ctor'])) {
 		usort ($cl['ctor'], 'name_sort_cb');
 		$rv.= ' <tr><th colspan="3">Constructor</th></tr>'.NL;

--- a/tools/linux_packaging/build
+++ b/tools/linux_packaging/build
@@ -3,7 +3,7 @@
 # script for pulling together a Linux app bundle.
 #
 # This will create a bundle for a single architecture.
-# Execute this scirpt on both x86 and x86_64 and then use
+# Execute this script on both x86 and x86_64 and then use
 # package to merge the 2 bundles into a final package with the
 # installer. See "noderun" for a complete build script.
 
@@ -376,11 +376,11 @@ for x in $BUILD_ROOT/../share/scripts/*.lua ; do
     cp "$x" $LuaScripts
 done
 
-# recusively copy web-surface html/js
+# recursively copy web-surface html/js
 cp -a $BUILD_ROOT/../share/web_surfaces $WebSurfaces
 rm $WebSurfaces/wscript
 
-# recusively copy clips/media
+# recursively copy clips/media
 cp -a $BUILD_ROOT/../share/media $MediaClips
 rm $MediaClips/wscript
 
@@ -547,7 +547,7 @@ while [ true ] ; do
 		for dep in $deps ; do
 			if test "not" = ${dep}; then
 				echo ""
-				echo "!!! ERROR !!! - Missing dependant library for $file."
+				echo "!!! ERROR !!! - Missing dependent library for $file."
 				echo "Searched: " $OURLIBS${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 				echo ""
 				(LD_LIBRARY_PATH=$OURLIBS${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} ldd $file)
@@ -562,7 +562,7 @@ while [ true ] ; do
 			if echo $dep | grep -qs "^/lib/" ; then continue; fi
 			if echo $dep | grep -qs "^/usr/lib/" ; then continue; fi
 			if echo $dep | grep -qs "^/usr/local/lib/" ; then continue; fi
-			## the following re likley redudant ##
+			## the following are likely redundant ##
 			# skip jack, ALSA & pulse
 			if echo $dep | grep -qs libjack ; then continue; fi
 			if echo $dep | grep -qs libasound ; then continue; fi
@@ -585,10 +585,10 @@ while [ true ] ; do
 			if ! test -f $Libraries/$base; then
 				parent=$(basename ${file})
 				if echo $dep | grep -sq '^libs' ; then
-					echo "Copying dependant lib $BUILD_ROOT/$dep    (required by ${parent})"
+					echo "Copying dependent lib $BUILD_ROOT/$dep    (required by ${parent})"
 					cp $BUILD_ROOT/$dep $Libraries
 				else
-					echo "Copying dependant lib $dep    (required by ${parent})"
+					echo "Copying dependent lib $dep    (required by ${parent})"
 					cp $dep $Libraries
 				fi
 				chmod 755 $Libraries/`basename $dep`

--- a/tools/linux_packaging/stage2.run.in
+++ b/tools/linux_packaging/stage2.run.in
@@ -229,7 +229,7 @@ if [ "$(id -u)" != "0" ]; then
 	fi
 	SUPER="sudo"
 	
-	# The quoting reqired for the su sanityCheck method does not work when used without
+	# The quoting required for the su sanityCheck method does not work when used without
 	# su. Using sh -c in the normal case gets around that, but is a bit of a hack.
 	NORM_USER="sh -c"
 else
@@ -577,13 +577,13 @@ PGM_BUILDTYPE=$(echo ${BUNDLE_DIR} | cut -d- -f3)
 if [ -z ${PGM_BUILDTYPE} ];
 then
 	PGM_FULL_NAME="${PGM_NAME}-${PGM_VERSION}"
-	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}"			#no dash between name and version since dash seperates vendor from program
-	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}.desktop"	#no dash between name and version since dash seperates vendor from program
+	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}"			#no dash between name and version since dash separates vendor from program
+	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}.desktop"	#no dash between name and version since dash separates vendor from program
 	DESKTOP_LINK_FILE="${PGM_NAME}_${PGM_VERSION}.desktop"
 else
 	PGM_FULL_NAME="${PGM_NAME}-${PGM_VERSION}-${PGM_BUILDTYPE}"
-	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}"			#no dash between name and version since dash seperates vendor from program
-	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}.desktop"	#no dash between name and version since dash seperates vendor from program
+	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}"			#no dash between name and version since dash separates vendor from program
+	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}.desktop"	#no dash between name and version since dash separates vendor from program
 	DESKTOP_LINK_FILE="${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}.desktop"
 fi
 

--- a/tools/linux_packaging/uninstall.sh.in
+++ b/tools/linux_packaging/uninstall.sh.in
@@ -25,13 +25,13 @@ USER_NAME=$(logname)
 #### Derived Variables ####
 if [ -z "${PGM_BUILDTYPE}" ]; then
 	PGM_PATH=${INSTALL_DEST_BASE}/${PGM_NAME}-${PGM_VERSION}
-	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}"			#no dash between name and version since dash seperates vendor from program
-	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}.desktop"	#no dash between name and version since dash seperates vendor from program
+	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}"			#no dash between name and version since dash separates vendor from program
+	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}.desktop"	#no dash between name and version since dash separates vendor from program
 	DESKTOP_LINK_FILE="${PGM_NAME}_${PGM_VERSION}.desktop"
 else
 	PGM_PATH=${INSTALL_DEST_BASE}/${PGM_NAME}-${PGM_VERSION}-${PGM_BUILDTYPE}
-	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}"			#no dash between name and version since dash seperates vendor from program
-	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}.desktop"	#no dash between name and version since dash seperates vendor from program
+	ICON_NAME="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}"			#no dash between name and version since dash separates vendor from program
+	MENU_FILE="${PGM_VENDOR}-${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}.desktop"	#no dash between name and version since dash separates vendor from program
 	DESKTOP_LINK_FILE="${PGM_NAME}_${PGM_VERSION}_${PGM_BUILDTYPE}.desktop"
 fi
 

--- a/tools/misc.py
+++ b/tools/misc.py
@@ -45,7 +45,7 @@ def action_process_file_func(tsk):
 
 @feature('cmd')
 def apply_cmd(self):
-	"call a command everytime"
+	"call a command every time"
 	if not self.fun: raise Errors.WafError('cmdobj needs a function!')
 	tsk = Task.TaskBase()
 	tsk.fun = self.fun

--- a/tools/nofuzz.sh
+++ b/tools/nofuzz.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 ## this script should be run from the top-level source dir
-## it remove all fuzzy and obsolte translations and wraps
+## it remove all fuzzy and obsolete translations and wraps
 ## long lines.
 ##
 ## update .po and .pot files:

--- a/tools/osx_packaging/osx_build
+++ b/tools/osx_packaging/osx_build
@@ -356,11 +356,11 @@ for x in $BUILD_ROOT/../share/scripts/*.lua ; do
 	cp "$x" $LuaScripts
 done
 
-# recusively copy web-surface html/js
+# recursively copy web-surface html/js
 cp -R $BUILD_ROOT/../share/web_surfaces $WebSurfaces
 rm $WebSurfaces/wscript
 
-# recusively copy clips/media
+# recursively copy clips/media
 cp -R $BUILD_ROOT/../share/media $MediaClips
 rm $MediaClips/wscript
 
@@ -769,7 +769,7 @@ if test x$WITH_GRATIS_X42_LV2 != x ; then
 fi
 
 if test -d ${PRODUCT_PKG_DIR}/${APPROOT}/lib/LV2/; then
-	echo "Removing unused achitectures from LV plugins"
+	echo "Removing unused architectures from LV plugins"
 	for file in ${PRODUCT_PKG_DIR}/${APPROOT}/lib/LV2/*/*.dylib ; do
 		lipo -extract_family ${OSX_ARCH} ${file} -output ${file}.thin 2>/dev/null && \
 		mv ${file}.thin ${file}
@@ -1088,7 +1088,7 @@ fi
 rm -rf ${PRODUCT_PKG_DIR}
 
 echo
-echo "packaging suceeded."
+echo "packaging succeeded."
 ls -l "$UC_DMG"
 
 echo "dmg: checking for signing credentials"

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -28,7 +28,7 @@ done
 exec 1>&2
 
 #-------------------------------------------------------------------------------
-# Check the copyright notice of all files to be commited.
+# Check the copyright notice of all files to be committed.
 
 user=`git config --global user.email`
 year=`date +"%Y"`

--- a/tools/sanity_check/main.cpp
+++ b/tools/sanity_check/main.cpp
@@ -24,10 +24,10 @@ typedef int (*testfuncOpPtr) (string);
 typedef struct
 {
 	string			switchText;			// ie -option
-	string			swOptionText;       // option arguments for just this swtich.
+	string			swOptionText;       // option arguments for just this switch.
 	string			descriptionText;	// Help Text on what this does
 	string			failureText;		// What to say when this test fails
-	bool			hasOption;			// Set true if this switch has option paramters
+	bool			hasOption;			// Set true if this switch has option parameters
 	testfuncPtr		functionPtr;		// Function to call
 	testfuncOpPtr	opFunctionPtr;		// Function with option string to call
 	string			optionArg;			// Storage used to hold any options passed in by the user

--- a/tools/sanity_check/systemtest.cpp
+++ b/tools/sanity_check/systemtest.cpp
@@ -96,7 +96,7 @@ static int read_int(char* filename, int* value) {
 
 
 /**
- * This function determines wether any CPU core uses a variable clock speed if frequency
+ * This function determines whether any CPU core uses a variable clock speed if frequency
  * scaling is available. If the governor for all cores is either "powersave" or
  * "performance", the CPU frequency can be assumed to be static. This is also the case
  * if scaling_min_freq and scaling_max_freq are set to the same value.
@@ -152,7 +152,7 @@ static gid_t get_group_by_name(const char* name) {
 }
 
 /**
- * Tests wether the owner of this process is in the group 'name'.
+ * Tests whether the owner of this process is in the group 'name'.
  *
  * @returns 0 if the owner of this process is not in the group, non-0 otherwise
  **/
@@ -230,7 +230,7 @@ int system_has_group(const char * name) {
 
 
 /**
- * Tests wether the owner of this process is in the 'audio' group.
+ * Tests whether the owner of this process is in the 'audio' group.
  *
  * @returns 0 if the owner of this process is not in the audio group, non-0 otherwise
  **/
@@ -240,7 +240,7 @@ int system_user_in_audiogroup() {
 
 
 /**
- * Determines wether the owner of this process can enable rt priority.
+ * Determines whether the owner of this process can enable rt priority.
  *
  * @returns 0 if this process can not be switched to rt prio, non-0 otherwise
  **/
@@ -283,7 +283,7 @@ long long unsigned int system_memlock_amount() {
 
 
 /**
- * Checks wether the memlock limit is unlimited
+ * Checks whether the memlock limit is unlimited
  *
  * @returns - 0 if the memlock limit is limited, non-0 otherwise
  **/

--- a/tools/sanity_check/systemtest.h
+++ b/tools/sanity_check/systemtest.h
@@ -24,7 +24,7 @@ int system_has_frequencyscaling();
 
 
 /**
- * This function determines wether the CPU has a variable clock speed if frequency
+ * This function determines whether the CPU has a variable clock speed if frequency
  * scaling is available.
  *
  * @returns 0 if system doesn't use frequency scaling at the moment, non-0 otherwise
@@ -32,7 +32,7 @@ int system_has_frequencyscaling();
 int system_uses_frequencyscaling();
 
 /**
- * Tests wether the owner of this process is in the group 'name'.
+ * Tests whether the owner of this process is in the group 'name'.
  *
  * @returns 0 if the owner of this process is not in the group, non-0 otherwise
  **/
@@ -61,7 +61,7 @@ int system_has_audiogroup();
 int system_has_group(const char * name);
 
 /**
- * Tests wether the owner of this process is in the 'audio' group.
+ * Tests whether the owner of this process is in the 'audio' group.
  *
  * @returns 0 if the owner of this process is not in the audio group, non-0 otherwise
  **/
@@ -69,7 +69,7 @@ int system_user_in_audiogroup();
 
 
 /**
- * Determines wether the owner of this process can enable rt priority.
+ * Determines whether the owner of this process can enable rt priority.
  *
  * @returns 0 if this process can not be switched to rt prio, non-0 otherwise
  **/
@@ -80,7 +80,7 @@ long long unsigned int system_memlock_amount();
 
 
 /**
- * Checks wether the memlock limit is unlimited
+ * Checks whether the memlock limit is unlimited
  *
  * @returns 0 if the memlock limit is limited, non-0 otherwise
  **/

--- a/tools/update_fluidsynth.sh
+++ b/tools/update_fluidsynth.sh
@@ -109,7 +109,7 @@ rsync -auc --info=progress2 \
 
 cd "$ASRC"
 ## 1st: apply patch below, fix up any merge-conflicts and git commit the result.
-## 2nd run (after commiting the new version): re-create the patch to upstream & amend:
+## 2nd run (after committing the new version): re-create the patch to upstream & amend:
 # git diff -R libs/fluidsynth/ > tools/fluid-patches/ardour_fluidsynth.diff
 #exit
 patch -p1 < tools/fluid-patches/ardour_fluidsynth.diff

--- a/wscript
+++ b/wscript
@@ -543,7 +543,7 @@ int main() { return 0; }''',
         #
         # ARCH_X86 means anything in the x86 family from i386 to x86_64
         # the compile-time presence of the macro _LP64 is used to
-        # distingush 32 and 64 bit assembler
+        # distinguish 32 and 64 bit assembler
         #
 
 


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./share/patchfiles,./libs -L ba,buss,busses,doubleclick,hsi,ontop,ro,seh,siz,sord,sur,te,trough,ue`  
Follow-up to 364f2f078