### PR TITLE
Use integer arithmetic to calculate number of samples per bin in the audiographer analyzer

### DIFF
--- a/libs/audiographer/src/general/analyser.cc
+++ b/libs/audiographer/src/general/analyser.cc
@@ -105,9 +105,8 @@ Analyser::set_duration (samplecnt_t n_samples)
 	}
 	_n_samples = n_samples;
 
-	const float width = _result.width;
-	_spp = ceil ((_n_samples + 2.f) / width);
-	_fpp = ceil ((_n_samples + 2.f) / width);
+	_spp = (_n_samples + 1) / _result.width + 1;
+	_fpp = _spp;
 }
 
 void


### PR DESCRIPTION
This pull request changes the way the number of samples per bin is calculated in the audiographer analyser that runs after exports. This is required to prevent the analyzer from crashing ardour in rare cases.

Previously, this was using floating-point arithmetic. For large amounts of samples, this may cause rounding errors, causing the amount of samples per bin to be too small, which in turn causes an assert to fail during processing when inevitably the processing tries to calculate the peaks for a bin that does not exist.

In particular, I had this problem (in Ardour 6.9) with a sample amount of 261498405 (about 90 minutes of audio at a sampling rate of 48k). Due to a floating-point rounding error, this calculated the number of samples per bin (at 800 bins) as 326873.0, while it is actually 326873.00625. The subsequent `ceil` therefore didn't round it up, and after every bin was filled, there were still samples left, causing an assert in process to fail.

I see that this code got rewritten somewhat in 7.0, but the ceil is still there, so I'm submitting this patch anyway. The issue is reproducible on current head of master by creating a new project, creating a region of exactly 261498405 samples, and exporting that to flac.

Note that I just copied the behavior that was already there (adding 2 to the sample count before dividing and rounding up). The formula I am using,
```
(_n_samples + 1) / _result.width + 1
```
is the shorter version of
```
(_n_samples + _result.width - 1 + 2) / _result.width
```

which is the equivalent of the original
```
ceil ((_n_samples + 2.f) / width)
```

So this uses the common trick of (n+x-1)/x to round up using integer arithmatic, while retaining the adding of 2. However, I have no idea why that 2 was added in the first place, and I wonder if it is maybe there to mitigate the original rounding error. If so, it'd be better to rewrite this to
```
(_n_samples + _result.width - 1) / _result.width
```
