### PR TITLE
Superclock init

### DIFF
--- a/gtk2_ardour/editor_audio_import.cc
+++ b/gtk2_ardour/editor_audio_import.cc
@@ -284,7 +284,7 @@ Editor::import_smf_tempo_map (Evoral::SMF const & smf, timepos_t const & pos)
 		return;
 	}
 
-	/* we have to create this in order to start the update process, but
+	/* we have to create this in order to get a write lock, but
 	   we're going to throw it away by creating our own new map and
 	   populating it. This will go out of scope when we return from this
 	   method.

--- a/libs/ardour/audioengine.cc
+++ b/libs/ardour/audioengine.cc
@@ -198,7 +198,7 @@ AudioEngine::sample_rate_change (pframes_t nframes)
 	}
 
 	SampleRateChanged (nframes); /* EMIT SIGNAL */
-	Temporal::set_sample_rate (nframes);
+	Temporal::set_most_recent_engine_sample_rate (nframes);
 
 #ifdef SILENCE_AFTER_SECONDS
 	_silence_countdown = nframes * SILENCE_AFTER_SECONDS;

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -650,6 +650,8 @@ Session::create (const string& session_template, BusProfile const * bus_profile,
 		}
 
 	} else {
+		set_superclock_ticks_per_second (56448000); /* 2^10 * 3^2 * 5^3 * 7^2 */
+
 		(void) TempoMap::write_copy(); /* we are going to throw away the return value and replace the map entirely */
 		TempoMap::WritableSharedPtr new_map (new TempoMap (Tempo (120, 4), Meter (4, 4)));
 		TempoMap::update (new_map);;

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -1718,7 +1718,7 @@ Session::set_state (const XMLNode& node, int version)
 				if (AudioEngine::instance()->running ()) {
 					error << _("Session: Load aborted due to sample-rate mismatch") << endmsg;
 				} else {
-					error << _("Session: Load aborted since engine if offline") << endmsg;
+					error << _("Session: Load aborted since engine is offline") << endmsg;
 				}
 				ret = -2;
 				goto out;

--- a/libs/ardour/test/testrunner.cc
+++ b/libs/ardour/test/testrunner.cc
@@ -10,6 +10,7 @@
 #include <cppunit/BriefTestProgressListener.h>
 
 #include "pbd/debug.h"
+#include "temporal/tempo.h"
 #include "ardour/ardour.h"
 #include "test_ui.h"
 
@@ -50,6 +51,12 @@ main(int argc, char* argv[])
 	}
 
 	CPPUNIT_ASSERT (ARDOUR::init (true, localedir));
+
+	Temporal::set_superclock_ticks_per_second (56448000); /* 2^10 * 3^2 * 5^3 * 7^2 */
+
+	(void) Temporal::TempoMap::write_copy(); /* we are going to throw away the return value and replace the map entirely */
+	Temporal::TempoMap::WritableSharedPtr new_map (new Temporal::TempoMap (Temporal::Tempo (120, 4), Temporal::Meter (4, 4)));
+	Temporal::TempoMap::update (new_map);;
 
 	TestUI* test_ui = new TestUI();
 

--- a/libs/temporal/superclock.cc
+++ b/libs/temporal/superclock.cc
@@ -25,7 +25,7 @@ Temporal::superclock_t Temporal::_superclock_ticks_per_second = 0;
 int Temporal::most_recent_engine_sample_rate = 48000; /* have to pick something as a default */
 
 void
-Temporal::set_sample_rate (int sr)
+Temporal::set_most_recent_engine_sample_rate (int sr)
 {
 	most_recent_engine_sample_rate = sr;
 }

--- a/libs/temporal/superclock.cc
+++ b/libs/temporal/superclock.cc
@@ -19,12 +19,10 @@
 #include "temporal/superclock.h"
 
 #ifndef COMPILER_MSVC
-Temporal::superclock_t Temporal::_superclock_ticks_per_second = 56448000; /* 2^10 * 3^2 * 5^3 * 7^2 */
+Temporal::superclock_t Temporal::_superclock_ticks_per_second = 0;
 #endif
 
 int Temporal::most_recent_engine_sample_rate = 48000; /* have to pick something as a default */
-
-bool Temporal::scts_set = false;
 
 void
 Temporal::set_sample_rate (int sr)
@@ -36,5 +34,4 @@ void
 Temporal::set_superclock_ticks_per_second (Temporal::superclock_t sc)
 {
 	_superclock_ticks_per_second = sc;
-	scts_set = true;
 }

--- a/libs/temporal/tempo.cc
+++ b/libs/temporal/tempo.cc
@@ -3274,7 +3274,7 @@ TempoMap::twist_tempi (TempoPoint* ts, samplepos_t start_sample, samplepos_t end
 void
 TempoMap::init ()
 {
-	WritableSharedPtr new_map (new TempoMap (Tempo (120, 4), Meter (4, 4)));
+	WritableSharedPtr new_map (new TempoMap ());
 	_map_mgr.init (new_map);
 	fetch ();
 }

--- a/libs/temporal/temporal/superclock.h
+++ b/libs/temporal/temporal/superclock.h
@@ -25,6 +25,11 @@
 
 #include "temporal/visibility.h"
 
+#ifdef DEBUG_EARLY_SCTS_USE
+#include <cstdlib>
+#include <csignal>
+#endif
+
 namespace Temporal {
 
 typedef int64_t superclock_t;
@@ -38,10 +43,6 @@ typedef int64_t superclock_t;
 extern bool scts_set;
 
 #ifdef DEBUG_EARLY_SCTS_USE
-
-#include <cstdlib>
-#include <csignal>
-
 static inline superclock_t superclock_ticks_per_second() { if (!scts_set) { raise (SIGUSR2); } return _superclock_ticks_per_second; }
 #else
 static inline superclock_t superclock_ticks_per_second() { return _superclock_ticks_per_second; }

--- a/libs/temporal/temporal/superclock.h
+++ b/libs/temporal/temporal/superclock.h
@@ -37,13 +37,11 @@ typedef int64_t superclock_t;
 #ifndef COMPILER_MSVC
 	extern superclock_t _superclock_ticks_per_second;
 #else
-	static superclock_t _superclock_ticks_per_second = 56448000; /* 2^10 * 3^2 * 5^3 * 7^2 */
+	static superclock_t _superclock_ticks_per_second = 0;
 #endif
 
-extern bool scts_set;
-
 #ifdef DEBUG_EARLY_SCTS_USE
-static inline superclock_t superclock_ticks_per_second() { if (!scts_set) { raise (SIGUSR2); } return _superclock_ticks_per_second; }
+static inline superclock_t superclock_ticks_per_second() { if (_superclock_ticks_per_second == 0) { raise (SIGUSR2); } return _superclock_ticks_per_second; }
 #else
 static inline superclock_t superclock_ticks_per_second() { return _superclock_ticks_per_second; }
 #endif

--- a/libs/temporal/temporal/superclock.h
+++ b/libs/temporal/temporal/superclock.h
@@ -51,7 +51,7 @@ static inline superclock_t samples_to_superclock (int64_t samples, int sr) { ret
 
 LIBTEMPORAL_API extern int most_recent_engine_sample_rate;
 
-LIBTEMPORAL_API void set_sample_rate (int sr);
+LIBTEMPORAL_API void set_most_recent_engine_sample_rate (int sr);
 LIBTEMPORAL_API void set_superclock_ticks_per_second (superclock_t sc);
 
 }

--- a/libs/temporal/temporal/tempo.h
+++ b/libs/temporal/temporal/tempo.h
@@ -699,6 +699,7 @@ class /*LIBTEMPORAL_API*/ TempoMap : public PBD::StatefulDestructible
 	/* and now on with the rest of the show ... */
 
   public:
+	LIBTEMPORAL_API TempoMap () {}
 	LIBTEMPORAL_API TempoMap (Tempo const& initial_tempo, Meter const& initial_meter);
 	LIBTEMPORAL_API TempoMap (TempoMap const&);
 	LIBTEMPORAL_API TempoMap (XMLNode const&, int version);

--- a/libs/temporal/test/testrunner.cc
+++ b/libs/temporal/test/testrunner.cc
@@ -13,6 +13,7 @@
 #include "pbd/debug.h"
 #include "pbd/pbd.h"
 #include "temporal/types.h"
+#include "temporal/tempo.h"
 
 int
 main(int argc, char* argv[])
@@ -51,9 +52,11 @@ main(int argc, char* argv[])
 	if (!PBD::init ()) return 1;
 	Temporal::init ();
 
-	// TempoMap::SharedPtr tmap = TempoMap::write_copy (); /* get writable copy of current tempo map */
-	// change it
-	// TempoMap::update (tmap); /* update the global tempo map manager */
+	Temporal::set_superclock_ticks_per_second (56448000); /* 2^10 * 3^2 * 5^3 * 7^2 */
+
+	(void) Temporal::TempoMap::write_copy(); /* we are going to throw away the return value and replace the map entirely */
+	Temporal::TempoMap::WritableSharedPtr new_map (new Temporal::TempoMap (Temporal::Tempo (120, 4), Temporal::Meter (4, 4)));
+	Temporal::TempoMap::update (new_map);;
 
 	CppUnit::TestResult testresult;
 


### PR DESCRIPTION
The purpose of this PR is to make some clean-up around superclock, making the code more maintainable. IMO.

It will establish some invariants and a more clean pattern for how superclock and tempomap are initialized, thus mitigating the risc and maintenance cost of these global variables. It makes sure that new sessions never accidentally use default values. The default values will only be used when explicitly requested.

It fixes some problems around DEBUG_EARLY_SCTS_USE, which has the purpose of detecting use of the global _superclock_ticks_per_second variable before it has been set.
1: The code structure had changed, so it wouldn't compile if the check was enabled.
2: Fixing that, it would fail at runtime because the superclock actually was used before being set, thus relying on the global default.

Tempomap is another global variable / singleton. It was initialized before superclock was set, and would use superclock incorrectly. (That caused some bugs that has been fixed.)


Some comments to the changes in this PR:

The default superclock value of 56448000 is no longer defined in 2 places. It is however now also set explicitly in the test runner, which doesn't use the full session initialization code. (But it could perhaps be beneficial to use another superclock value there, to help make sure the variable really still can be changed. It wouldn't be a problem if they came out of sync.)

The scts_set flag is no longer used. Instead, we initialize the superclock to the obviously invalid value 0, and use that to detect if it has been set.

The setter for the global variable most_recent_engine_sample_rate was named set_sample_rate, but is very different from Session::set_sample_rate and AudioEngine::set_sample_rate / AudioBackend::set_sample_rate . It is renamed to make it more clear what it does.

The hardcoded TempoMap defaults of 120/4 are removed from TempoMap::init - it is already set in Session::create, which also is the single point where we will set the superclock for new sessions. Existing sessions are handled differently ... and AFAICS they are also handled correctly. And if not, we will find out and can make an explicit fix. 


One concern remains: What values should be used when loading a session that for some reason doesn't contain tempomap and superclock? I do think it is crucial that this fall-back handling is explicit. My refactorings might create new problems in this area, but they might also make existing problems more clear so they can be fixed.

1. TempoMap is mandatory, handled by TempoMap::set_state. Sessions before 6.0 are handled by set_state_3x, but that code path doesn't set superclock explicitly ... which seems crucial, as the global default changed in March this year.

2. In TempoMap::set_state , 46117303da7 made superclocks-per-second seems optional. I guess it should bail out explicitly if it is missing.

3. In TempoMap::set_state , Tempos and Meters also seem optional, but since the maps are cleared before trying to read, they are essentially mandatory, and it should bail out if they are missing.

Also, slightly related: Session::set_state makes sample-rate optional in session files, but it seems like a crucial synchronization with the audio engine thus is skipped. Are sessions that predates sample-rate (before 2.3 - bd3b9d763b0 in 2008) really still supported? Or should sample-rate be considered mandatory now? 


This is a follow-up to https://github.com/Ardour/ardour/pull/711 trying to bring remaining good parts forward.
See the individual commit messages.