### PR TITLE
Fix ControlList::_x_scale to avoid ratio overflow when adjusting fade length

### DIFF
--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -277,8 +277,8 @@ Drag::Drag (Editor* e, ArdourCanvas::Item* i, Temporal::TimeDomain td, bool trac
 	, _constraint_pressed (false)
 	, _grab_button (-1)
 {
-
 }
+
 timepos_t
 Drag::pixel_to_time (double x) const
 {

--- a/libs/evoral/ControlList.cc
+++ b/libs/evoral/ControlList.cc
@@ -359,8 +359,9 @@ ControlList::list_merge (ControlList const& other, boost::function<double(double
 void
 ControlList::_x_scale (ratio_t const & factor)
 {
+	double double_factor = (double)factor;
 	for (iterator i = _events.begin(); i != _events.end(); ++i) {
-		(*i)->when = (*i)->when.operator* (factor);
+		(*i)->when = timepos_t::from_superclock ((*i)->when.val() * double_factor + 0.5);
 	}
 
 	mark_dirty ();

--- a/libs/temporal/tempo.cc
+++ b/libs/temporal/tempo.cc
@@ -2466,7 +2466,7 @@ TempoMap::set_state (XMLNode const & node, int version)
 
 	/* global map properties */
 
-	/* XXX this should probably be at the global level in the session file because it affects a lot more than just the tempo map, potentially */
+	/* XXX this should probably be at the global level in the session file because it is the basic time unit in session files and affects a lot more than just the tempo map */
 	superclock_t sc;
 	if (node.get_property (X_("superclocks-per-second"), sc)) {
 		set_superclock_ticks_per_second (sc);

--- a/libs/temporal/temporal/types.h
+++ b/libs/temporal/temporal/types.h
@@ -89,7 +89,7 @@ class _ratio_t {
 
 	int64_t operator* (int64_t v) const { return int_div_round (v * _numerator, _denominator); }
 
-                                        private:
+  private:
 	T _numerator;
 	T _denominator;
 };


### PR DESCRIPTION
Region fades would sometimes get in a mode with weird behaviour. They would be drawn in 2d with crossing lines, mainly moving back and forth horizontally - not as a function of time. It would sound as weird as it looked. The fade would sometimes jump around when resizing. It could be worked around by resetting the fade shape. It turned out the problem could be reproduced by making minute long fades.

This change fixes or works around the problem.

Back story:

timepos_t (in temporal/timeline.h) uses 62 bit for integer value and the max value is thus 4611686018427387904 ~ 5e18.
timepos_t counts superclocks, where superclock_ticks_per_second is 56448000 ~ 6e7. It can thus store up to 8e10 seconds - thousands of years.

ratio_t (in temporal/types.h) can represent fractions as 64 bit (signed) numerator and denominator.
timepos_t avoids floating point operations, but has operator* with ratio_t. To avoid crazy loss of precision it will multiply the superclock count with the numerator before dividing with the denominator.

Audio region fade in and out uses a number of increasing timepos_t values (in a ControlList) up to the length of fade. When dragging to resize, these values are (in_x_scale) multiplied with the ratio_t of the new and old fade length.
The problem is that the 62 bits will overflow if using fades more than sqrt(5e18) ~ 2e9 superclock ticks ~ 38 seconds. It will overflow into the "beat" flag and (at 58 seconds) into the sign bit. The timepos_t values in the fade will thus jump and can be negative or change to count beats.

To work around that problem, this changeset just use floating point values for scaling the timepos_t values. All scaled values are stored as integer anyway, so it should not make any actual difference for this use case. There might however be other uses of ControlList where it matters.

As an implementation detail of this "workaround" of using double, it could perhaps also be nice to implement timepos_t operator* (or operator*=) for double. But I'm not sure we want floating point support in timepos_t.

An alternative (and better) solution would be to convince the fraction multiplication to use 128 bits. It is essential to avoid overflow - mainly in static analysis, alternatively as runtime checks or asserts. It is fair enough that data types can overflow, but very unfortunate when it happens inside utility functions - such as scaling with ratios.


Perspective / further work / ideas:

It would be nice if timepos_t had detection of overflow - at least in debug mode.

Also, it would be nice to have the type system enforce that these timepos_t values are positive and count superclock ticks - not beats. It backfires a bit to use timepos_t for plain unsigned "superclock tick count". It doesn't seem like much would be lost by using plain uint64_t of superclock ticks in this place.

The .ardour file format doesn't store explicitly what shape and fade length was used. It just stores the generated timepos_t values of fades, and not as "nice" XML, but in a multiline string that has to be parsed. It would be nice to store the source information instead of the generated values. That would make it possible to (re)generate the fade curve.

I have seen .ardour files with jumping and negative time values. It would be nice to detect and recover from such bad timepos_t values. Especially to make sure that the series is strictly monotonically increasing.

Right now, the timepos_t values are scaled up and down when resizing, expecting to keep the same shape. That means that once an error has been introduced, it will never go away (until the shape is reset). That fragility will be less of a problem once the root cause is fixed. It would probably be cleaner to avoid the scaling problem completely by creating a fade curve of the right size instead of scaling the old one. Computing the curves is not instantaneous. That could be mitigated by storing the curve values precomputed.

Some code snippets that demonstrate some confusing aspects when trying to pinpoint the problem::

        std::cout << "Finding the limits of int_div_round, around sqrt(2**63) = 3037000499.976" << "\n";
        int64_t i64, i64x;
        i64 = 3037000499;
        std::cout << "Playing around just below the signed overflow limit for 64 bit: " << i64 << "\n";
        std::cout << "inline: " << (i64 * i64) / i64 << "\n";
        // prints: 3037000499
        std::cout << "int_div_round: " << int_div_round (i64 * i64, i64) << "\n";
        // prints: 3037000499

        i64 = 3037000500;
        i64x = i64 * i64;
        std::cout << "Playing around just above the signed overflow limit for 64 bit: " << i64 << "\n";
        std::cout << "checking inline overflow: " << (i64 * i64) << "\n";
        // prints: -9223372036709301616 - which is correct signed value of 0x8000000008abc290
        std::cout << "checking variable overflow: " << i64x << "\n";
        // prints: -9223372036709301616 - which is correct signed value of 0x8000000008abc290
        std::cout << "inline multiplication: " << (i64 * i64) / i64 << "\n";
        // prints: 3037000500 - which is surprisingly correct
        // this is actually incorrect in signed 64 bit - the compiler must be optimizing
        std::cout << "variable multiplication: " << i64x / i64 << "\n";
        // prints: -3037000499 - which seems wrong but is correct in signed 64 bit
        std::cout << "int_div_round: " << int_div_round (i64 * i64, i64) << "\n";
        // prints: 3037000499 - which shows surprising results from rounding when sign flips

        i64 = 3037000501;
        i64x = i64 * i64;
        std::cout << "Playing around further above the signed overflow limit for 64 bit: " << i64 << "\n";
        std::cout << "inline multiplication: " << (i64 * i64) / i64 << "\n";
        // prints: 3037000501 - which is surprisingly correct
        std::cout << "variable multiplication: " << i64x / i64 << "\n";
        // prints: -3037000496 - which seems wrong but is correct in signed 64 bit
        std::cout << "int_div_round: " << int_div_round (i64 * i64, i64) << "\n";
        // prints: -3037000497 - which shows other surprising results from rounding when sign flips


I guess there will be discussion of different ways to solve this problem. Please consider picking the first changesets first.