### PR TITLE
AutomationLine: make sure control points aren't empty

### DIFF
--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -1035,7 +1035,7 @@ AutomationLine::reset_callback (const Evoral::ControlList& events)
 		delete cp;
 	}
 
-	if (!terminal_points_can_slide) {
+	if (!terminal_points_can_slide && !control_points.empty()) {
 		control_points.back()->set_can_slide(false);
 	}
 


### PR DESCRIPTION
- Otherwise this trigger a C++ assert when built with it
- More reference https://github.com/flathub/org.ardour.Ardour/issues/34

You may not get a crash or assert (if they are turned off), but accessing `back()` if the container `empty()` is true is UB at best. When built with asserts, it triggers an assert that abort.

There is a session file attachd to https://github.com/flathub/org.ardour.Ardour/issues/34

This patch is against `master`, but I have tested the fix (no more assert) on my 6.9 build.

Let me know if I need to do anything else.