### PR TITLE
TempoMap init and superclock_ticks_per_second

### DIFF
--- a/gtk2_ardour/ardour_ui_dialogs.cc
+++ b/gtk2_ardour/ardour_ui_dialogs.cc
@@ -150,7 +150,7 @@ ARDOUR_UI::set_session (Session *s)
 	mini_timeline.set_session (s);
 	time_info_box->set_session (s);
 
-	primary_clock->set_session (s);
+	primary_clock->set_session (s);  // this is first time a new session will need a populated TempoMap (so it can be shown in the primary clock)
 	secondary_clock->set_session (s);
 	big_clock->set_session (s);
 	video_timeline->set_session (s);
@@ -382,6 +382,11 @@ ARDOUR_UI::unload_session (bool hide_stuff, bool force_unload)
 	delete session_to_delete;
 
 	update_title ();
+
+	// TODO: clear singletons and globals (statics) so we are ready to load
+	// a new session - for example the global _superclock_ticks_per_second
+	// that might be set differently by next session, and the global
+	// TempoMap which contain entries that depend on the superclock.
 
 	return 0;
 }

--- a/gtk2_ardour/ardour_ui_session.cc
+++ b/gtk2_ardour/ardour_ui_session.cc
@@ -349,7 +349,7 @@ ARDOUR_UI::load_session (const std::string& path, const std::string& snap_name, 
 
 		Session::get_info_from_path (Glib::build_filename (path, snap_name + statefile_suffix), sr, sf, pv);
 
-		/* this will stop the engine if the SR is different */
+		/* this will stop the engine if the SR is different */ // TODO: also if superclock is different?
 
 		audio_midi_setup->set_desired_sample_rate (sr);
 

--- a/gtk2_ardour/audio_clock.cc
+++ b/gtk2_ardour/audio_clock.cc
@@ -1298,7 +1298,7 @@ AudioClock::set_bbt (timepos_t const & w, timecnt_t const & o, bool /*force*/)
 			pos = bbt_reference_time;
 		}
 
-		TempoMetric m (TempoMap::use()->metric_at (pos));
+		TempoMetric m (TempoMap::use()->metric_at (pos));  // first time we need a populated TempoMap
 
 #ifndef PLATFORM_WINDOWS
 		/* UTF8 1/4 note and 1/8 note ♩ (\u2669) and ♪ (\u266a) are n/a on Windows */

--- a/gtk2_ardour/editor_audio_import.cc
+++ b/gtk2_ardour/editor_audio_import.cc
@@ -296,7 +296,10 @@ Editor::import_smf_tempo_map (Evoral::SMF const & smf, timepos_t const & pos)
 	   values for tempo and meter, then overwrite them.
 	*/
 
-	TempoMap::WritableSharedPtr new_map (new TempoMap (Tempo (120, 4), Meter (4, 4)));
+	TempoMap::WritableSharedPtr new_map (new TempoMap ());
+	new_map->set_initial(Tempo (120, 4), Meter (4, 4));
+	TempoMap::update (new_map);
+
 	Meter last_meter (4.0, 4.0);
 	bool have_initial_meter = false;
 

--- a/libs/temporal/tempo.cc
+++ b/libs/temporal/tempo.cc
@@ -713,8 +713,13 @@ TempoMapPoint::end_float ()
 
 /* TEMPOMAP */
 
-TempoMap::TempoMap (Tempo const & initial_tempo, Meter const & initial_meter)
+void
+TempoMap::set_initial (Tempo const & initial_tempo, Meter const & initial_meter)
 {
+	assert (_tempos.size() == 0);
+	assert (_meters.size() == 0);
+	assert (_points.size() == 0);
+
 	TempoPoint* tp = new TempoPoint (*this, initial_tempo, 0, Beats(), BBT_Time());
 	MeterPoint* mp = new MeterPoint (*this, initial_meter, 0, Beats(), BBT_Time());
 
@@ -3288,7 +3293,7 @@ TempoMap::twist_tempi (TempoPoint* ts, samplepos_t start_sample, samplepos_t end
 void
 TempoMap::init ()
 {
-	WritableSharedPtr new_map (new TempoMap (Tempo (120, 4), Meter (4, 4)));
+	WritableSharedPtr new_map (new TempoMap ());
 	_map_mgr.init (new_map);
 	fetch ();
 }

--- a/libs/temporal/temporal/superclock.h
+++ b/libs/temporal/temporal/superclock.h
@@ -19,6 +19,8 @@
 #ifndef __ardour_superclock_h__
 #define __ardour_superclock_h__
 
+#define DEBUG_EARLY_SCTS_USE
+
 #include <stdint.h>
 
 #include "pbd/integer_division.h"

--- a/libs/temporal/temporal/superclock.h
+++ b/libs/temporal/temporal/superclock.h
@@ -25,6 +25,11 @@
 
 #include "temporal/visibility.h"
 
+#ifdef DEBUG_EARLY_SCTS_USE
+#include <cstdlib>
+#include <csignal>
+#endif
+
 namespace Temporal {
 
 typedef int64_t superclock_t;
@@ -38,10 +43,6 @@ typedef int64_t superclock_t;
 extern bool scts_set;
 
 #ifdef DEBUG_EARLY_SCTS_USE
-
-#include <cstdlib>
-#include <csignal>
-
 static inline superclock_t superclock_ticks_per_second() { if (!scts_set) { raise (SIGUSR2); } return _superclock_ticks_per_second; }
 #else
 static inline superclock_t superclock_ticks_per_second() { return _superclock_ticks_per_second; }

--- a/libs/temporal/temporal/tempo.h
+++ b/libs/temporal/temporal/tempo.h
@@ -691,10 +691,13 @@ class /*LIBTEMPORAL_API*/ TempoMap : public PBD::StatefulDestructible
 	/* and now on with the rest of the show ... */
 
   public:
-	LIBTEMPORAL_API TempoMap (Tempo const& initial_tempo, Meter const& initial_meter);
+	LIBTEMPORAL_API TempoMap () {}
 	LIBTEMPORAL_API TempoMap (TempoMap const&);
 	LIBTEMPORAL_API TempoMap (XMLNode const&, int version);
 	LIBTEMPORAL_API ~TempoMap();
+
+	/* must (and can only) be used after using the empty constructor, and before the map can be used */
+	LIBTEMPORAL_API void set_initial (Tempo const & initial_tempo, Meter const & initial_meter);
 
 	LIBTEMPORAL_API TempoMap& operator= (TempoMap const&);
 


### PR DESCRIPTION
This relates to random comments/questions I made on IRC.
I suggest taking the first changeset now - a slight improvement.
The rest - especially the "big" TempoMap change is mainly a RFC. I think my change shows "something", but most certainly not the right solution.
Diving into code and debugging has given many random thoughts and hypothesises. I have tried to straighten them out, but would like some feedback.

This hack solves my problem with playback of trivial sessions created
with 7.0pre, before https://github.com/Ardour/ardour/commit/a803dd0df87ad75b5449afca2e7617f39fd28f10 changed superclock_ticks_per_second from
508032000 to 56448000. I saw two sides of the problem: the UI would show
1080 bpm (exactly the ratio between the two), and playback would fail
reporting problems with time going backwards.

The global TempoMap is initialized early with Tempo 120. The problem
turned out to be related to how constructing a Tempo uses
superclock_ticks_per_second to compute _superclocks_per_note_type. This
global Tempo survives loading a session that sets a different
superclock_ticks_per_second and invalidates _superclocks_per_note_type.

While the early 7.0pre versions with different
superclock_ticks_per_second are "unsupported", it still expose a real
problem with the reading superclock_ticks_per_second from session files -
that is something that is intended to work.

(BTW: While I see the benefit of using superclock internally, I'm not
convinced of the benefits of using it in the storage format. It seems to
me like it would be cleaner to keep it as samples or beat fractions. The
superclock rate seems like a runtime implementation detail to allow
samples and beats to co-exist.)

Both superclock_ticks_per_second and samplerate are very basic ... with
superclock even more basic than samplerate. Both are in session XML, as
'Session.sample-rate' and 'Session>TempoMap.superclocks-per-second'.
Both are decided when creating a new session, and cannot be changed
later. Conceptually (but pointless, except for testing),
superclock_ticks_per_second could be exposed in the UI when creating
projects.

It seems like it would be nice if set_superclock_ticks_per_second were
invoked pretty much the same place as set_sample_rate. They both control
global variables through superclock.h . But it doesn't seem like there
is a clear boundary where the sample rate is set.

(It would perhaps be better if none of these global values had a default
value - that would make it explicit if a code path doesn't set it. A
default value of 0 would also make it easy to assert if it had been set.)

Taking a step back and going in another direction:

The global TempoMap is initialized early, in Temporal::init . The first
actual use is in AudioEngine::process_callback , introduced in https://github.com/Ardour/ardour/commit/22b50c1716bda71e8f97471e21ebcf6bde8bc57d
to handle tempo map changes synchronously. It doesn't seem like there
currently is a good way to see if TempoMap is initialized at all, and
skip if it isn't. If there was, TempoMap::init could be moved to a point
after reading / defaulting superclock_ticks_per_second ... and before
needing the TempoMap to render BMP in ARDOUR_UI::set_session .

But the ideal place for TempoMap::init when loading sessions is tricky.
TempoMap::set_state has an inherent chicken-and-egg problem: It needs
the TempoMap instance before it can read the right
superclocks-per-second and invoke set_superclock_ticks_per_second so
TempoMap::init can do the right thing, without accessing
superclock_ticks_per_second before it has been set. We can thus not use
TempoMap::init as it was.

Back to the solution chosen and proposed here:

The best solution thus seems to make sure TempoMap::init doesn't create
default values, but allow them to be set later - as defaults, or reading
from a session.

I guess it could work to accept early access to
superclock_ticks_per_second and keep the (incorrect) default entries in
TempoMap, but let session load override them. But overriding doesn't
seem to work. And accessing superclock before it has been set and
creating (unnecessary) Tempo/Meter entries seems unnecessarily
unfortunate and fragile.

The new two-phase creation of TempoMap, with the empty constructor
leaving it in a somewhat invalid state, is unfortunate. It would perhaps
be better to not have to create TempoMap early.

When loading a session, we don't have to populate TempoMap first. But
when creating a new session we have to find the right place to do it.
gtk2_ardour/ardour_ui_session.cc seems too high level, but I haven't
found a good lower level place to do it. The Session itself doesn't seem
to know the difference.