### PR TITLE
adds ability to bank over in mackie sends subview

### DIFF
--- a/libs/surfaces/mackie/subview.cc
+++ b/libs/surfaces/mackie/subview.cc
@@ -732,17 +732,17 @@ bool SendsSubview::handle_cursor_left_press()
 bool SendsSubview::handle_cursor_right_press()
 {
 	uint32_t num_sends = 0;
-	if(_subview_stripable->send_name(0).size() > 0) {
+	if (_subview_stripable->send_name(0).size() > 0) {
 		bool more_sends = true;
-		while(more_sends) {
-			if(_subview_stripable->send_name(num_sends).size() > 0) {
+		while (more_sends) {
+			if (_subview_stripable->send_name(num_sends).size() > 0) {
 				num_sends++;
 			} else {
 				more_sends = false;
 			}
 		}
 	}
-	if(num_sends > _current_bank + 1) {
+	if (num_sends > _current_bank + 1) {
 		_current_bank += 1;
 		mcp().redisplay_subview_mode();
 	}

--- a/libs/surfaces/mackie/subview.cc
+++ b/libs/surfaces/mackie/subview.cc
@@ -732,22 +732,17 @@ bool SendsSubview::handle_cursor_left_press()
 bool SendsSubview::handle_cursor_right_press()
 {
 	uint32_t num_sends = 0;
-	if(_subview_stripable->send_name(0).size() > 0)
-	{
+	if(_subview_stripable->send_name(0).size() > 0) {
 		bool more_sends = true;
-		while(more_sends)
-		{
-			if(_subview_stripable->send_name(num_sends).size() > 0)
-			{
+		while(more_sends) {
+			if(_subview_stripable->send_name(num_sends).size() > 0) {
 				num_sends++;
-			} else
-			{
+			} else {
 				more_sends = false;
 			}
 		}
 	}
-	if(num_sends > _current_bank + 1)
-	{
+	if(num_sends > _current_bank + 1) {
 		_current_bank += 1;
 		mcp().redisplay_subview_mode();
 	}

--- a/libs/surfaces/mackie/subview.cc
+++ b/libs/surfaces/mackie/subview.cc
@@ -731,8 +731,26 @@ bool SendsSubview::handle_cursor_left_press()
 
 bool SendsSubview::handle_cursor_right_press()
 {
-	_current_bank += 1;
-	mcp().redisplay_subview_mode();
+	uint32_t num_sends = 0;
+	if(_subview_stripable->send_name(0).size() > 0)
+	{
+		bool more_sends = true;
+		while(more_sends)
+		{
+			if(_subview_stripable->send_name(num_sends).size() > 0)
+			{
+				num_sends++;
+			} else
+			{
+				more_sends = false;
+			}
+		}
+	}
+	if(num_sends > _current_bank + 1)
+	{
+		_current_bank += 1;
+		mcp().redisplay_subview_mode();
+	}
 	return true;
 }
 

--- a/libs/surfaces/mackie/subview.cc
+++ b/libs/surfaces/mackie/subview.cc
@@ -584,6 +584,7 @@ DynamicsSubview::notify_change (boost::weak_ptr<ARDOUR::AutomationControl> pc, u
 
 SendsSubview::SendsSubview(MackieControlProtocol& mcp, boost::shared_ptr<ARDOUR::Stripable> subview_stripable)
 	: Subview(mcp, subview_stripable)
+	, _current_bank(0)
 {}
 
 SendsSubview::~SendsSubview()
@@ -614,8 +615,8 @@ void SendsSubview::setup_vpot(
 		Pot* vpot,
 		std::string pending_display[2])
 {
-	const uint32_t global_strip_position = _mcp.global_index (*strip);
-	store_pointers(strip, vpot, pending_display, global_strip_position);
+	const uint32_t global_strip_position = _mcp.global_index (*strip) + _current_bank;
+	store_pointers(strip, vpot, pending_display, global_strip_position - _current_bank);
 
 	if (!_subview_stripable) {
 		return;
@@ -649,7 +650,7 @@ SendsSubview::notify_send_level_change (uint32_t global_strip_position, bool for
 	Strip* strip = 0;
 	Pot* vpot = 0;
 	std::string* pending_display = 0;
-	if (!retrieve_pointers(&strip, &vpot, &pending_display, global_strip_position))
+	if (!retrieve_pointers(&strip, &vpot, &pending_display, global_strip_position - _current_bank))
 	{
 		return;
 	}
@@ -717,6 +718,23 @@ void SendsSubview::handle_vselect_event(uint32_t global_strip_position)
 	}
 }
 
+bool SendsSubview::handle_cursor_left_press()
+{
+	if (_current_bank >= 1)
+	{
+		_current_bank -= 1;
+	}
+	mcp().redisplay_subview_mode();
+
+	return true;
+}
+
+bool SendsSubview::handle_cursor_right_press()
+{
+	_current_bank += 1;
+	mcp().redisplay_subview_mode();
+	return true;
+}
 
 
 TrackViewSubview::TrackViewSubview(MackieControlProtocol& mcp, boost::shared_ptr<ARDOUR::Stripable> subview_stripable)

--- a/libs/surfaces/mackie/subview.h
+++ b/libs/surfaces/mackie/subview.h
@@ -163,6 +163,11 @@ class SendsSubview : public Subview {
 	void notify_send_level_change (uint32_t global_strip_position, bool force);
 
 	virtual void handle_vselect_event(uint32_t global_strip_position);
+	virtual bool handle_cursor_right_press();
+	virtual bool handle_cursor_left_press();
+  protected:
+	uint32_t _current_bank;
+
 };
 
 class TrackViewSubview : public Subview {


### PR DESCRIPTION
The cursor_left and cursor_right mackie control buttons will now move the
sends subview left and right like it does in the plugin subview. Previously,
if you had more than 8 sends (which is almost always the case for Mixbus),
then sends 9+ were unreachable on an 8 channel controller.