### PR TITLE
Add Roland A-30 binding map for controlling Ardour's Play/Stop

### DIFF
--- a/share/midi_maps/Roland_A-30.map
+++ b/share/midi_maps/Roland_A-30.map
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="Roland A-30">
+
+<!-- Standard Start/Stop commands.  Should work with many more MIDI devices. -->
+
+  <Binding msg="fa" function="transport-roll"/>
+  <Binding msg="fc" function="transport-stop"/>
+
+</ArdourMIDIBindings>


### PR DESCRIPTION
To use it, select
```
Preferences -> Control Surfaces -> Generic MIDI -> MIDI Bindings -> Roland A-30
```
as well as the `Incoming MIDI on` corresponding to your Roland A-30.

It works as expected, however, for some reason, `Incoming MIDI on` sometimes disconnect and I need to manually reconnect.  I have no idea why.