### PR TITLE
Fix user facing typos

### DIFF
--- a/gtk2_ardour/editor_export_audio.cc
+++ b/gtk2_ardour/editor_export_audio.cc
@@ -328,7 +328,7 @@ Editor::bounce_region_selection (bool with_processing)
 		}
 
 		/* copy to the user's Clip Library ? */
-		Gtk::CheckButton *cliplib = manage (new Gtk::CheckButton (_("Bounce to Clip Libary")));
+		Gtk::CheckButton *cliplib = manage (new Gtk::CheckButton (_("Bounce to Clip Library")));
 		Gtk::Alignment *align = manage (new Gtk::Alignment (0, .5, 0, 0));
 		align->add (*cliplib);
 		align->show_all ();

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -4202,7 +4202,7 @@ Editor::bounce_range_selection (BounceTarget target, bool with_processing)
 		}
 
 		/* copy to the user's Clip Library ? */
-		Gtk::CheckButton *cliplib = manage (new Gtk::CheckButton (_("Bounce to Clip Libary")));
+		Gtk::CheckButton *cliplib = manage (new Gtk::CheckButton (_("Bounce to Clip Library")));
 		Gtk::Alignment *align = manage (new Gtk::Alignment (0, .5, 0, 0));
 		align->add (*cliplib);
 		align->show_all ();


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./.git,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch  -L ba,buss,busses,discreet,doubleclick,hsi,ontop,ro,scrollin,seh,siz,sord,sur,te,trough,ue`