### PR TITLE
Reanable solo for all previous soloed tracks

### DIFF
--- a/gtk2_ardour/ardour_ui3.cc
+++ b/gtk2_ardour/ardour_ui3.cc
@@ -62,7 +62,11 @@ void
 ARDOUR_UI::cancel_solo ()
 {
 	if (_session) {
-		_session->cancel_all_solo ();
+		if( _session->soloing() )
+			_session->cancel_all_solo ();
+		else{
+			_session->restore_solo_history ();
+		}
 	}
 }
 

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -615,6 +615,10 @@ public:
 	int save_template (const std::string& template_name, const std::string& description = "", bool replace_existing = false);
 	int save_history (std::string snapshot_name = "");
 	int restore_history (std::string snapshot_name);
+
+	void add_solo_history (const PBD::ID &routeId);
+	void restore_solo_history ();
+
 	void remove_state (std::string snapshot_name);
 	void rename_state (std::string old_name, std::string new_name);
 	void remove_pending_capture_state ();
@@ -1457,6 +1461,8 @@ private:
 	unsigned int            _xrun_count;
 
 	std::string             _missing_file_replacement;
+
+	std::list<PBD::ID> 		_solo_history;
 
 	mutable GATOMIC_QUAL gint _processing_prohibited;
 	mutable GATOMIC_QUAL gint _record_status;

--- a/libs/ardour/ardour/solo_control.h
+++ b/libs/ardour/ardour/solo_control.h
@@ -91,7 +91,7 @@ class LIBARDOUR_API SoloControl : public SlavableAutomationControl
 
 	int32_t transitioned_into_solo () const { return _transition_into_solo; }
 
-	void clear_all_solo_state ();
+	bool clear_all_solo_state ();
 
 	int set_state (XMLNode const&, int);
 	XMLNode& get_state () const;

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -6279,7 +6279,9 @@ Route::muted_by_others_soloing () const
 void
 Route::clear_all_solo_state ()
 {
-	_solo_control->clear_all_solo_state ();
+	if (_solo_control->clear_all_solo_state ()) {
+		_session.add_solo_history( id() );
+	}
 }
 
 boost::shared_ptr<AutomationControl>

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -6348,6 +6348,24 @@ Session::listen_position_changed ()
 }
 
 void
+Session::add_solo_history (const PBD::ID &routeId)
+{
+	_solo_history.emplace_back (routeId);
+}
+
+void Session::restore_solo_history ()
+{
+	for (PBD::ID routeId : _solo_history) {
+		boost::shared_ptr<Stripable> route = stripable_by_id( routeId );
+		if (route && route->solo_control()){
+			set_control (route->solo_control(), 1.0, Controllable::NoGroup);
+			continue;
+		}
+	}
+	_solo_history.clear ();
+}
+
+void
 Session::solo_control_mode_changed ()
 {
 	if (soloing() || listening()) {
@@ -7448,7 +7466,6 @@ Session::cancel_all_solo ()
 
 	get_stripables (sl);
 
-	set_controls (stripable_list_to_control_list (sl, &Stripable::solo_control), 0.0, Controllable::NoGroup);
 	clear_all_solo_state (routes.reader());
 
 	_engine.monitor_port().clear_ports (false);

--- a/libs/ardour/solo_control.cc
+++ b/libs/ardour/solo_control.cc
@@ -189,15 +189,16 @@ SoloControl::get_value () const
 	return soloed();
 }
 
-void
+bool
 SoloControl::clear_all_solo_state ()
 {
 	bool change = false;
+	bool write_history = false;
 
 	if (self_soloed()) {
 		PBD::info << string_compose (_("Cleared Explicit solo: %1\n"), name()) << endmsg;
 		actually_set_value (0.0, Controllable::NoGroup);
-		change = true;
+		write_history = change = true;
 	}
 
 	if (_soloed_by_others_upstream) {
@@ -219,6 +220,7 @@ SoloControl::clear_all_solo_state ()
 	if (change) {
 		Changed (false, Controllable::NoGroup); /* EMIT SIGNAL */
 	}
+	return write_history; 
 }
 
 int

--- a/libs/ardour/vca_manager.cc
+++ b/libs/ardour/vca_manager.cc
@@ -235,6 +235,8 @@ VCAManager::clear_all_solo_state ()
 	Mutex::Lock lm (lock);
 
 	for (VCAList::const_iterator i = _vcas.begin(); i != _vcas.end(); ++i) {
+		if( (*i)->solo_control()->self_soloed() )
+			_session.add_solo_history( (*i)->id() );
 		(*i)->clear_all_solo_state ();
 	}
 }


### PR DESCRIPTION
I have spent a lot of time mixing in the last few days and kept missing the possibility to reactivate solo mode for the same tracks after deactivating several soloed tracks via the flashing solo button in the transport or monitor area.
This should only affect the solo mode. No other mixer parameters as I want to adjust them, in solo mode, then listen to the full mix, switch to solo again...
With this change, when you have put some channel strips to solo mode and decativate them with the solo button in the transport or monitor area, these channels are stored.
When pressing the solo button in the transport or monitor area again,all channel strips are set to solo mode again.