### PR TITLE
Fix memory leak in ctorNilPtrPlacementProxy

### DIFF
--- a/libs/lua/LuaBridge/detail/Namespace.h
+++ b/libs/lua/LuaBridge/detail/Namespace.h
@@ -485,8 +485,8 @@ private:
     template <class T>
     static int ctorNilPtrPlacementProxy (lua_State* L)
     {
-      const T* newobject = new T ();
-      Stack<T>::push (L, *newobject);
+      const T newobject;
+      Stack<T>::push (L, newobject);
       return 1;
     }
 


### PR DESCRIPTION
The missing `delete` here is I think clearly visible. The other functions above also allocate on the stack, so I just did the same in this function.