### PR TITLE
use backend_client_name parsed from options when initializing backend

### DIFF
--- a/gtk2_ardour/engine_dialog.cc
+++ b/gtk2_ardour/engine_dialog.cc
@@ -1089,7 +1089,7 @@ EngineControl::backend_changed ()
 	string backend_name = backend_combo.get_active_text();
 	boost::shared_ptr<ARDOUR::AudioBackend> backend;
 
-	if (!(backend = ARDOUR::AudioEngine::instance()->set_backend (backend_name, downcase (std::string(PROGRAM_NAME)), ""))) {
+	if (!(backend = ARDOUR::AudioEngine::instance()->set_backend (backend_name, ARDOUR_COMMAND_LINE::backend_client_name, ""))) {
 		/* eh? setting the backend failed... how ? */
 		/* A: stale config contains a backend that does not exist in current build */
 		return;
@@ -2259,7 +2259,7 @@ EngineControl::set_current_state (const State& state)
 
 	boost::shared_ptr<ARDOUR::AudioBackend> backend;
 
-	if (!(backend = ARDOUR::AudioEngine::instance ()->set_backend (state->backend, downcase (std::string (PROGRAM_NAME)), ""))) {
+	if (!(backend = ARDOUR::AudioEngine::instance ()->set_backend (state->backend, ARDOUR_COMMAND_LINE::backend_client_name, ""))) {
 		DEBUG_ECONTROL (string_compose ("Unable to set backend to %1", state->backend));
 		// this shouldn't happen as the invalid backend names should have been
 		// removed from the list of states.

--- a/gtk2_ardour/opts.cc
+++ b/gtk2_ardour/opts.cc
@@ -41,7 +41,7 @@
 using namespace std;
 
 string ARDOUR_COMMAND_LINE::session_name = "";
-string ARDOUR_COMMAND_LINE::backend_client_name = "ardour";
+string ARDOUR_COMMAND_LINE::backend_client_name = PBD::downcase(PROGRAM_NAME);
 bool  ARDOUR_COMMAND_LINE::show_key_actions = false;
 bool  ARDOUR_COMMAND_LINE::show_actions = false;
 bool ARDOUR_COMMAND_LINE::no_splash = false;


### PR DESCRIPTION
Ardour has an option `--name` (short `-c`) to specify the name of the backend client. Unfortunately, this is currently ignored in gtk2_ardour, and instead, the program name is always used.

This change ensures that the specified backend client name is used when initializing the backend, defaulting to the program name.