### PR TITLE
Remove unused includes to speed up build time

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -39,13 +39,8 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
-#include <cerrno>
 
 #include <stdarg.h>
-
-#ifndef PLATFORM_WINDOWS
-#include <sys/resource.h>
-#endif
 
 #ifdef __FreeBSD__
 #include <sys/types.h>
@@ -54,7 +49,6 @@
 
 #include <stdint.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <unistd.h>
 #include <time.h>
 
@@ -67,25 +61,17 @@
 #include <gtkmm/uimanager.h>
 
 #include "pbd/error.h"
-#include "pbd/basename.h"
 #include "pbd/compose.h"
 #include "pbd/convert.h"
 #include "pbd/failed_constructor.h"
-#include "pbd/file_archive.h"
-#include "pbd/enumwriter.h"
 #include "pbd/memento_command.h"
 #include "pbd/openuri.h"
-#include "pbd/stl_delete.h"
 #include "pbd/types_convert.h"
-#include "pbd/unwind.h"
 #include "pbd/file_utils.h"
-#include "pbd/localtime_r.h"
 #include "pbd/pthread_utils.h"
 #include "pbd/replace_all.h"
 #include "pbd/scoped_file_descriptor.h"
 #include "pbd/xml++.h"
-
-#include "temporal/tempo.h"
 
 #include "gtkmm2ext/application.h"
 #include "gtkmm2ext/bindings.h"
@@ -102,30 +88,22 @@
 #include "ardour/audio_track.h"
 #include "ardour/audioengine.h"
 #include "ardour/audiofilesource.h"
-#include "ardour/automation_watch.h"
 #include "ardour/disk_reader.h"
 #include "ardour/disk_writer.h"
-#include "ardour/filename_extensions.h"
 #include "ardour/filesystem_paths.h"
-#include "ardour/ltc_file_reader.h"
 #include "ardour/monitor_control.h"
 #include "ardour/midi_track.h"
 #include "ardour/port.h"
 #include "ardour/plugin_manager.h"
 #include "ardour/process_thread.h"
 #include "ardour/profile.h"
-#include "ardour/recent_sessions.h"
-#include "ardour/record_enable_control.h"
 #include "ardour/revision.h"
 #include "ardour/session_directory.h"
 #include "ardour/session_route.h"
-#include "ardour/session_state_utils.h"
-#include "ardour/session_utils.h"
 #include "ardour/source_factory.h"
 #include "ardour/transport_master.h"
 #include "ardour/transport_master_manager.h"
 #include "ardour/triggerbox.h"
-#include "ardour/system_exec.h"
 #include "ardour/track.h"
 #include "ardour/vca_manager.h"
 #include "ardour/utils.h"
@@ -147,11 +125,9 @@
 #include "temporal/time.h"
 
 #include "about.h"
-#include "editing.h"
 #include "enums_convert.h"
 #include "actions.h"
 #include "add_route_dialog.h"
-#include "ambiguous_file_dialog.h"
 #include "ardour_message.h"
 #include "ardour_ui.h"
 #include "audio_clock.h"
@@ -164,7 +140,6 @@
 #include "debug.h"
 #include "engine_dialog.h"
 #include "export_video_dialog.h"
-#include "gain_meter.h"
 #include "global_port_matrix.h"
 #include "gui_object.h"
 #include "gui_thread.h"
@@ -176,15 +151,12 @@
 #include "lua_script_manager.h"
 #include "luawindow.h"
 #include "main_clock.h"
-#include "missing_file_dialog.h"
 #include "missing_plugin_dialog.h"
 #include "mixer_ui.h"
 #include "meterbridge.h"
-#include "meter_patterns.h"
 #include "mouse_cursors.h"
 #include "nsm.h"
 #include "opts.h"
-#include "pingback.h"
 #include "plugin_dspload_window.h"
 #include "plugin_manager_ui.h"
 #include "processor_box.h"
@@ -210,11 +182,8 @@
 #include "trigger_page.h"
 #include "triggerbox_ui.h"
 #include "utils.h"
-#include "utils_videotl.h"
-#include "video_server_dialog.h"
 #include "virtual_keyboard_window.h"
 #include "add_video_dialog.h"
-#include "transcode_video_dialog.h"
 #include "plugin_selector.h"
 
 #include "pbd/i18n.h"

--- a/gtk2_ardour/editor_audiotrack.cc
+++ b/gtk2_ardour/editor_audiotrack.cc
@@ -18,13 +18,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "ardour/rc_configuration.h"
-
 #include "canvas/canvas.h"
 
 #include "editor.h"
-#include "editing.h"
-#include "audio_time_axis.h"
 #include "route_time_axis.h"
 #include "audio_region_view.h"
 #include "selection.h"

--- a/gtk2_ardour/editor_group_tabs.cc
+++ b/gtk2_ardour/editor_group_tabs.cc
@@ -19,8 +19,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "gtkmm2ext/utils.h"
-
 #include "ardour/route_group.h"
 
 #include "gtkmm2ext/colors.h"
@@ -29,10 +27,8 @@
 #include "editor_group_tabs.h"
 #include "editor_route_groups.h"
 #include "editor_routes.h"
-#include "rgb_macros.h"
 #include "route_time_axis.h"
 #include "ui_config.h"
-#include "utils.h"
 
 #include "pbd/i18n.h"
 

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -35,7 +35,6 @@
 #include <cstdlib>
 #include <cmath>
 #include <string>
-#include <limits>
 #include <map>
 #include <set>
 
@@ -84,15 +83,12 @@
 #include "ardour/triggerbox.h"
 #include "ardour/vca_manager.h"
 
-#include "canvas/canvas.h"
-
 #include "actions.h"
 #include "ardour_message.h"
 #include "ardour_ui.h"
 #include "audio_region_view.h"
 #include "audio_streamview.h"
 #include "audio_time_axis.h"
-#include "automation_region_view.h"
 #include "automation_time_axis.h"
 #include "control_point.h"
 #include "debug.h"
@@ -111,14 +107,12 @@
 #include "midi_region_view.h"
 #include "mixer_ui.h"
 #include "mixer_strip.h"
-#include "mouse_cursors.h"
 #include "normalize_dialog.h"
 #include "note.h"
 #include "paste_context.h"
 #include "patch_change_dialog.h"
 #include "quantize_dialog.h"
 #include "region_gain_line.h"
-#include "rgb_macros.h"
 #include "route_time_axis.h"
 #include "selection.h"
 #include "selection_templates.h"

--- a/gtk2_ardour/editor_route_groups.cc
+++ b/gtk2_ardour/editor_route_groups.cc
@@ -19,14 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifdef WAF_BUILD
-#include "gtk2ardour-config.h"
-#endif
-
 #include <cstdlib>
-#include <cmath>
-
-#include "fix_carbon.h"
 
 #include <gtkmm/stock.h>
 
@@ -36,7 +29,6 @@
 #include "widgets/tooltips.h"
 
 #include "ardour/route_group.h"
-#include "ardour/route.h"
 #include "ardour/session.h"
 
 #include "ardour_ui.h"
@@ -46,9 +38,7 @@
 #include "editor_routes.h"
 #include "gui_thread.h"
 #include "keyboard.h"
-#include "marker.h"
 #include "route_group_dialog.h"
-#include "route_time_axis.h"
 #include "time_axis_view.h"
 #include "utils.h"
 

--- a/gtk2_ardour/editor_summary.cc
+++ b/gtk2_ardour/editor_summary.cc
@@ -25,13 +25,10 @@
 
 #include "ardour/session.h"
 
-#include "canvas/debug.h"
-
 #include <gtkmm/menu.h>
 #include <gtkmm/menuitem.h>
 
 #include "context_menu_helper.h"
-#include "time_axis_view.h"
 #include "streamview.h"
 #include "editor_summary.h"
 #include "gui_thread.h"

--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -37,9 +37,7 @@
 
 #include "midi++/midnam_patch.h"
 
-#include "pbd/memento_command.h"
 #include "pbd/stateful_diff_command.h"
-#include "pbd/stacktrace.h"
 #include "pbd/unwind.h"
 
 #include "ardour/debug.h"
@@ -57,7 +55,6 @@
 #include "evoral/midi_util.h"
 
 #include "canvas/debug.h"
-#include "canvas/text.h"
 
 #include "automation_region_view.h"
 #include "automation_time_axis.h"
@@ -77,7 +74,6 @@
 #include "midi_time_axis.h"
 #include "midi_util.h"
 #include "midi_velocity_dialog.h"
-#include "mouse_cursors.h"
 #include "note_player.h"
 #include "paste_context.h"
 #include "public_editor.h"

--- a/gtk2_ardour/midi_time_axis.h
+++ b/gtk2_ardour/midi_time_axis.h
@@ -45,12 +45,10 @@
 #include "route_time_axis.h"
 #include "midi_streamview.h"
 
-namespace MIDI {
-namespace Name {
+namespace MIDI::Name {
 class MasterDeviceNames;
 class CustomDeviceMode;
 struct PatchPrimaryKey;
-}
 }
 
 namespace ARDOUR {

--- a/gtk2_ardour/mixer_strip.cc
+++ b/gtk2_ardour/mixer_strip.cc
@@ -2045,7 +2045,6 @@ MixerStrip::set_meter_type (MeterType t)
 void
 MixerStrip::update_track_number_visibility ()
 {
-	DisplaySuspender ds;
 	bool show_label = _session->config.get_track_name_number();
 
 	if (_route && _route->is_master()) {

--- a/gtk2_ardour/route_time_axis.cc
+++ b/gtk2_ardour/route_time_axis.cc
@@ -27,7 +27,6 @@
  */
 
 #include <cstdlib>
-#include <cmath>
 #include <cassert>
 
 #include <algorithm>
@@ -43,9 +42,7 @@
 #include <gtkmm/stock.h>
 
 #include "pbd/error.h"
-#include "pbd/stl_delete.h"
 #include "pbd/whitespace.h"
-#include "pbd/memento_command.h"
 #include "pbd/enumwriter.h"
 #include "pbd/stateful_diff_command.h"
 
@@ -53,7 +50,6 @@
 
 #include "ardour/amp.h"
 #include "ardour/meter.h"
-#include "ardour/event_type_map.h"
 #include "ardour/pannable.h"
 #include "ardour/panner.h"
 #include "ardour/plugin_insert.h"
@@ -87,7 +83,6 @@
 #include "point_selection.h"
 #include "public_editor.h"
 #include "region_view.h"
-#include "rgb_macros.h"
 #include "selection.h"
 #include "streamview.h"
 #include "ui_config.h"

--- a/gtk2_ardour/route_time_axis.h
+++ b/gtk2_ardour/route_time_axis.h
@@ -260,7 +260,6 @@ protected:
 
 	Gtk::Menu           subplugin_menu;
 	Gtk::Menu*          automation_action_menu;
-	Gtk::MenuItem*      plugins_submenu_item;
 	RouteGroupMenu*     route_group_menu;
 	Gtk::MenuItem*      overlaid_menu_item;
 	Gtk::MenuItem*      stacked_menu_item;

--- a/gtk2_ardour/route_time_axis.h
+++ b/gtk2_ardour/route_time_axis.h
@@ -70,7 +70,6 @@ class RegionSelection;
 class Selectable;
 class AutomationTimeAxisView;
 class AutomationLine;
-class ProcessorAutomationLine;
 class TimeSelection;
 class RouteGroupMenu;
 class ItemCounts;

--- a/gtk2_ardour/route_ui.cc
+++ b/gtk2_ardour/route_ui.cc
@@ -32,7 +32,6 @@
 
 #include <gtkmm/stock.h>
 
-#include "pbd/memento_command.h"
 #include "pbd/controllable.h"
 #include "pbd/enumwriter.h"
 
@@ -61,22 +60,18 @@
 
 #include "gtkmm2ext/gtk_ui.h"
 #include "gtkmm2ext/doi.h"
-#include "gtkmm2ext/gtk_ui.h"
 #include "gtkmm2ext/utils.h"
 
 #include "widgets/ardour_button.h"
 #include "widgets/binding_proxy.h"
 #include "widgets/prompter.h"
 
-#include "ardour_dialog.h"
 #include "ardour_ui.h"
-#include "automation_time_axis.h"
 #include "editor.h"
 #include "group_tabs.h"
 #include "gui_object.h"
 #include "gui_thread.h"
 #include "keyboard.h"
-#include "latency_gui.h"
 #include "mixer_strip.h"
 #include "mixer_ui.h"
 #include "patch_change_widget.h"

--- a/gtk2_ardour/streamview.cc
+++ b/gtk2_ardour/streamview.cc
@@ -31,10 +31,8 @@
 #include <gtkmm2ext/gtk_ui.h>
 #include <gtkmm2ext/utils.h>
 
-#include "ardour/playlist.h"
 #include "ardour/region.h"
 #include "ardour/track.h"
-#include "ardour/session.h"
 
 #include "pbd/compose.h"
 
@@ -48,7 +46,6 @@
 #include "selection.h"
 #include "public_editor.h"
 #include "timers.h"
-#include "rgb_macros.h"
 #include "gui_thread.h"
 #include "ui_config.h"
 #include "utils.h"


### PR DESCRIPTION
I just removed unused includes from each file where `route_time_axis.h` gets included, because I currently work on that file.