### PR TITLE
iCon controllers

### DIFF
--- a/libs/surfaces/mackie/device_info.cc
+++ b/libs/surfaces/mackie/device_info.cc
@@ -61,6 +61,7 @@ DeviceInfo::DeviceInfo()
 	, _no_handshake (false)
 	, _is_qcon(false)
 	, _is_platformMp(false)
+	, _is_proG2(false)
 	, _has_qcon_second_lcd(false)
 	, _has_qcon_master_meters(false)
 	, _has_meters (true)
@@ -346,6 +347,12 @@ DeviceInfo::set_state (const XMLNode& node, int /* version */)
 		_is_platformMp = false;
 	}
 
+	if ((child = node.child ("IsProG2")) != 0) {
+		child->get_property ("value", _is_proG2);
+	} else {
+		_is_proG2 = false;
+	}
+
 	if ((child = node.child ("HasQConSecondLCD")) != 0) {
 		child->get_property ("value", _has_qcon_second_lcd);
 	} else {
@@ -509,6 +516,11 @@ DeviceInfo::is_qcon () const
 bool DeviceInfo::is_platformMp () const
 {
 	return _is_platformMp;
+}
+
+bool DeviceInfo::is_proG2 () const
+{
+	return _is_proG2;
 }
 
 bool

--- a/libs/surfaces/mackie/device_info.cc
+++ b/libs/surfaces/mackie/device_info.cc
@@ -60,6 +60,7 @@ DeviceInfo::DeviceInfo()
 	, _uses_ipmidi (false)
 	, _no_handshake (false)
 	, _is_qcon(false)
+	, _is_platformMp(false)
 	, _has_qcon_second_lcd(false)
 	, _has_qcon_master_meters(false)
 	, _has_meters (true)
@@ -339,6 +340,12 @@ DeviceInfo::set_state (const XMLNode& node, int /* version */)
 		_is_qcon = false;
 	}
 
+	if ((child = node.child ("IsPlatformMp")) != 0) {
+		child->get_property ("value", _is_platformMp);
+	} else {
+		_is_platformMp = false;
+	}
+
 	if ((child = node.child ("HasQConSecondLCD")) != 0) {
 		child->get_property ("value", _has_qcon_second_lcd);
 	} else {
@@ -497,6 +504,11 @@ bool
 DeviceInfo::is_qcon () const
 {
 	return _is_qcon;
+}
+
+bool DeviceInfo::is_platformMp () const
+{
+	return _is_platformMp;
 }
 
 bool

--- a/libs/surfaces/mackie/device_info.h
+++ b/libs/surfaces/mackie/device_info.h
@@ -81,6 +81,7 @@ class DeviceInfo
 	bool uses_ipmidi() const;
 	bool no_handshake() const;
 	bool is_qcon() const;
+	bool is_platformMp() const;
 	bool has_qcon_second_lcd() const;
 	bool has_qcon_master_meters() const;
 	bool has_meters() const;
@@ -114,6 +115,7 @@ class DeviceInfo
 	bool     _uses_ipmidi;
 	bool     _no_handshake;
 	bool     _is_qcon;
+	bool     _is_platformMp;
 	bool     _has_qcon_second_lcd;
 	bool     _has_qcon_master_meters;
 	bool     _has_meters;

--- a/libs/surfaces/mackie/device_info.h
+++ b/libs/surfaces/mackie/device_info.h
@@ -82,6 +82,7 @@ class DeviceInfo
 	bool no_handshake() const;
 	bool is_qcon() const;
 	bool is_platformMp() const;
+	bool is_proG2() const;
 	bool has_qcon_second_lcd() const;
 	bool has_qcon_master_meters() const;
 	bool has_meters() const;
@@ -116,6 +117,7 @@ class DeviceInfo
 	bool     _no_handshake;
 	bool     _is_qcon;
 	bool     _is_platformMp;
+	bool	 _is_proG2;
 	bool     _has_qcon_second_lcd;
 	bool     _has_qcon_master_meters;
 	bool     _has_meters;

--- a/libs/surfaces/mackie/mackie_control_protocol.cc
+++ b/libs/surfaces/mackie/mackie_control_protocol.cc
@@ -1590,6 +1590,24 @@ MackieControlProtocol::build_device_specific_button_map()
 		DEFINE_BUTTON_HANDLER (Button::Marker, &MackieControlProtocol::flip_window_press, &MackieControlProtocol::flip_window_release);
 	}
 
+	if(_device_info.is_proG2()) {
+		DEFINE_BUTTON_HANDLER (Button::View, &MackieControlProtocol::user_press, &MackieControlProtocol::user_release);
+		DEFINE_BUTTON_HANDLER (Button::Trim, &MackieControlProtocol::send_press, &MackieControlProtocol::send_release);
+		DEFINE_BUTTON_HANDLER (Button::Touch, &MackieControlProtocol::open_press, &MackieControlProtocol::open_release);
+		DEFINE_BUTTON_HANDLER (Button::Latch, &MackieControlProtocol::flip_window_press, &MackieControlProtocol::flip_window_release);
+		DEFINE_BUTTON_HANDLER (Button::Save, &MackieControlProtocol::prog2_vst_press, &MackieControlProtocol::prog2_vst_release);
+		DEFINE_BUTTON_HANDLER (Button::Undo, &MackieControlProtocol::master_press, &MackieControlProtocol::master_release);
+		DEFINE_BUTTON_HANDLER (Button::Cancel, &MackieControlProtocol::prog2_clear_solo_press, &MackieControlProtocol::prog2_clear_solo_release);
+		DEFINE_BUTTON_HANDLER (Button::Enter, &MackieControlProtocol::shift_press, &MackieControlProtocol::shift_release);
+		DEFINE_BUTTON_HANDLER (Button::Marker, &MackieControlProtocol::prog2_left_press, &MackieControlProtocol::prog2_left_release);
+		DEFINE_BUTTON_HANDLER (Button::Nudge, &MackieControlProtocol::prog2_right_press, &MackieControlProtocol::prog2_right_release);
+		DEFINE_BUTTON_HANDLER (Button::Replace, &MackieControlProtocol::prev_marker_press, &MackieControlProtocol::prev_marker_release);
+		DEFINE_BUTTON_HANDLER (Button::Click, &MackieControlProtocol::prog2_marker_press, &MackieControlProtocol::prog2_marker_release);
+		DEFINE_BUTTON_HANDLER (Button::ClearSolo, &MackieControlProtocol::next_marker_press, &MackieControlProtocol::next_marker_release);
+		DEFINE_BUTTON_HANDLER (Button::Shift, &MackieControlProtocol::prog2_undo_press, &MackieControlProtocol::prog2_undo_release);
+		DEFINE_BUTTON_HANDLER (Button::Option, &MackieControlProtocol::redo_press, &MackieControlProtocol::redo_release);
+		DEFINE_BUTTON_HANDLER (Button::Ctrl, &MackieControlProtocol::prog2_save_press, &MackieControlProtocol::prog2_save_release);
+	}
 }
 
 void

--- a/libs/surfaces/mackie/mackie_control_protocol.cc
+++ b/libs/surfaces/mackie/mackie_control_protocol.cc
@@ -1586,6 +1586,10 @@ MackieControlProtocol::build_device_specific_button_map()
 	
 #define DEFINE_BUTTON_HANDLER(b,p,r) button_map.insert (pair<Button::ID,ButtonHandlers> ((b), ButtonHandlers ((p),(r))));
 
+	if (_device_info.is_platformMp()) {
+		DEFINE_BUTTON_HANDLER (Button::Marker, &MackieControlProtocol::flip_window_press, &MackieControlProtocol::flip_window_release);
+	}
+
 }
 
 void

--- a/libs/surfaces/mackie/mackie_control_protocol.cc
+++ b/libs/surfaces/mackie/mackie_control_protocol.cc
@@ -834,6 +834,8 @@ MackieControlProtocol::set_device (const string& device_name, bool force)
 		ARDOUR::AudioEngine::instance()->PortConnectedOrDisconnected.connect (port_connection, MISSING_INVALIDATOR, boost::bind (&MackieControlProtocol::connection_handler, this, _1, _2, _3, _4, _5), this);
 	}
 
+	build_button_map();
+
 	if (create_surfaces ()) {
 		return -1;
 	}
@@ -1503,6 +1505,12 @@ MackieControlProtocol::build_button_map ()
 
 #define DEFINE_BUTTON_HANDLER(b,p,r) button_map.insert (pair<Button::ID,ButtonHandlers> ((b), ButtonHandlers ((p),(r))));
 
+	if(!button_map.empty()) {
+		button_map.clear();
+	}
+
+	build_device_specific_button_map();
+
 	DEFINE_BUTTON_HANDLER (Button::Track, &MackieControlProtocol::track_press, &MackieControlProtocol::track_release);
 	DEFINE_BUTTON_HANDLER (Button::Send, &MackieControlProtocol::send_press, &MackieControlProtocol::send_release);
 	DEFINE_BUTTON_HANDLER (Button::Pan, &MackieControlProtocol::pan_press, &MackieControlProtocol::pan_release);
@@ -1568,6 +1576,16 @@ MackieControlProtocol::build_button_map ()
 	DEFINE_BUTTON_HANDLER (Button::UserA, &MackieControlProtocol::user_a_press, &MackieControlProtocol::user_a_release);
 	DEFINE_BUTTON_HANDLER (Button::UserB, &MackieControlProtocol::user_b_press, &MackieControlProtocol::user_b_release);
 	DEFINE_BUTTON_HANDLER (Button::MasterFaderTouch, &MackieControlProtocol::master_fader_touch_press, &MackieControlProtocol::master_fader_touch_release);
+}
+
+void
+MackieControlProtocol::build_device_specific_button_map()
+{
+	/* this maps our device-dependent button codes to the methods that handle them.
+	 */
+	
+#define DEFINE_BUTTON_HANDLER(b,p,r) button_map.insert (pair<Button::ID,ButtonHandlers> ((b), ButtonHandlers ((p),(r))));
+
 }
 
 void

--- a/libs/surfaces/mackie/mackie_control_protocol.h
+++ b/libs/surfaces/mackie/mackie_control_protocol.h
@@ -511,6 +511,8 @@ class MackieControlProtocol
 	Mackie::LedState view_release (Mackie::Button&);
 
 	Mackie::LedState bank_release (Mackie::Button&, uint32_t bank_num);
+	Mackie::LedState master_press(Mackie::Button &);
+	Mackie::LedState master_release(Mackie::Button &);
 	Mackie::LedState redo_press(Mackie::Button &);
 	Mackie::LedState redo_release(Mackie::Button &);
 	Mackie::LedState prev_marker_press(Mackie::Button &);

--- a/libs/surfaces/mackie/mackie_control_protocol.h
+++ b/libs/surfaces/mackie/mackie_control_protocol.h
@@ -511,8 +511,16 @@ class MackieControlProtocol
 	Mackie::LedState view_release (Mackie::Button&);
 
 	Mackie::LedState bank_release (Mackie::Button&, uint32_t bank_num);
+	Mackie::LedState redo_press(Mackie::Button &);
+	Mackie::LedState redo_release(Mackie::Button &);
+	Mackie::LedState prev_marker_press(Mackie::Button &);
+	Mackie::LedState prev_marker_release(Mackie::Button &);
+	Mackie::LedState next_marker_press(Mackie::Button &);
+	Mackie::LedState next_marker_release(Mackie::Button &);
 	Mackie::LedState flip_window_press (Mackie::Button&);
 	Mackie::LedState flip_window_release (Mackie::Button&);
+	Mackie::LedState open_press(Mackie::Button &);
+	Mackie::LedState open_release(Mackie::Button &);
 };
 
 } // namespace

--- a/libs/surfaces/mackie/mackie_control_protocol.h
+++ b/libs/surfaces/mackie/mackie_control_protocol.h
@@ -523,6 +523,20 @@ class MackieControlProtocol
 	Mackie::LedState flip_window_release (Mackie::Button&);
 	Mackie::LedState open_press(Mackie::Button &);
 	Mackie::LedState open_release(Mackie::Button &);
+	Mackie::LedState prog2_clear_solo_press(Mackie::Button &);
+	Mackie::LedState prog2_clear_solo_release(Mackie::Button &);
+	Mackie::LedState prog2_save_press(Mackie::Button &);
+	Mackie::LedState prog2_save_release(Mackie::Button &);
+	Mackie::LedState prog2_vst_press(Mackie::Button &);
+	Mackie::LedState prog2_vst_release(Mackie::Button &);
+	Mackie::LedState prog2_left_press(Mackie::Button &);
+	Mackie::LedState prog2_left_release(Mackie::Button &);
+	Mackie::LedState prog2_right_press(Mackie::Button &);
+	Mackie::LedState prog2_right_release(Mackie::Button &);
+	Mackie::LedState prog2_marker_press(Mackie::Button &);
+	Mackie::LedState prog2_marker_release(Mackie::Button &);
+	Mackie::LedState prog2_undo_press(Mackie::Button &);
+	Mackie::LedState prog2_undo_release(Mackie::Button &);
 };
 
 } // namespace

--- a/libs/surfaces/mackie/mackie_control_protocol.h
+++ b/libs/surfaces/mackie/mackie_control_protocol.h
@@ -511,6 +511,8 @@ class MackieControlProtocol
 	Mackie::LedState view_release (Mackie::Button&);
 
 	Mackie::LedState bank_release (Mackie::Button&, uint32_t bank_num);
+	Mackie::LedState flip_window_press (Mackie::Button&);
+	Mackie::LedState flip_window_release (Mackie::Button&);
 };
 
 } // namespace

--- a/libs/surfaces/mackie/mackie_control_protocol.h
+++ b/libs/surfaces/mackie/mackie_control_protocol.h
@@ -353,6 +353,7 @@ class MackieControlProtocol
 	void clear_surfaces ();
 	void force_special_stripable_to_strip (boost::shared_ptr<ARDOUR::Stripable> r, uint32_t surface, uint32_t strip_number);
 	void build_button_map ();
+	void build_device_specific_button_map ();
 	void stripable_selection_changed ();
 	int ipmidi_restart ();
         void initialize ();

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -1226,3 +1226,139 @@ MackieControlProtocol::view_release (Mackie::Button&)
 {
 	return none;
 }
+
+/////////////////////////////////////
+// QCon Pro G2 Buttons
+/////////////////////////////////////
+
+LedState
+MackieControlProtocol::prog2_undo_press (Button &)
+{
+	if(main_modifier_state () & MODIFIER_SHIFT) {
+		access_action ("Common/menu-show-preferences");
+		return on;
+	}
+	undo ();
+	return on;
+}
+
+LedState
+MackieControlProtocol::prog2_undo_release (Button &)
+{
+	return off;
+}
+
+LedState
+MackieControlProtocol::prog2_clear_solo_press (Button &)
+{
+	if (main_modifier_state() & MODIFIER_SHIFT) {
+
+		StripableList sl;
+		session->get_stripables (sl);
+		bool allmuted = true;
+		for (StripableList::const_iterator i = sl.begin(); i != sl.end(); ++i)
+		{
+			boost::shared_ptr<MuteControl> mc = (*i)->mute_control();
+			if (!mc->muted() && (!(*i)->is_master()))
+			{
+				mc->set_value(1.0, Controllable::UseGroup);
+				allmuted = false;
+			}
+		}
+
+		return none;   
+	}
+	cancel_all_solo ();
+	return none;
+}
+
+LedState
+MackieControlProtocol::prog2_clear_solo_release (Button &)
+{
+	return none;
+}
+
+LedState
+MackieControlProtocol::prog2_save_press (Button &)
+{
+	if (main_modifier_state() & MODIFIER_SHIFT)
+	{
+		access_action("Main/SaveAs");
+		return on;
+	}
+	save_state ();
+	return on;
+}
+
+LedState
+MackieControlProtocol::prog2_save_release (Button &)
+{
+	return off;
+}
+
+LedState
+MackieControlProtocol::prog2_vst_press (Button &)
+{
+	access_action("Mixer/select-all-processors");
+	access_action("Mixer/toggle-processors");
+
+	return on;
+}
+
+LedState
+MackieControlProtocol::prog2_vst_release (Button &)
+{
+	return off;
+}
+
+LedState
+MackieControlProtocol::prog2_left_press (Button &)
+{
+	access_action("Mixer/select-prev-stripable");
+	return on;
+}
+
+LedState
+MackieControlProtocol::prog2_left_release (Button &)
+{
+	return off;
+}
+
+LedState
+MackieControlProtocol::prog2_right_press (Button &)
+{
+	access_action("Mixer/select-next-stripable");
+	return on;
+}
+
+LedState
+MackieControlProtocol::prog2_right_release (Button &)
+{
+	return off;
+}
+
+LedState
+MackieControlProtocol::prog2_marker_press (Button &)
+{
+	if (main_modifier_state() & MODIFIER_SHIFT) {
+		access_action ("Common/remove-location-from-playhead");
+		return on;
+	}
+
+	samplepos_t where = session->audible_sample();
+	if (session->transport_stopped_or_stopping() && session->locations()->mark_at (timepos_t (where), timecnt_t (session->sample_rate() / 100.0))) {
+		return on;
+	}
+
+	string markername;
+	session->locations()->next_available_name (markername,"mark");
+	add_marker (markername);
+
+	return on;
+}
+
+LedState
+MackieControlProtocol::prog2_marker_release (Button &)
+{
+	return off;
+}

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -384,6 +384,19 @@ MackieControlProtocol::undo_release (Button&)
 }
 
 LedState
+MackieControlProtocol::redo_press (Button &)
+{
+	redo ();
+	return on;
+}
+
+LedState
+MackieControlProtocol::redo_release (Button &)
+{
+	return off;
+}
+
+LedState
 MackieControlProtocol::drop_press (Button &)
 {
 	if (main_modifier_state() == MODIFIER_SHIFT) {
@@ -417,6 +430,19 @@ LedState
 MackieControlProtocol::save_release (Button &)
 {
 	return none;
+}
+
+LedState
+MackieControlProtocol::open_press (Button &)
+{
+	access_action ("Main/Open");
+	return on;
+}
+
+LedState
+MackieControlProtocol::open_release (Button &)
+{
+	return off;
 }
 
 LedState
@@ -492,6 +518,32 @@ MackieControlProtocol::marker_release (Button &)
 	session->locations()->next_available_name (markername,"mark");
 	add_marker (markername);
 
+	return off;
+}
+
+LedState
+MackieControlProtocol::prev_marker_press (Button &)
+{
+	prev_marker ();
+	return on;
+}
+
+LedState
+MackieControlProtocol::prev_marker_release (Button &)
+{
+	return off;
+}
+
+LedState
+MackieControlProtocol::next_marker_press (Button &)
+{
+	next_marker ();
+	return on;
+}
+
+LedState
+MackieControlProtocol::next_marker_release (Button &)
+{
 	return off;
 }
 

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -495,6 +495,19 @@ MackieControlProtocol::marker_release (Button &)
 	return off;
 }
 
+LedState
+MackieControlProtocol::flip_window_press (Button &)
+{
+	access_action("Common/toggle-editor-and-mixer");
+	return on;
+}
+
+LedState
+MackieControlProtocol::flip_window_release (Button &)
+{
+	return off;
+}
+
 /////////////////////////////////////
 // Transport Buttons
 /////////////////////////////////////

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -111,8 +111,14 @@ MackieControlProtocol::left_press (Button &)
 
 	DEBUG_TRACE (DEBUG::MackieControl, string_compose ("bank left with current initial = %1 nstrips = %2 tracks/busses = %3\n",
 							   _current_initial_bank, strip_cnt, sorted.size()));
+
 	if (_current_initial_bank > 0) {
-		(void) switch_banks ((_current_initial_bank - 1) / strip_cnt * strip_cnt);
+		uint32_t initial = (_current_initial_bank - 1) / strip_cnt * strip_cnt;
+		while (initial >= sorted.size())
+		{
+			initial -= strip_cnt;
+		}
+		(void) switch_banks (initial);
 	} else {
 		(void) switch_banks (0);
 	}

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -560,6 +560,19 @@ MackieControlProtocol::flip_window_release (Button &)
 	return off;
 }
 
+LedState
+MackieControlProtocol::master_press (Button &)
+{
+	_master_surface->toggle_master_monitor ();
+	return on;
+}
+
+LedState
+MackieControlProtocol::master_release (Button &)
+{
+	return off;
+}
+
 /////////////////////////////////////
 // Transport Buttons
 /////////////////////////////////////

--- a/libs/surfaces/mackie/mcp_buttons.cc
+++ b/libs/surfaces/mackie/mcp_buttons.cc
@@ -1261,14 +1261,12 @@ MackieControlProtocol::prog2_clear_solo_press (Button &)
 
 		StripableList sl;
 		session->get_stripables (sl);
-		bool allmuted = true;
 		for (StripableList::const_iterator i = sl.begin(); i != sl.end(); ++i)
 		{
 			boost::shared_ptr<MuteControl> mc = (*i)->mute_control();
-			if (!mc->muted() && (!(*i)->is_master()))
+			if (!mc->muted() && (!(*i)->is_master()) && (!(*i)->is_monitor()))
 			{
 				mc->set_value(1.0, Controllable::UseGroup);
-				allmuted = false;
 			}
 		}
 

--- a/libs/surfaces/mackie/surface.cc
+++ b/libs/surfaces/mackie/surface.cc
@@ -410,6 +410,33 @@ Surface::master_monitor_may_have_changed ()
 	}
 }
 
+bool
+Surface::master_stripable_is_master_monitor ()
+{
+	if (_master_stripable == _mcp.get_session().monitor_out())
+	{
+		return true;
+	}
+	return false;
+}
+
+void
+Surface::toggle_master_monitor ()
+{
+	if(master_stripable_is_master_monitor())
+	{
+		_master_stripable = _mcp.get_session().master_out();
+	} else if (_mcp.get_session().monitor_out() != 0)
+	{
+		_master_stripable = _mcp.get_session().monitor_out();
+	} else { return; }
+	
+	_master_fader->set_control (_master_stripable->gain_control());
+	_master_stripable->gain_control()->Changed.connect (master_connection, MISSING_INVALIDATOR, boost::bind (&Surface::master_gain_changed, this), ui_context());
+	_last_master_gain_written = FLT_MAX;
+	master_gain_changed ();
+}
+
 void
 Surface::setup_master ()
 {

--- a/libs/surfaces/mackie/surface.h
+++ b/libs/surfaces/mackie/surface.h
@@ -198,6 +198,9 @@ public:
 
 	bool get_qcon_flag() { return is_qcon; }
 
+	void toggle_master_monitor ();
+	bool master_stripable_is_master_monitor ();
+
   private:
 	MackieControlProtocol& _mcp;
 	SurfacePort*           _port;

--- a/share/mcp/platform_m+.device
+++ b/share/mcp/platform_m+.device
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MackieProtocolDevice>
+  <Name value="iCON Platform M+"/>
+  <Strips value="8"/>
+  <MasterFader value="yes"/>
+  <TimecodeDisplay value="no"/>
+  <TwoCharacterDisplay value="no"/>
+  <Extenders value="0"/>
+  <MasterPosition value="0"/>
+  <GlobalControls value="yes"/>
+  <JogWheel value="yes"/>
+  <TouchSenseFaders value="yes"/>
+  <NoHandShake value="yes"/>
+  <HasMeters value="no"/>
+  <IsPlatformMp value="yes"/>
+</MackieProtocolDevice>

--- a/share/mcp/platform_m+_platformx+.device
+++ b/share/mcp/platform_m+_platformx+.device
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MackieProtocolDevice>
+  <Name value="iCON Platform M+ with Platform X+ on right"/>
+  <Strips value="8"/>
+  <Extenders value="1"/>
+  <MasterPosition value="1"/>
+  <MasterFader value="yes"/>
+  <TimecodeDisplay value="no"/>
+  <TwoCharacterDisplay value="no"/>
+  <Extenders value="0"/>
+  <MasterPosition value="0"/>
+  <GlobalControls value="yes"/>
+  <JogWheel value="yes"/>
+  <TouchSenseFaders value="yes"/>
+  <NoHandShake value="yes"/>
+  <HasMeters value="no"/>
+  <IsPlatformMp value="yes"/>
+</MackieProtocolDevice>

--- a/share/mcp/platform_x+_platform_m+.device
+++ b/share/mcp/platform_x+_platform_m+.device
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MackieProtocolDevice>
+  <Name value="iCON Platform M+ with Platform X+ on left"/>
+  <Strips value="8"/>
+  <Extenders value="1"/>
+  <MasterPosition value="2"/>
+  <MasterFader value="yes"/>
+  <TimecodeDisplay value="no"/>
+  <TwoCharacterDisplay value="no"/>
+  <Extenders value="0"/>
+  <MasterPosition value="0"/>
+  <GlobalControls value="yes"/>
+  <JogWheel value="yes"/>
+  <TouchSenseFaders value="yes"/>
+  <NoHandShake value="yes"/>
+  <HasMeters value="no"/>
+  <IsPlatformMp value="yes"/>
+</MackieProtocolDevice>

--- a/share/mcp/qcon_g2+g2ex.device
+++ b/share/mcp/qcon_g2+g2ex.device
@@ -14,5 +14,6 @@
   <LogicControlButtons value="yes"/>
   <usesIPMIDI value="no"/>
   <NoHandShake value="yes"/>
+  <IsProG2 value="yes"/>
   <IsQCon value="yes"/>
 </MackieProtocolDevice>

--- a/share/mcp/qcon_g2.device
+++ b/share/mcp/qcon_g2.device
@@ -14,5 +14,6 @@
   <LogicControlButtons value="yes"/>
   <usesIPMIDI value="no"/>
   <NoHandShake value="yes"/>
+  <IsProG2 value="yes"/>
   <IsQCon value="yes"/>
 </MackieProtocolDevice>

--- a/share/mcp/qcon_g2ex+g2.device
+++ b/share/mcp/qcon_g2ex+g2.device
@@ -14,5 +14,6 @@
   <LogicControlButtons value="yes"/>
   <usesIPMIDI value="no"/>
   <NoHandShake value="yes"/>
+  <IsProG2 value="yes"/>
   <IsQCon value="yes"/>
 </MackieProtocolDevice>

--- a/share/mcp/two_platform_x+_platform_m+.device
+++ b/share/mcp/two_platform_x+_platform_m+.device
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MackieProtocolDevice>
+  <Name value="iCON Platform M+ with two Platform X+'s on left"/>
+  <Strips value="8"/>
+  <Extenders value="2"/>
+  <MasterPosition value="3"/>
+  <MasterFader value="yes"/>
+  <TimecodeDisplay value="no"/>
+  <TwoCharacterDisplay value="no"/>
+  <Extenders value="0"/>
+  <MasterPosition value="0"/>
+  <GlobalControls value="yes"/>
+  <JogWheel value="yes"/>
+  <TouchSenseFaders value="yes"/>
+  <NoHandShake value="yes"/>
+  <HasMeters value="no"/>
+  <IsPlatformMp value="yes"/>
+</MackieProtocolDevice>


### PR DESCRIPTION
Implements support for iCon Platform M+ controller and iCon QCon ProG2 controller.

Many of the buttons do not map to these controllers well by default using the Mackie Control device profile. These changes remap the buttons using some existing button handlers, and several new ones.
Some functions added are specific to the QCon ProG2 button labeling, and some are more general.
There is also a fix for a bug where controller strips could get stuck if tracks were deleted.