### PR TITLE
Fix typos in source foward(s)->forwards(s)

### DIFF
--- a/libs/ardour/ardour/transport_fsm.h
+++ b/libs/ardour/ardour/transport_fsm.h
@@ -188,7 +188,7 @@ struct TransportFSM
 	bool forwards() const             { return _direction_state == Forwards; }
 	bool backwards() const             { return _direction_state == Backwards; }
 	bool reversing() const             { return _direction_state == Reversing; }
-	bool will_roll_fowards() const;
+	bool will_roll_forwards() const;
 
 	void enqueue (Event* ev);
 

--- a/libs/ardour/ardour/triggerbox.h
+++ b/libs/ardour/ardour/triggerbox.h
@@ -722,7 +722,7 @@ class LIBARDOUR_API TriggerBox : public Processor
 	void add_trigger (TriggerPtr);
 
 	void fast_forward (CueEvents const &, samplepos_t transport_postiion);
-	bool fast_forwarding() const { return _fast_fowarding; }
+	bool fast_forwarding() const { return _fast_forwarding; }
 
 	void set_pending (uint32_t slot, Trigger*);
 
@@ -827,7 +827,7 @@ class LIBARDOUR_API TriggerBox : public Processor
 	int32_t                  _active_slots;
 	bool                     _locate_armed;
 	bool                     _cancel_locate_armed;
-	bool                     _fast_fowarding;
+	bool                     _fast_forwarding;
 
 	boost::shared_ptr<SideChain> _sidechain;
 

--- a/libs/ardour/ardour/vst3_plugin.h
+++ b/libs/ardour/ardour/vst3_plugin.h
@@ -221,7 +221,7 @@ private:
 	void psl_subscribe_to (boost::shared_ptr<ARDOUR::AutomationControl>, FIDString);
 	void psl_stripable_property_changed (PBD::PropertyChange const&);
 
-	void foward_signal (Presonus::IContextInfoHandler2*, FIDString) const;
+	void forward_signal (Presonus::IContextInfoHandler2*, FIDString) const;
 
 	boost::shared_ptr<ARDOUR::VST3PluginModule> _module;
 

--- a/libs/ardour/session_transport.cc
+++ b/libs/ardour/session_transport.cc
@@ -602,7 +602,7 @@ Session::start_transport (bool after_loop)
 		SessionEvent* ev = new SessionEvent (SessionEvent::TransportStateChange, SessionEvent::Add, _transport_sample, _transport_sample, 1.0);
 		queue_event (ev);
 
-		samplepos_t roll_pos = _transport_sample + std::max (_count_in_samples, _remaining_latency_preroll) * (_transport_fsm->will_roll_fowards () ? 1 : -1);
+		samplepos_t roll_pos = _transport_sample + std::max (_count_in_samples, _remaining_latency_preroll) * (_transport_fsm->will_roll_forwards () ? 1 : -1);
 		if (roll_pos > 0 && roll_pos != _transport_sample) {
 			/* and when transport_rolling () == true */
 			SessionEvent* ev = new SessionEvent (SessionEvent::TransportStateChange, SessionEvent::Add, roll_pos, roll_pos, 1.0);
@@ -2081,7 +2081,7 @@ Session::declick_in_progress () const
 bool
 Session::transport_will_roll_forwards () const
 {
-	return _transport_fsm->will_roll_fowards ();
+	return _transport_fsm->will_roll_forwards ();
 }
 
 double

--- a/libs/ardour/transport_fsm.cc
+++ b/libs/ardour/transport_fsm.cc
@@ -842,7 +842,7 @@ TransportFSM::set_speed (Event const & ev)
 }
 
 bool
-TransportFSM::will_roll_fowards () const
+TransportFSM::will_roll_forwards () const
 {
 	if (reversing() || _reverse_after_declick) {
 		return most_recently_requested_speed >= 0; /* note: future speed of zero is equivalent to Forwards */

--- a/libs/ardour/triggerbox.cc
+++ b/libs/ardour/triggerbox.cc
@@ -2869,7 +2869,7 @@ TriggerBox::TriggerBox (Session& s, DataType dt)
 	, _active_slots (0)
 	, _locate_armed (false)
 	, _cancel_locate_armed (false)
-	, _fast_fowarding (false)
+	, _fast_forwarding (false)
 
 	, requests (1024)
 {
@@ -2956,7 +2956,7 @@ TriggerBox::fast_forward (CueEvents const & cues, samplepos_t transport_position
 		return;
 	}
 
-	PBD::Unwinder<bool> uw (_fast_fowarding, true);
+	PBD::Unwinder<bool> uw (_fast_forwarding, true);
 
 	using namespace Temporal;
 	TempoMap::SharedPtr tmap (TempoMap::use());

--- a/libs/ardour/vst3_plugin.cc
+++ b/libs/ardour/vst3_plugin.cc
@@ -2891,11 +2891,11 @@ VST3PI::psl_subscribe_to (boost::shared_ptr<ARDOUR::AutomationControl> ac, FIDSt
 	}
 
 	DEBUG_TRACE (DEBUG::VST3Callbacks, string_compose ("VST3PI::psl_subscribe_to: %1\n", ac->name ()));
-	ac->Changed.connect_same_thread (_ac_connection_list, boost::bind (&VST3PI::foward_signal, this, nfo2.get (), id));
+	ac->Changed.connect_same_thread (_ac_connection_list, boost::bind (&VST3PI::forward_signal, this, nfo2.get (), id));
 }
 
 void
-VST3PI::foward_signal (IContextInfoHandler2* handler, FIDString id) const
+VST3PI::forward_signal (IContextInfoHandler2* handler, FIDString id) const
 {
 	assert (handler);
 	DEBUG_TRACE (DEBUG::VST3Callbacks, string_compose ("VST3PI::psl_subscribtion AC changed %1\n", id));


### PR DESCRIPTION
Fix source typos