### PR TITLE
Disable sandbox in lua SessionInit scripts.

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -2449,7 +2449,7 @@ ARDOUR_UI::meta_session_setup (const std::string& script_path)
 
 	LuaState lua;
 	lua.Print.connect (&_lua_print);
-	lua.sandbox (true);
+	lua.sandbox (false);
 
 	lua_State* L = lua.getState();
 	LuaInstance::register_classes (L);


### PR DESCRIPTION
Original discussion : https://discourse.ardour.org/t/no-standard-io-library-in-a-sessioninit-lua-script/107159/2