### PR TITLE
Update clear_gray-ardour.colors - patch selector knobs fill active >> intelligible light

### DIFF
--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -288,9 +288,9 @@
     <ColorAlias name="page switch button: fill" alias="widget:bg"/>
     <ColorAlias name="page switch button: fill active" alias="alert:orange"/>
     <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
-    <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
+    <ColorAlias name="patch change button unnamed: fill active" alias="neutral:foregroundest/>
     <ColorAlias name="patch change button: fill" alias="widget:bg"/>
-    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill active" alias="neutral:foregroundest"/>
     <ColorAlias name="piano roll black" alias="theme:bg"/>
     <ColorAlias name="piano roll black outline" alias="widget:gray"/>
     <ColorAlias name="piano roll white" alias="neutral:foreground2"/>


### PR DESCRIPTION
This PR changes active knobs fill in the midi patch selector to the more intelligible light.
![patch_fill_active](https://user-images.githubusercontent.com/19673308/163687793-e7b2097c-2f49-4bd2-a502-5deb29297b36.gif)

