### PR TITLE
Update dark-ardour.colors - patch selector knobs unnamed >> lighter

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -287,7 +287,7 @@
     <ColorAlias name="nudge clock: text" alias="theme:contrasting clock"/>
     <ColorAlias name="page switch button: fill" alias="widget:bg"/>
     <ColorAlias name="page switch button: fill active" alias="alert:green"/>
-    <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
+    <ColorAlias name="patch change button unnamed: fill" alias="neutral:midground"/>
     <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
     <ColorAlias name="patch change button: fill" alias="widget:bg"/>
     <ColorAlias name="patch change button: fill active" alias="widget:blue"/>


### PR DESCRIPTION
This PR changes unnamed **knobs** fill in the midi **patch selector** from almost indistinguishable dark to the intelligible light.
![unnamed_patch_fill](https://user-images.githubusercontent.com/19673308/163687261-2a5c8d57-bca5-4399-8d90-63589ccbda92.gif)

