### PR TITLE
Export dialog: update state after "Select All" and "Deselect All"

### DIFF
--- a/gtk2_ardour/export_timespan_selector.cc
+++ b/gtk2_ardour/export_timespan_selector.cc
@@ -388,6 +388,9 @@ ExportTimespanSelector::set_selection_state_of_all_timespans (bool s)
 	for (Gtk::ListStore::Children::iterator it = range_list->children().begin(); it != range_list->children().end(); ++it) {
 		it->set_value (range_cols.selected, s);
 	}
+
+	update_timespans ();
+	CriticalSelectionChanged ();
 }
 
 /*** ExportTimespanSelectorSingle ***/


### PR DESCRIPTION
The state was inconsistent after using the "All" buttons, causing
confusing behaviour. Most visibly, the message "No timespan has been
selected!" message and the disabling of the "Export" button were not
cleared.

Fixed by making
ExportTimespanSelector::set_selection_state_of_all_timespans call
update_timespans and CriticalSelectionChanged , like for example
ExportTimespanSelector::update_range_name and
ExportTimespanSelectorMultiple::update_selection do.