### PR TITLE
Remember last route type

### DIFF
--- a/gtk2_ardour/add_route_dialog.cc
+++ b/gtk2_ardour/add_route_dialog.cc
@@ -23,7 +23,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include <cstdio>
 #include <cmath>
 
 #include <sigc++/bind.h>
@@ -49,12 +48,10 @@
 
 #include "LuaBridge/LuaBridge.h"
 
-#include "ardour_message.h"
 #include "add_route_dialog.h"
 #include "ardour_ui.h"
 #include "route_group_dialog.h"
 #include "ui_config.h"
-#include "utils.h"
 
 #include "pbd/i18n.h"
 
@@ -66,7 +63,7 @@ using namespace ARDOUR;
 using namespace ARDOUR_UI_UTILS;
 
 std::vector<std::string> AddRouteDialog::channel_combo_strings;
-std::vector<std::pair<std::string,std::string> > AddRouteDialog::builtin_types;
+std::vector<std::pair<std::string, std::string>> AddRouteDialog::builtin_types;
 
 AddRouteDialog::AddRouteDialog ()
 	: ArdourDialog (_("Add Track/Bus/VCA"))
@@ -100,8 +97,7 @@ AddRouteDialog::AddRouteDialog ()
 	refill_track_modes ();
 
 	if (builtin_types.empty()) {
-		builtin_types.push_back (
-		   std::pair<string,string> (_("Audio Tracks"), std::string () +
+		builtin_types.emplace_back(_("Audio Tracks"), std::string () +
 		     _("Use these settings to create one or more audio tracks.") + "\n\n" +
 		     _("You may select:") + "\n" +
 		     "* " + _("The number of tracks to add") + "\n" +
@@ -112,10 +108,9 @@ AddRouteDialog::AddRouteDialog ()
 		     "* " + _("The pin connections mode (see tooltip for details)") + "\n" +
 #endif
 		     "\n" + _("The track(s) will be added at the location specified by \"Position\"")
-		     ));
+		     );
 
-		builtin_types.push_back (
-		   std::pair<string,string> (_("MIDI Tracks"), std::string () +
+		builtin_types.emplace_back(_("MIDI Tracks"), std::string () +
 		     _("Use these settings to create one or more MIDI tracks.") + "\n\n" +
 		     _("You may select:") + "\n" +
 		     "* " + _("The number of tracks to add") + "\n" +
@@ -126,10 +121,9 @@ AddRouteDialog::AddRouteDialog ()
 		     "* " + _("The pin connections mode (see tooltip for details)") + "\n" +
 #endif
 		     "\n" + _("The track(s) will be added at the location specified by \"Position\"")
-		     ));
+		     );
 
-		builtin_types.push_back (
-		   std::pair<string,string> (_("Audio Busses"), std::string () +
+		builtin_types.emplace_back(_("Audio Busses"), std::string () +
 		     _("Use these settings to create one or more audio busses.") + "\n\n" +
 		     _("You may select:") + "\n" +
 		     "* " + _("The number of busses to add") + "\n" +
@@ -139,10 +133,9 @@ AddRouteDialog::AddRouteDialog ()
 		     "* " + _("The pin connections mode (see tooltip for details)") + "\n" +
 #endif
 		     "\n" + _("The buss(es) will be added at the location specified by \"Position\"")
-		     ));
+		     );
 
-		builtin_types.push_back (
-		   std::pair<string,string> (_("MIDI Busses"), std::string () +
+		builtin_types.emplace_back(_("MIDI Busses"), std::string () +
 		     _("Use these settings to create one or more MIDI busses.") + "\n\n" +
 		     _("MIDI busses can combine the output of multiple tracks. They are sometimes used\nto host a single \"heavy\" instrument plugin which is fed from multiple MIDI tracks.") + "\n\n" +
 		     _("You may select:") + "\n" +
@@ -154,24 +147,22 @@ AddRouteDialog::AddRouteDialog ()
 		     "* " + _("The pin connections mode (see tooltip for details)") + "\n" +
 #endif
 		     "\n" + _("The buss(es) will be added at the location specified by \"Position\"")
-		     ));
+		     );
 
-		builtin_types.push_back (
-		   std::pair<string,string> (_("VCA Masters"), std::string () +
+		builtin_types.emplace_back(_("VCA Masters"), std::string () +
 		     _("Use these settings to create one or more VCA masters.") + "\n\n" +
 		     _("You may select:") + "\n" +
 		     "* " + _("The number of VCAs to add") + "\n" +
 		     "* " + _("A name for the VCA(s). \"%n\" will be replaced by an index number for each VCA")
-		     ));
+		     );
 
-		builtin_types.push_back (
-		   std::pair<string,string> (_("Foldback Busses"), std::string () +
+		builtin_types.emplace_back(_("Foldback Busses"), std::string () +
 		     _("Use these settings to create one or more foldback busses.") + "\n\n" +
 		     _("Foldback busses are used as master outputs for monitor channels and are fed by\nhidden monitor sends.") + "\n\n" +
 		     _("You may select:") + "\n" +
 		     "* " + _("The number of busses to add") + "\n" +
 		     "* " + _("A name for the buss(es)")
-		     ));
+		     );
 	}
 
 	insert_at_combo.append (_("First"));
@@ -361,9 +352,7 @@ AddRouteDialog::AddRouteDialog ()
 	refill_channel_setups ();
 }
 
-AddRouteDialog::~AddRouteDialog ()
-{
-}
+AddRouteDialog::~AddRouteDialog () = default;
 
 void
 AddRouteDialog::on_response (int r)

--- a/gtk2_ardour/add_route_dialog.h
+++ b/gtk2_ardour/add_route_dialog.h
@@ -74,63 +74,64 @@ public:
 		VCAMaster,
 		FoldbackBus,
 	};
-	TypeWanted type_wanted();
+	TypeWanted type_wanted ();
 
 	ARDOUR::ChanCount channels ();
-	uint32_t channel_count ();
-	int count ();
+	uint32_t          channel_count ();
+	int               count ();
 
-	std::string name_template () const;
-	bool name_template_is_default () const;
+	std::string           name_template () const;
+	bool                  name_template_is_default () const;
 	ARDOUR::PluginInfoPtr requested_instrument ();
 
-	ARDOUR::TrackMode mode();
+	ARDOUR::TrackMode   mode ();
 	ARDOUR::RouteGroup* route_group ();
 
-	RouteDialogs::InsertAt insert_at();
-	bool use_strict_io();
+	RouteDialogs::InsertAt insert_at ();
+	bool                   use_strict_io ();
 
-	bool show_on_cue_page();
+	bool show_on_cue_page ();
 
-	std::string get_template_path();
+	std::string get_template_path ();
 
 	void reset_name_edited () { name_edited_by_user = false; }
 
 private:
-	Gtk::Entry name_template_entry;
-	Gtk::Adjustment routes_adjustment;
-	Gtk::SpinButton routes_spinner;
-	Gtk::ComboBoxText channel_combo;
-	Gtk::Label configuration_label;
-	Gtk::Label manual_label;
-	Gtk::Label add_label;
-	Gtk::Label name_label;
-	Gtk::Label group_label;
-	Gtk::Label insert_label;
-	Gtk::Label strict_io_label;
-	Gtk::Label mode_label;
-	Gtk::Label instrument_label;
-	Gtk::ComboBoxText mode_combo;
-	Gtk::ComboBoxText route_group_combo;
+	Gtk::Entry         name_template_entry;
+	Gtk::Adjustment    routes_adjustment;
+	Gtk::SpinButton    routes_spinner;
+	Gtk::ComboBoxText  channel_combo;
+	Gtk::Label         configuration_label;
+	Gtk::Label         manual_label;
+	Gtk::Label         add_label;
+	Gtk::Label         name_label;
+	Gtk::Label         group_label;
+	Gtk::Label         insert_label;
+	Gtk::Label         strict_io_label;
+	Gtk::Label         mode_label;
+	Gtk::Label         instrument_label;
+	Gtk::ComboBoxText  mode_combo;
+	Gtk::ComboBoxText  route_group_combo;
 	InstrumentSelector instrument_combo;
-	Gtk::ComboBoxText insert_at_combo;
-	Gtk::ComboBoxText strict_io_combo;
-	Gtk::CheckButton show_on_cue_chkbox;
+	Gtk::ComboBoxText  insert_at_combo;
+	Gtk::ComboBoxText  strict_io_combo;
+	Gtk::CheckButton   show_on_cue_chkbox;
 
 	void track_type_chosen ();
 	void refill_channel_setups ();
 	void refill_route_groups ();
 	void refill_track_modes ();
-	void add_route_group (ARDOUR::RouteGroup *);
+	void add_route_group (ARDOUR::RouteGroup*);
 	void group_changed ();
 	void channel_combo_changed ();
-	bool channel_separator (const Glib::RefPtr<Gtk::TreeModel> &m, const Gtk::TreeModel::iterator &i);
-	bool route_separator (const Glib::RefPtr<Gtk::TreeModel> &m, const Gtk::TreeModel::iterator &i);
+	bool channel_separator (const Glib::RefPtr<Gtk::TreeModel>& m, const Gtk::TreeModel::iterator& i);
+	bool route_separator (const Glib::RefPtr<Gtk::TreeModel>& m, const Gtk::TreeModel::iterator& i);
 	void maybe_update_name_template_entry ();
 	void instrument_changed ();
 
 	struct TrackTemplateColumns : public Gtk::TreeModel::ColumnRecord {
-		TrackTemplateColumns () {
+		TrackTemplateColumns ()
+		{
 			add (name);
 			add (path);
 			add (description);
@@ -145,8 +146,8 @@ private:
 
 	TrackTemplateColumns track_template_columns;
 
-	Glib::RefPtr<Gtk::TreeStore>  trk_template_model;
-	Gtk::TreeView                 trk_template_chooser;
+	Glib::RefPtr<Gtk::TreeStore> trk_template_model;
+	Gtk::TreeView                trk_template_chooser;
 
 	void trk_template_row_selected ();
 
@@ -154,10 +155,9 @@ private:
 	Gtk::Frame    trk_template_outer_frame;
 	Gtk::Frame    trk_template_desc_frame;
 
-	void reset_template_option_visibility ();
 	void new_group_dialog_finished (int, RouteGroupDialog*);
-	void on_show ();
-	void on_response (int);
+	void on_show () override;
+	void on_response (int) override;
 
 	struct ChannelSetup {
 		std::string name;
@@ -165,17 +165,17 @@ private:
 	};
 
 	typedef std::vector<ChannelSetup> ChannelSetups;
-	ChannelSetups channel_setups;
+	ChannelSetups                     channel_setups;
 
-	int last_route_count;
+	int  last_route_count;
 	bool route_count_set_by_template;
 
-	static std::vector<std::pair<std::string, std::string> > builtin_types;
-	static std::vector<std::string> channel_combo_strings;
-	static std::vector<std::string> bus_mode_strings;
+	static std::vector<std::pair<std::string, std::string>> builtin_types;
+	static std::vector<std::string>                         channel_combo_strings;
+	static std::vector<std::string>                         bus_mode_strings;
 
 	bool name_edited_by_user;
-	void name_template_entry_insertion (Glib::ustring const &,int*);
+	void name_template_entry_insertion (Glib::ustring const&, int*);
 	void name_template_entry_deletion (int, int);
 };
 

--- a/gtk2_ardour/add_route_dialog.h
+++ b/gtk2_ardour/add_route_dialog.h
@@ -47,6 +47,7 @@
 #include "ardour/plugin.h"
 #include "ardour/types.h"
 #include "ardour/template_utils.h"
+#include "ardour/route_group.h"
 
 #include "ardour_dialog.h"
 #include "instrument_selector.h"
@@ -117,17 +118,18 @@ private:
 	Gtk::ComboBoxText  strict_io_combo;
 	Gtk::CheckButton   show_on_cue_chkbox;
 
-	void track_type_chosen ();
-	void refill_channel_setups ();
-	void refill_route_groups ();
-	void refill_track_modes ();
-	void add_route_group (ARDOUR::RouteGroup*);
-	void group_changed ();
-	void channel_combo_changed ();
-	bool channel_separator (const Glib::RefPtr<Gtk::TreeModel>& m, const Gtk::TreeModel::iterator& i);
-	bool route_separator (const Glib::RefPtr<Gtk::TreeModel>& m, const Gtk::TreeModel::iterator& i);
-	void maybe_update_name_template_entry ();
-	void instrument_changed ();
+	void        track_type_chosen ();
+	std::string type_wanted_to_localized_string (TypeWanted type_wanted);
+	void        refill_channel_setups ();
+	void        refill_route_groups ();
+	void        refill_track_modes ();
+	void        add_route_group (ARDOUR::RouteGroup*);
+	void        group_changed ();
+	void        channel_combo_changed ();
+	bool        channel_separator (const Glib::RefPtr<Gtk::TreeModel>& m, const Gtk::TreeModel::iterator& i);
+	bool        route_separator (const Glib::RefPtr<Gtk::TreeModel>& m, const Gtk::TreeModel::iterator& i);
+	void        maybe_update_name_template_entry ();
+	void        instrument_changed ();
 
 	struct TrackTemplateColumns : public Gtk::TreeModel::ColumnRecord {
 		TrackTemplateColumns ()

--- a/gtk2_ardour/ardour_dialog.cc
+++ b/gtk2_ardour/ardour_dialog.cc
@@ -30,7 +30,6 @@
 #include "keyboard.h"
 #include "splash.h"
 #include "ui_config.h"
-#include "utils.h"
 #include "window_manager.h"
 
 using namespace std;
@@ -38,21 +37,21 @@ using namespace Gtk;
 using namespace Gtkmm2ext;
 using namespace ARDOUR_UI_UTILS;
 
-ArdourDialog::ArdourDialog (string title, bool modal, bool use_seperator)
-	: Dialog (title, modal, use_seperator)
-	, _sensitive (true)
-	, proxy (0)
-	, _splash_pushed (false)
+ArdourDialog::ArdourDialog (const string& title, bool modal, bool use_seperator)
+        : Dialog (title, modal, use_seperator)
+        , _sensitive (true)
+        , proxy (nullptr)
+        , _splash_pushed (false)
 {
 	init ();
 	set_position (Gtk::WIN_POS_MOUSE);
 }
 
-ArdourDialog::ArdourDialog (Gtk::Window& parent, string title, bool modal, bool use_seperator)
-	: Dialog (title, parent, modal, use_seperator)
-	, _sensitive (true)
-	, proxy (0)
-	, _splash_pushed (false)
+ArdourDialog::ArdourDialog (Gtk::Window& parent, const string& title, bool modal, bool use_seperator)
+        : Dialog (title, parent, modal, use_seperator)
+        , _sensitive (true)
+        , proxy (nullptr)
+        , _splash_pushed (false)
 {
 	init ();
 	set_position (Gtk::WIN_POS_CENTER_ON_PARENT);
@@ -61,8 +60,8 @@ ArdourDialog::ArdourDialog (Gtk::Window& parent, string title, bool modal, bool 
 ArdourDialog::~ArdourDialog ()
 {
 	pop_splash ();
-	Keyboard::the_keyboard().focus_out_window (0, this);
-	WM::Manager::instance().remove (proxy);
+	Keyboard::the_keyboard ().focus_out_window (nullptr, this);
+	WM::Manager::instance ().remove (proxy);
 	proxy->explicit_delete ();
 }
 
@@ -90,7 +89,7 @@ void
 ArdourDialog::pop_splash ()
 {
 	if (_splash_pushed) {
-		Splash* spl = Splash::exists () ? Splash::instance() : NULL;
+		Splash* spl = Splash::exists () ? Splash::instance () : nullptr;
 
 		if (spl) {
 			spl->pop_front_for (*this);
@@ -100,17 +99,17 @@ ArdourDialog::pop_splash ()
 }
 
 bool
-ArdourDialog::on_focus_in_event (GdkEventFocus *ev)
+ArdourDialog::on_focus_in_event (GdkEventFocus* ev)
 {
-	Keyboard::the_keyboard().focus_in_window (ev, this);
+	Keyboard::the_keyboard ().focus_in_window (ev, this);
 	return Dialog::on_focus_in_event (ev);
 }
 
 bool
-ArdourDialog::on_focus_out_event (GdkEventFocus *ev)
+ArdourDialog::on_focus_out_event (GdkEventFocus* ev)
 {
-	if (!get_modal()) {
-		Keyboard::the_keyboard().focus_out_window (ev, this);
+	if (!get_modal ()) {
+		Keyboard::the_keyboard ().focus_out_window (ev, this);
 	}
 	return Dialog::on_focus_out_event (ev);
 }
@@ -118,7 +117,7 @@ ArdourDialog::on_focus_out_event (GdkEventFocus *ev)
 void
 ArdourDialog::on_unmap ()
 {
-	Keyboard::the_keyboard().leave_window (0, this);
+	Keyboard::the_keyboard ().leave_window (nullptr, this);
 	pop_splash ();
 	Dialog::on_unmap ();
 }
@@ -130,8 +129,8 @@ ArdourDialog::on_show ()
 
 	// never allow the splash screen to obscure any dialog
 
-	if (Splash::exists()) {
-		Splash* spl = Splash::instance();
+	if (Splash::exists ()) {
+		Splash* spl = Splash::instance ();
 
 		spl->pop_back_for (*this);
 		_splash_pushed = true;
@@ -156,14 +155,14 @@ ArdourDialog::init ()
 #ifdef __APPLE__
 	set_type_hint (Gdk::WINDOW_TYPE_HINT_DIALOG);
 #else
-	if (UIConfiguration::instance().get_all_floating_windows_are_dialogs () || get_modal ()) {
+	if (UIConfiguration::instance ().get_all_floating_windows_are_dialogs () || get_modal ()) {
 		set_type_hint (Gdk::WINDOW_TYPE_HINT_DIALOG);
 	} else {
 		set_type_hint (Gdk::WINDOW_TYPE_HINT_UTILITY);
 	}
 #endif
 
-	Gtk::Window* parent = WM::Manager::instance().transient_parent();
+	Gtk::Window* parent = WM::Manager::instance ().transient_parent ();
 
 	if (parent) {
 		set_transient_for (*parent);
@@ -171,8 +170,8 @@ ArdourDialog::init ()
 
 	ARDOUR_UI::CloseAllDialogs.connect (sigc::mem_fun (*this, &ArdourDialog::close_self)); /* send a RESPONSE_CANCEL to self */
 
-	proxy = new WM::ProxyTemporary (get_title(), this);
-	WM::Manager::instance().register_window (proxy);
+	proxy = new WM::ProxyTemporary (get_title (), this);
+	WM::Manager::instance ().register_window (proxy);
 }
 
 void

--- a/gtk2_ardour/ardour_dialog.h
+++ b/gtk2_ardour/ardour_dialog.h
@@ -40,8 +40,8 @@ namespace WM {
 class ArdourDialog : public Gtk::Dialog, public ARDOUR::SessionHandlePtr
 {
 public:
-	ArdourDialog (std::string title, bool modal = false, bool use_separator = false);
-	ArdourDialog (Gtk::Window& parent, std::string title, bool modal = false, bool use_separator = false);
+	explicit ArdourDialog (const std::string& title, bool modal = false, bool use_separator = false);
+	ArdourDialog (Gtk::Window& parent, const std::string& title, bool modal = false, bool use_separator = false);
 	~ArdourDialog();
 
 	bool on_focus_in_event (GdkEventFocus*);

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -147,7 +147,6 @@ class SelectionPropertiesBox;
 class SoundFileOmega;
 class StreamView;
 class GridLines;
-class TempoLines;
 class TimeAxisView;
 class TimeInfoBox;
 class TimeFXDialog;
@@ -452,9 +451,6 @@ public:
 	                                                 bool use_context_click = false,
 	                                                 bool from_outside_canvas = false);
 
-	bool update_mouse_speed ();
-	bool decelerate_mouse_speed ();
-
 	void toggle_meter_updating();
 
 	void show_rhythm_ferret();
@@ -462,15 +458,9 @@ public:
 	void goto_visual_state (uint32_t);
 	void save_visual_state (uint32_t);
 
-	void queue_draw_resize_line (int at);
-	void start_resize_line_ops ();
-	void end_resize_line_ops ();
-
 	TrackViewList const & get_track_views () const {
 		return track_views;
 	}
-
-	void do_ptimport(std::string path, ARDOUR::SrcQuality quality);
 
 	void do_import (std::vector<std::string>              paths,
 	                Editing::ImportDisposition            disposition,

--- a/gtk2_ardour/enums.cc
+++ b/gtk2_ardour/enums.cc
@@ -24,12 +24,11 @@
 
 #include "pbd/enumwriter.h"
 
-#include "widgets/ardour_icon.h"
-
+#include "add_route_dialog.h"
 #include "audio_clock.h"
 #include "editing.h"
-#include "enums.h"
 #include "editor_items.h"
+#include "enums.h"
 #include "startup_fsm.h"
 
 using namespace std;
@@ -60,11 +59,12 @@ setup_gtk_ardour_enums ()
 	StartupFSM::MainState startup_state;
 	StartupFSM::DialogID startup_dialog;
 	Gtk::ResponseType dialog_response;
+	AddRouteDialog::TypeWanted type_wanted;
 
 #define REGISTER(e) enum_writer.register_distinct (typeid(e).name(), i, s); i.clear(); s.clear()
 #define REGISTER_BITS(e) enum_writer.register_bits (typeid(e).name(), i, s); i.clear(); s.clear()
-#define REGISTER_ENUM(e) i.push_back (e); s.push_back (#e)
-#define REGISTER_CLASS_ENUM(t,e) i.push_back (t::e); s.push_back (#e)
+#define REGISTER_ENUM(e) i.emplace_back (e); s.emplace_back (#e)
+#define REGISTER_CLASS_ENUM(t,e) i.emplace_back (t::e); s.emplace_back (#e)
 
 	REGISTER_CLASS_ENUM (AudioClock, Timecode);
 	REGISTER_CLASS_ENUM (AudioClock, BBT);
@@ -217,4 +217,12 @@ setup_gtk_ardour_enums ()
 	REGISTER_ENUM (RESPONSE_APPLY);
 	REGISTER_ENUM (RESPONSE_HELP);
 	REGISTER (dialog_response);
+
+	REGISTER_CLASS_ENUM (AddRouteDialog, AudioTrack);
+	REGISTER_CLASS_ENUM (AddRouteDialog, MidiTrack);
+	REGISTER_CLASS_ENUM (AddRouteDialog, AudioBus);
+	REGISTER_CLASS_ENUM (AddRouteDialog, MidiBus);
+	REGISTER_CLASS_ENUM (AddRouteDialog, VCAMaster);
+	REGISTER_CLASS_ENUM (AddRouteDialog, FoldbackBus);
+	REGISTER (type_wanted);
 }


### PR DESCRIPTION
In the Add Tracks/Busses dialog the last chosen route type will be remembered now. It works only for the builtin types.
Also it works only for ardour as it looked to me as if there were some default selections made for Mixbus.

The other two commits remove some unused imports and unimplemented methods and can be dropped if you don't want them.