### PR TITLE
US2400: maps track parameters and sends to vpots

### DIFF
--- a/libs/surfaces/us2400/mcp_buttons.cc
+++ b/libs/surfaces/us2400/mcp_buttons.cc
@@ -98,6 +98,10 @@ LedState
 US2400Protocol::left_press (Button &)
 {
 	if (_subview_mode != None) {
+		if (_sends_bank > 0) {
+			_sends_bank--;
+			redisplay_subview_mode();
+		}
 		return none;
 	}
 
@@ -126,6 +130,19 @@ LedState
 US2400Protocol::right_press (Button &)
 {
 	if (_subview_mode != None) {
+		bool hasNextSend = true;
+		int numSends = 0;
+		while (hasNextSend) {
+			if (first_selected_stripable()->send_name(numSends).length() < 1) {
+				hasNextSend = false;
+			} else {
+				numSends++;
+			}
+		}
+		if (numSends > (_sends_bank + 1) * 16) {
+			_sends_bank++;
+			redisplay_subview_mode();
+		}
 		return none;
 	}
 

--- a/libs/surfaces/us2400/strip.cc
+++ b/libs/surfaces/us2400/strip.cc
@@ -920,7 +920,7 @@ Strip::setup_trackview_vpot (boost::shared_ptr<Stripable> r)
 		case 21:
 		case 22:
 		case 23:
-			pc = r->send_level_controllable ( global_pos - 16 );
+			pc = r->send_level_controllable ( global_pos - 16 + (_surface->mcp().get_sends_bank() * 8));
 			break;
 		}  //global_pos switch
 

--- a/libs/surfaces/us2400/strip.cc
+++ b/libs/surfaces/us2400/strip.cc
@@ -799,8 +799,9 @@ Strip::setup_trackview_vpot (boost::shared_ptr<Stripable> r)
 
 	_vpot->set_mode(Pot::wrap);
 
-#ifdef MIXBUS
 	const uint32_t global_pos = _surface->mcp().global_index (*this);
+
+#ifdef MIXBUS
 
 	//Trim & dynamics
 	switch (global_pos) {
@@ -924,6 +925,48 @@ Strip::setup_trackview_vpot (boost::shared_ptr<Stripable> r)
 		}  //global_pos switch
 
 	} //if input_strip
+
+#else
+
+	switch (global_pos) {
+		// Track view equivalent
+		case 0:
+			pc = r->trim_control ();
+			_vpot->set_mode(Pot::boost_cut);
+			break;
+		case 1:
+			pc = r->monitoring_control ();
+			break;
+		case 2:
+			pc = r->solo_isolate_control ();
+			break;
+		case 3:
+			pc = r->solo_safe_control ();
+			break;
+		case 4:
+			pc = r->phase_control ();
+			break;
+		
+		// Sends
+		case 8:
+		case 9:
+		case 10:
+		case 11:
+		case 12:
+		case 13:
+		case 14:
+		case 15:
+		case 16:
+		case 17:
+		case 18:
+		case 19:
+		case 20:
+		case 21:
+		case 22:
+		case 23:
+			pc = r->send_level_controllable (global_pos - 8);
+			break;
+	}
 #endif //ifdef MIXBUS
 
 	if (pc) {  //control found; set our knob to watch for changes in it

--- a/libs/surfaces/us2400/strip.cc
+++ b/libs/surfaces/us2400/strip.cc
@@ -964,7 +964,7 @@ Strip::setup_trackview_vpot (boost::shared_ptr<Stripable> r)
 		case 21:
 		case 22:
 		case 23:
-			pc = r->send_level_controllable (global_pos - 8);
+			pc = r->send_level_controllable (global_pos - 8 + (_surface->mcp().get_sends_bank() * 16));
 			break;
 	}
 #endif //ifdef MIXBUS

--- a/libs/surfaces/us2400/us2400_control_protocol.cc
+++ b/libs/surfaces/us2400/us2400_control_protocol.cc
@@ -122,6 +122,7 @@ US2400Protocol::US2400Protocol (Session& session)
 	, state_version (0)
 	, marker_modifier_consumed_by_button (false)
 	, nudge_modifier_consumed_by_button (false)
+	, _sends_bank (0)
 {
 	DEBUG_TRACE (DEBUG::US2400, "US2400Protocol::US2400Protocol\n");
 
@@ -1875,6 +1876,7 @@ US2400Protocol::is_mapped (boost::shared_ptr<Stripable> r) const
 void
 US2400Protocol::stripable_selection_changed ()
 {
+	_sends_bank = 0;
 	//this function is called after the stripable selection is "stable", so this is the place to check surface selection state
 	for (Surfaces::iterator si = surfaces.begin(); si != surfaces.end(); ++si) {
 		(*si)->update_strip_selection ();
@@ -1987,4 +1989,10 @@ US2400Protocol::set_automation_state (AutoState as)
 	}
 
 	ac->set_automation_state (as);
+}
+
+int
+US2400Protocol::get_sends_bank ()
+{
+	return _sends_bank;
 }

--- a/libs/surfaces/us2400/us2400_control_protocol.h
+++ b/libs/surfaces/us2400/us2400_control_protocol.h
@@ -214,6 +214,8 @@ class US2400Protocol
 	void remove_down_select_button (int surface, int strip);
 	void select_range (uint32_t pressed);
 
+	int get_sends_bank ();
+
   protected:
 	// shut down the surface
 	void close();
@@ -302,6 +304,7 @@ class US2400Protocol
 	int                      _last_bank[9];
 	bool                     marker_modifier_consumed_by_button;
 	bool                     nudge_modifier_consumed_by_button;
+	int						 _sends_bank;
 
 	boost::shared_ptr<ArdourSurface::US2400::Surface>	_master_surface;
 


### PR DESCRIPTION
Pots 0-4 now display the 5 track parameters from the Mackie track subview
when a track is selected and pots 8-23 will display up to the first 16 sends.