### PR TITLE
Fix source comment typos in `libs/ardour`

### DIFF
--- a/libs/ardour/ardour/lua_api.h
+++ b/libs/ardour/ardour/lua_api.h
@@ -304,7 +304,7 @@ namespace ARDOUR { namespace LuaAPI {
 			 */
 			int analyze (boost::shared_ptr<ARDOUR::AudioReadable> r, uint32_t channel, luabridge::LuaRef fn);
 
-			/** call plugin():reset() and clear intialization flag */
+			/** call plugin():reset() and clear initialization flag */
 			void reset ();
 
 			/** initialize the plugin for use with analyze().

--- a/libs/ardour/ardour/midi_buffer.h
+++ b/libs/ardour/ardour/midi_buffer.h
@@ -179,7 +179,7 @@ public:
 
 	/**
 	 * returns true if the message with the second argument as its MIDI
-	 * status byte should preceed the message with the first argument as
+	 * status byte should precede the message with the first argument as
 	 * its MIDI status byte.
 	 */
 	static bool second_simultaneous_midi_byte_is_first (uint8_t, uint8_t);

--- a/libs/ardour/ardour/midi_ui.h
+++ b/libs/ardour/ardour/midi_ui.h
@@ -32,7 +32,7 @@ class Session;
 class AsyncMIDIPort;
 
 /* this is mostly a placeholder because I suspect that at some
-   point we will want to add more members to accomodate
+   point we will want to add more members to accommodate
    certain types of requests to the MIDI UI
 */
 

--- a/libs/ardour/audio_buffer.cc
+++ b/libs/ardour/audio_buffer.cc
@@ -37,7 +37,7 @@ AudioBuffer::AudioBuffer(size_t capacity)
 	if (capacity) {
 		_owns_data = true; // prevent resize() from gagging
 		resize (capacity);
-		_silent = false; // force silence on the intial buffer state
+		_silent = false; // force silence on the initial buffer state
 		clear ();
 	}
 }

--- a/libs/ardour/audio_unit.cc
+++ b/libs/ardour/audio_unit.cc
@@ -1847,7 +1847,7 @@ AUPlugin::parameter_is_control (uint32_t param) const
 {
 	assert(param < descriptors.size());
 	if (descriptors[param].automatable) {
-		/* corrently ardour expects all controls to be automatable
+		/* currently ardour expects all controls to be automatable
 		 * IOW ardour GUI elements mandate an Evoral::Parameter
 		 * for all input+control ports.
 		 */

--- a/libs/ardour/audioengine.cc
+++ b/libs/ardour/audioengine.cc
@@ -687,7 +687,7 @@ AudioEngine::do_reset_backend()
 			// backup the device name
 			std::string name = _backend->device_name ();
 
-			std::cout << "AudioEngine::RESET::Reseting device..." << std::endl;
+			std::cout << "AudioEngine::RESET::Resetting device..." << std::endl;
 			if ( ( 0 == stop () ) &&
 					( 0 == _backend->reset_device () ) &&
 					( 0 == start () ) ) {
@@ -1195,7 +1195,7 @@ AudioEngine::client_real_time_priority ()
 		/* this is only an issue with the Dummy backend.
 		 * - with JACK, we require rt permissions.
 		 * - with ALSA/Pulseaudio this can only happen if rt permissions
-		 *   are n/a. Other atempts to get rt will fail likewise.
+		 *   are n/a. Other attempts to get rt will fail likewise.
 		 *
 		 * perhaps:
 		 * TODO: use is_realtime () ? PBD_SCHED_FIFO : PBD_SCHED_OTHER

--- a/libs/ardour/audioregion.cc
+++ b/libs/ardour/audioregion.cc
@@ -1626,7 +1626,7 @@ void
 AudioRegion::source_offset_changed ()
 {
 	/* XXX this fixes a crash that should not occur. It does occur
-	   becauses regions are not being deleted when a session
+	   because regions are not being deleted when a session
 	   is unloaded. That bug must be fixed.
 	*/
 

--- a/libs/ardour/audiosource.cc
+++ b/libs/ardour/audiosource.cc
@@ -960,7 +960,7 @@ AudioSource::compute_and_write_peaks (Sample* buf, samplecnt_t first_sample, sam
 			goto restart;
 		}
 
-		/* else ... had leftovers, but they immediately preceed the new data, so just
+		/* else ... had leftovers, but they immediately precede the new data, so just
 		   merge them and compute.
 		*/
 

--- a/libs/ardour/automation_list.cc
+++ b/libs/ardour/automation_list.cc
@@ -380,7 +380,7 @@ AutomationList::serialize_events (bool need_lock) const
 		str << '\n';
 	}
 
-	/* XML is a bit wierd */
+	/* XML is a bit weird */
 
 	XMLNode* content_node = new XMLNode (X_("foo")); /* it gets renamed by libxml when we set content */
 	content_node->set_content (str.str());

--- a/libs/ardour/disk_reader.cc
+++ b/libs/ardour/disk_reader.cc
@@ -823,7 +823,7 @@ DiskReader::seek (samplepos_t sample, bool complete_refill)
 	/* There are two possible shortcuts we can take that will completely
 	 * skip reading from disk. However, they are invalid if we need to read
 	 * data in the opposite direction than we did last time, or if our need
-	 * for looped data has chaned since the last read. Both of these change
+	 * for looped data has changed since the last read. Both of these change
 	 * the semantics of a read from disk, even if the position we are
 	 * reading from is the same.
 	 */

--- a/libs/ardour/export_format_manager.cc
+++ b/libs/ardour/export_format_manager.cc
@@ -608,7 +608,7 @@ ExportFormatManager::select_format (ExportFormatPtr const & format)
 
 	if (format) {
 
-		/* Slect right quality for format */
+		/* Select right quality for format */
 
 		ExportFormatBase::Quality quality = format->get_quality();
 		for (QualityList::iterator it = qualities.begin (); it != qualities.end (); ++it) {

--- a/libs/ardour/fluid_synth.cc
+++ b/libs/ardour/fluid_synth.cc
@@ -85,7 +85,7 @@ FluidSynth::load_sf2 (const std::string& fn)
 		return false;
 	}
 
-	/* boostrap synth engine. The first call re-initializes the chorus
+	/* bootstrap synth engine. The first call re-initializes the chorus
 	 * (fluid_rvoice_mixer_set_samplerate) which is not rt-safe.
 	 */
 	float l[1024];

--- a/libs/ardour/globals.cc
+++ b/libs/ardour/globals.cc
@@ -370,7 +370,7 @@ lotsa_files_please ()
 		error << string_compose (_("Could not get system open files limit (%1)"), strerror (errno)) << endmsg;
 	}
 #else
-	/* this only affects stdio. 2048 is the maxium possible (512 the default).
+	/* this only affects stdio. 2048 is the maximum possible (512 the default).
 	 *
 	 * If we want more, we'll have to replaces the POSIX I/O interfaces with
 	 * Win32 API calls (CreateFile, WriteFile, etc) which allows for 16K.

--- a/libs/ardour/import.cc
+++ b/libs/ardour/import.cc
@@ -597,7 +597,7 @@ Session::deinterlace_midi_region ( boost::shared_ptr<MidiRegion> mr )
 }
 
 // This function is still unable to cleanly update an existing source, even though
-// it is possible to set the ImportStatus flag accordingly. The functinality
+// it is possible to set the ImportStatus flag accordingly. The functionality
 // is disabled at the GUI until the Source implementations are able to provide
 // the necessary API.
 void

--- a/libs/ardour/luabindings.cc
+++ b/libs/ardour/luabindings.cc
@@ -163,7 +163,7 @@ luabridge::getIdentityKey ()
 
 /* ...and this is the ugly part of it.
  *
- * We need to foward declare classes from gtk2_ardour
+ * We need to forward declare classes from gtk2_ardour
  * AND explicily list classes which are used by gtk2_ardour's bindings.
  *
  * This is required because some of the GUI classes use objects from libardour
@@ -354,7 +354,7 @@ CLASSKEYS(LuaDialog::ProgressWindow);
 
 /* Some notes on Lua bindings for libardour and friends
  *
- * - Prefer factory methods over Contructors whenever possible.
+ * - Prefer factory methods over Constructors whenever possible.
  *   Don't expose the constructor method unless required.
  *
  *   e.g. Don't allow the script to construct a "Track" Object directly
@@ -2045,7 +2045,7 @@ LuaBindings::common (lua_State* L)
 
 		.beginClass <DataType> ("DataType")
 		.addConstructor <void (*) (std::string)> ()
-		.addStaticCFunction ("null",  &LuaAPI::datatype_ctor_null) // "nil" is a lua reseved word
+		.addStaticCFunction ("null",  &LuaAPI::datatype_ctor_null) // "nil" is a lua reserved word
 		.addStaticCFunction ("audio", &LuaAPI::datatype_ctor_audio)
 		.addStaticCFunction ("midi",  &LuaAPI::datatype_ctor_midi)
 		.addFunction ("to_string",  &DataType::to_string) // TODO Lua __tostring
@@ -2936,7 +2936,7 @@ LuaBindings::dsp (lua_State* L)
 		.endClass ()
 		.endNamespace ();
 
-	// dsp releated session functions
+	// dsp related session functions
 	luabridge::getGlobalNamespace (L)
 		.beginNamespace ("ARDOUR")
 		.beginClass <Session> ("Session")

--- a/libs/ardour/luaproc.cc
+++ b/libs/ardour/luaproc.cc
@@ -71,7 +71,7 @@ LuaProc::LuaProc (AudioEngine& engine,
 {
 	init ();
 
-	/* when loading a session, or pasing a processor,
+	/* when loading a session, or passing a processor,
 	 * the script is set during set_state();
 	 */
 	if (!_script.empty () && load_script ()) {

--- a/libs/ardour/lv2_plugin.cc
+++ b/libs/ardour/lv2_plugin.cc
@@ -2208,7 +2208,7 @@ LV2Plugin::set_state(const XMLNode& node, int version)
 	}
 
 	/* Do not call latency_compute_run() concurrently with connect_and_run().
-	 * So far this can only guarnteed when the session is loading,
+	 * So far this can only guaranteed when the session is loading,
 	 * and the plugin has not been added to the processor chain.
 	 *
 	 * Ideally this would clso be called when copying a plugin from another track,

--- a/libs/ardour/mac_vst_support.cc
+++ b/libs/ardour/mac_vst_support.cc
@@ -222,7 +222,7 @@ mac_vst_instantiate (VSTHandle* fhandle, audioMasterCallback amc, void* userptr)
 
 void mac_vst_close (VSTState* mac_vst)
 {
-	// assert that the GUI object is destoyed
+	// assert that the GUI object is destroyed
 
 	if (mac_vst->plugin)
 	{

--- a/libs/ardour/midi_port.cc
+++ b/libs/ardour/midi_port.cc
@@ -136,7 +136,7 @@ MidiPort::get_midi_buffer (pframes_t nframes)
 				 *
 				 * But of course ... if
 				 * _global_port_buffer_offset is zero,
-				 * something wierd is happening.
+				 * something weird is happening.
 				 */
 #ifndef NDEBUG
 				if (_global_port_buffer_offset == 0) {

--- a/libs/ardour/midi_ui.cc
+++ b/libs/ardour/midi_ui.cc
@@ -91,7 +91,7 @@ MidiControlUI::midi_input_handler (IOCondition ioc, boost::weak_ptr<AsyncMIDIPor
 		return false;
 	}
 
-	DEBUG_TRACE (DEBUG::MidiIO, string_compose ("something happend on  %1\n", boost::shared_ptr<ARDOUR::Port> (port)->name()));
+	DEBUG_TRACE (DEBUG::MidiIO, string_compose ("something happened on  %1\n", boost::shared_ptr<ARDOUR::Port> (port)->name()));
 
 	if (ioc & ~IO_IN) {
 		return false;

--- a/libs/ardour/playlist.cc
+++ b/libs/ardour/playlist.cc
@@ -785,7 +785,7 @@ Playlist::add_region_internal (boost::shared_ptr<Region> region, timepos_t const
 	region->DropReferences.connect_same_thread (region_drop_references_connections, boost::bind (&Playlist::region_going_away, this, boost::weak_ptr<Region> (region)));
 
 	/* do not handle property changes of newly added regions.
-	 * Otherwise this would triggger Playlist::notify_region_moved()
+	 * Otherwise this would trigger Playlist::notify_region_moved()
 	 * -> RangesMoved() and move automation.
 	 */
 	region->clear_changes ();
@@ -1673,7 +1673,7 @@ Playlist::region_changed (const PropertyChange& what_changed, boost::shared_ptr<
 	}
 
 	/* since cc6c0f1263ab272707b0241ec333776036515fc2 can no longer distinguish between
-	 * position and length changes, so we have to assume that all have happpened :(
+	 * position and length changes, so we have to assume that all have happened :(
 	 */
 	if (what_changed.contains (Properties::length)) {
 		notify_region_moved (region);
@@ -3194,7 +3194,7 @@ Playlist::uncombine (boost::shared_ptr<Region> target)
 	   the original regions that we find, and add them
 	   instead.
 
-	   3) target region is a copy of a compount region previously
+	   3) target region is a copy of a compound region previously
 	   created. In this case we will also need to make copies ot each of
 	   the original regions, and add them instead.
 	*/

--- a/libs/ardour/plugin.cc
+++ b/libs/ardour/plugin.cc
@@ -592,5 +592,5 @@ PluginInfo::is_utility () const
 bool
 PluginInfo::is_analyzer () const
 {
-	return (category == "Analyser" || category == "Anaylsis" || category == "Analyzer");
+	return (category == "Analyser" || category == "Analysis" || category == "Analyzer");
 }

--- a/libs/ardour/port.cc
+++ b/libs/ardour/port.cc
@@ -81,7 +81,7 @@ Port::Port (std::string const & n, DataType t, PortFlags f)
 		cerr << "Failed to register port \"" << _name << "\", reason is unknown from here\n";
 		throw failed_constructor ();
 	}
-	DEBUG_TRACE (DEBUG::Ports, string_compose ("registed port %1 handle %2\n", name(), _port_handle));
+	DEBUG_TRACE (DEBUG::Ports, string_compose ("registered port %1 handle %2\n", name(), _port_handle));
 
 	PortDrop.connect_same_thread (drop_connection, boost::bind (&Port::session_global_drop, this));
 	PortSignalDrop.connect_same_thread (drop_connection, boost::bind (&Port::signal_drop, this));
@@ -259,7 +259,7 @@ Port::connect (std::string const & other)
 
 	if (r == 0) {
 		/* Connections can be saved on either or both sides. The code above works regardless
-		 * from which end the conneciton is initiated, and connecting already connected ports
+		 * from which end the connection is initiated, and connecting already connected ports
 		 * is idempotent.
 		 *
 		 * Only saving internal connection on the source-side would be preferable,

--- a/libs/ardour/port_manager.cc
+++ b/libs/ardour/port_manager.cc
@@ -982,7 +982,7 @@ PortManager::update_input_ports (bool clear)
 	}
 
 	if (clear) {
-		/* don't send notifcation for initial setup.
+		/* don't send notification for initial setup.
 		 * Physical I/O is initially connected in
 		 * reconnect_ports(), it is too early to
 		 * do this when called from ::reestablish_ports()

--- a/libs/ardour/port_set.cc
+++ b/libs/ardour/port_set.cc
@@ -174,4 +174,4 @@ PortSet::clear()
 	_all_ports.clear();
 }
 
-} // namepace ARDOUR
+} // namespace ARDOUR

--- a/libs/ardour/rb_effect.cc
+++ b/libs/ardour/rb_effect.cc
@@ -244,7 +244,7 @@ RBEffect::run (boost::shared_ptr<Region> r, Progress* progress)
 			stretcher.study (buffers, this_read, pos == read_duration);
 		}
 
-		/* done studing, start process */
+		/* done studying, start process */
 		pos = 0;
 
 		while (pos < read_duration && !tsr.cancel) {

--- a/libs/ardour/route.cc
+++ b/libs/ardour/route.cc
@@ -261,7 +261,7 @@ Route::init ()
 	}
 
 	_main_outs.reset (new Delivery (_session, _output, _pannable, _mute_master, _name, Delivery::Main));
-	/* master outut volume */
+	/* master output volume */
 	if (is_master()) {
 		_volume_control.reset (new GainControl (_session, MainOutVolume));
 		_volume_control->set_flag (Controllable::NotAutomatable);
@@ -413,11 +413,11 @@ Route::process_output_buffers (BufferSet& bufs,
 		end_sample += latency_offset;
 	}
 
-	/* Note: during intial pre-roll 'start_sample' as passed as argument can be negative.
+	/* Note: during initial pre-roll 'start_sample' as passed as argument can be negative.
 	 * Functions calling process_output_buffers() will set  "run_disk_reader"
 	 * to false if the pre-roll count-down is larger than playback_latency ().
 	 *
-	 * playback_latency() is guarnteed to be <= _signal_latency + _output->latency ()
+	 * playback_latency() is guaranteed to be <= _signal_latency + _output->latency ()
 	 */
 	assert (!_disk_reader || !run_disk_reader || start_sample >= 0 || speed < 0);
 
@@ -525,7 +525,7 @@ Route::process_output_buffers (BufferSet& bufs,
 		 *
 		 * cycle 1: run (t): automation (t) = on: -> increase latency
 		 * cycle 2: run (t-latency): automation (t-latency) = off -> decrease latency
-		 * reapeat.
+		 * repeat.
 		 */
 
 		if ((*i)->active ()) {
@@ -3687,7 +3687,7 @@ Route::output_effectively_connected_real () const
 			return _connection_cache[rp];
 		}
 		/* First mark node a traversed to prevent endless recursion.
-		 * Othewise graph loops A -> B -> A will cause a stack overflow.
+		 * Otherwise graph loops A -> B -> A will cause a stack overflow.
 		 */
 		_connection_cache[rp] = false;
 

--- a/libs/ardour/route_group.cc
+++ b/libs/ardour/route_group.cc
@@ -556,7 +556,7 @@ RouteGroup::make_subgroup (bool aux, Placement placement)
 		/* use master bus etc. to determine default nouts.
 		 *
 		 * (since tracks can't have fewer outs than ins,
-		 * "nin" currently defines the number of outpus if nin > 2)
+		 * "nin" currently defines the number of outputs if nin > 2)
 		 */
 		rl = _session.new_audio_route (nin, 2, 0, 1, string(), PresentationInfo::AudioBus, PresentationInfo::max_order);
 	} catch (...) {

--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -2573,7 +2573,7 @@ Session::ensure_route_presentation_info_gap (PresentationInfo::order_t first_new
 		return;
 	}
 
-	/* create a gap in the presentation info to accomodate @param how_many
+	/* create a gap in the presentation info to accommodate @param how_many
 	 * new objects.
 	 */
 	StripableList sl;
@@ -6763,7 +6763,7 @@ Session::update_latency (bool playback)
 		set_worst_output_latency ();
 		update_route_latency (true, /*apply_to_delayline*/ true, NULL);
 
-		/* relese before emiting signals */
+		/* release before emitting signals */
 		lm.release ();
 
 	} else {
@@ -7132,7 +7132,7 @@ Session::auto_connect (const AutoConnectRequest& ar)
 				}
 
 				if (!port.empty() && route->output()->connect (route->output()->ports().port(*t, i), port, this)) {
-					DEBUG_TRACE (DEBUG::PortConnectAuto, "Failed to auto-connect ouput.");
+					DEBUG_TRACE (DEBUG::PortConnectAuto, "Failed to auto-connect output.");
 					break;
 				}
 			}

--- a/libs/ardour/session_process.cc
+++ b/libs/ardour/session_process.cc
@@ -114,7 +114,7 @@ Session::process (pframes_t nframes)
 	 *
 	 * ideally this would be done in
 	 * Route::process_output_buffers() but various functions
-	 * callig it hold a _processor_lock reader-lock
+	 * calling it hold a _processor_lock reader-lock
 	 */
 	bool one_or_more_routes_declicking = false;
 	{
@@ -1337,7 +1337,7 @@ Session::plan_master_strategy (pframes_t nframes, double master_speed, samplepos
 		return desired;
 	}
 
-	/* When calling TransportMasterStart, sould aim for
+	/* When calling TransportMasterStart, should aim for
 	 *   delta >= _remaining_latency_preroll
 	 * This way there can be silent pre-roll of exactly the delta time.
 	 *

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -1619,7 +1619,7 @@ Session::set_state (const XMLNode& node, int version)
 
 	setup_raid_path(_session_dir->root_path());
 
-	node.get_property (X_("end-is-free"), _session_range_is_free);  //deprectated, but use old values if they are in the config
+	node.get_property (X_("end-is-free"), _session_range_is_free);  //deprecated, but use old values if they are in the config
 
 	node.get_property (X_("session-range-is-free"), _session_range_is_free);
 

--- a/libs/ardour/sndfileimportable.cc
+++ b/libs/ardour/sndfileimportable.cc
@@ -62,7 +62,7 @@ SndFileImportableSource::get_timecode_info (SNDFILE* sf, SF_BROADCAST_INFO* binf
 	}
 
 	exists = true;
-	/* libsndfile reads eactly 4 bytes for high and low, but
+	/* libsndfile reads exactly 4 bytes for high and low, but
 	 * uses "unsigned int" which may or may not be 32 bit little
 	 * endian.
 	 */

--- a/libs/ardour/sndfilesource.cc
+++ b/libs/ardour/sndfilesource.cc
@@ -346,7 +346,7 @@ SndFileSource::open ()
 // We really only want to use g_open for all platforms but because of this
 // method(SndfileSource::open), the compiler(or at least GCC) is confused
 // because g_open will expand to "open" on non-POSIX systems and needs the
-// global namespace qualifer. The problem is since since C99 ::g_open will
+// global namespace qualifier. The problem is since since C99 ::g_open will
 // apparently expand to ":: open"
 #ifdef PLATFORM_WINDOWS
 	int fd = g_open (_path.c_str(), writable() ? O_CREAT | O_RDWR : O_RDONLY, writable() ? 0644 : 0444);

--- a/libs/ardour/sse_avx_functions_64bit_win.s
+++ b/libs/ardour/sse_avx_functions_64bit_win.s
@@ -559,7 +559,7 @@ x86_sse_avx_compute_peak:
 	vshufps $0xb1, %ymm0, %ymm0, %ymm1     #; shuffle the floats inside pairs (1234 => 2143) in each 128 bit half
 	vmaxps  %ymm1, %ymm0, %ymm0			   #; maximums of the four pairs, we had up to 4 unique elements was unique, 2 unique elements left now
 	vperm2f128 $0x01, %ymm0, %ymm0, %ymm1  #; swap 128 bit halfs
-	vmaxps  %ymm1, %ymm0, %ymm0			   #; the result will be - all 8 elemens are maximums
+	vmaxps  %ymm1, %ymm0, %ymm0			   #; the result will be - all 8 elements are maximums
 
 	#; now every float in %ymm0 is the same value, current maximum value
 

--- a/libs/ardour/sse_functions.s
+++ b/libs/ardour/sse_functions.s
@@ -50,7 +50,7 @@ x86_sse_mix_buffers_with_gain:
 	movl 12(%ebp), %esi #; src
 
 	movl %edi, %eax
-	andl $12, %eax #; mask alignemnt offset
+	andl $12, %eax #; mask alignment offset
 
 	movl %esi, %ebx
 	andl $12, %ebx #; mask alignment offset
@@ -186,7 +186,7 @@ x86_sse_mix_buffers_no_gain:
 	movl 12(%ebp), %esi #; src
 
 	movl %edi, %eax
-	andl $12, %eax #; mask alignemnt offset
+	andl $12, %eax #; mask alignment offset
 
 	movl %esi, %ebx
 	andl $12, %ebx #; mask alignment offset

--- a/libs/ardour/sse_functions_xmm.cc
+++ b/libs/ardour/sse_functions_xmm.cc
@@ -45,7 +45,7 @@ x86_sse_find_peaks(const ARDOUR::Sample* buf, ARDOUR::pframes_t nframes, float *
         // use 64 byte prefetch for quadruple quads
         while (nframes >= 16) {
 #ifdef COMPILER_MSVC
-				_mm_prefetch(((char*)buf+64), 0);  // A total guess! Assumed to be eqivalent to
+				_mm_prefetch(((char*)buf+64), 0);  // A total guess! Assumed to be equivalent to
 #else                                              // the line below but waiting to be tested !!
                 __builtin_prefetch(buf+64,0,0);
 #endif

--- a/libs/ardour/transport_fsm.cc
+++ b/libs/ardour/transport_fsm.cc
@@ -337,7 +337,7 @@ TransportFSM::process_event (Event& ev, bool already_deferred, bool& deferred)
 				 * This happens because we only need to do a
 				 * realtime locate and continue rolling. No
 				 * disk I/O is required - the loop is
-				 * automically present in buffers already.
+				 * automatically present in buffers already.
 				 *
 				 * Note that ev.ltd is ignored and
 				 * assumed to be true because we're looping.

--- a/libs/ardour/triggerbox.cc
+++ b/libs/ardour/triggerbox.cc
@@ -2513,7 +2513,7 @@ MIDITrigger::natural_length() const
 void
 MIDITrigger::estimate_midi_patches ()
 {
-	/* first, intialize all our slot's patches to GM defaults, to make playback deterministic */
+	/* first, initialize all our slot's patches to GM defaults, to make playback deterministic */
 	for (uint8_t chan = 0; chan < 16; ++chan) {
 		_patch_change[chan].set_channel(chan);
 		_patch_change[chan].set_bank( chan == 9 ? 120 : 0 );
@@ -2737,7 +2737,7 @@ MIDITrigger::midi_run (BufferSet& bufs, samplepos_t start_sample, samplepos_t en
 
 		/* "final_beat" is an inclusive end of the trigger, not
 		 * exclusive, so we must use <= here. That is, any last event
-		 * (remeber, iter == model->end() here, so we have already read
+		 * (remember, iter == model->end() here, so we have already read
 		 * through the entire MIDI model) that is up to AND INCLUDING
 		 * final_beat counts as "haven't reached the end".
 		 */

--- a/libs/ardour/vst3_scan.cc
+++ b/libs/ardour/vst3_scan.cc
@@ -328,7 +328,7 @@ ARDOUR::module_path_vst3 (string const& path)
 #ifdef __APPLE__
 	/* Check for "Contents/MacOS/" and "Context/Info.plist".
 	 * VST3MacModule calls CFBundleCreate() which handles Info.plist files.
-	 * (on macOS/X the binrary name may differ from the bundle name)
+	 * (on macOS/X the binary name may differ from the bundle name)
 	 */
 	string plist = Glib::build_filename (path, "Contents", "Info.plist");
 	if (Glib::file_test (Glib::path_get_dirname (module_path), Glib::FILE_TEST_IS_DIR) &&


### PR DESCRIPTION
Found via `codespell`