### PR TITLE
Add missing comma to luasession/wscript

### DIFF
--- a/luasession/wscript
+++ b/luasession/wscript
@@ -45,7 +45,7 @@ def build(bld):
     obj.source       = 'luasession.cc'
     obj.target       = 'luasession'
     obj.includes     = ['../libs']
-    obj.use          = ['liblua'
+    obj.use          = ['liblua',
                         'libpbd',
                         'libardour',
                         'libardour_cp',


### PR DESCRIPTION
"Omitting a comma between strings causes implicit concatenation which is confusing in a list."