### PR TITLE
Fix various typos

### DIFF
--- a/gtk2_ardour/editor_rulers.cc
+++ b/gtk2_ardour/editor_rulers.cc
@@ -854,7 +854,7 @@ Editor::set_timecode_ruler_scale (samplepos_t lower, samplepos_t upper)
 		   to set the ruler scale, because the caller has already determined
 		   the width and set lower + upper arguments to this function to match that.
 
-		   But in this case, where the range defined by lower and uppper can vary
+		   But in this case, where the range defined by lower and upper can vary
 		   substantially (basically anything from 24hrs+ to several billion years)
 		   trying to decide which tick marks to show does require us to know
 		   about the available width.
@@ -1652,7 +1652,7 @@ Editor::set_minsec_ruler_scale (samplepos_t lower, samplepos_t upper)
 		   to set the ruler scale, because the caller has already determined
 		   the width and set lower + upper arguments to this function to match that.
 
-		   But in this case, where the range defined by lower and uppper can vary
+		   But in this case, where the range defined by lower and upper can vary
 		   substantially (anything from 24hrs+ to several billion years)
 		   trying to decide which tick marks to show does require us to know
 		   about the available width.

--- a/gtk2_ardour/engine_dialog.cc
+++ b/gtk2_ardour/engine_dialog.cc
@@ -2996,7 +2996,7 @@ EngineControl::check_audio_latency_measurement ()
 
 	if (mtdm->err () > 0.2) {
 		strcat (buf, "\n");
-		strcat (buf, _("Large mesurement deviation. Invalid result."));
+		strcat (buf, _("Large measurement deviation. Invalid result."));
 		solid = false;
 	}
 

--- a/gtk2_ardour/sfdb_ui.cc
+++ b/gtk2_ardour/sfdb_ui.cc
@@ -1116,7 +1116,7 @@ SoundFileBrowser::freesound_get_audio_file(Gtk::TreeIter iter)
 		DEBUG_TRACE(PBD::DEBUG::Freesound, string_compose("downloading %1 (id %2) from %3...\n", filename, id, uri));
 		(*iter)[freesound_list_columns.downloading] = true;
 		// if we don't already have a token, fetchAudioFile() will get
-		// one: otherwse it'll return the one we already gave it.
+		// one: otherwise it'll return the one we already gave it.
 		if (!mootcher->fetchAudioFile(filename, id, uri, this, freesound_token)) {
 			// download cancelled or failed
 			(*iter)[freesound_list_columns.downloading] = false;

--- a/libs/gtkmm2ext/bindings.cc
+++ b/libs/gtkmm2ext/bindings.cc
@@ -65,7 +65,7 @@ MouseButton::MouseButton (uint32_t state, uint32_t keycode)
 {
 	uint32_t ignore = ~Keyboard::RelevantModifierKeyMask;
 
-	/* this is a slightly wierd test that relies on
+	/* this is a slightly weird test that relies on
 	 * gdk_keyval_is_{upper,lower}() returning true for keys that have no
 	 * case-sensitivity. This covers mostly non-alphanumeric keys.
 	 */

--- a/libs/gtkmm2ext/utils.cc
+++ b/libs/gtkmm2ext/utils.cc
@@ -398,7 +398,7 @@ _position_menu_anchored (int& x, int& y, bool& push_in,
 	 *  e) if there is no selected menu item, align the menu above the button or
 	 *     below the button, depending on where there is more space.
 	 * For the d) and e) cases, the menu contents will be aligned as told, but
-	 * the menu itself will be bigger than that to accomodate the menu items
+	 * the menu itself will be bigger than that to accommodate the menu items
 	 * that are scrolled out of view, thanks to |push_in = true|.
 	 */
 

--- a/libs/libltc/ltc/ltc.h
+++ b/libs/libltc/ltc/ltc.h
@@ -671,7 +671,7 @@ int ltc_encoder_set_bufsize(LTCEncoder *e, double sample_rate, double fps);
 /**
  * Set the volume of the generated LTC signal
  *
- * typically LTC is sent at 0dBu ; in EBU callibrated systems that
+ * typically LTC is sent at 0dBu ; in EBU calibrated systems that
  * corresponds to -18dBFS. - by default libltc creates -3dBFS
  *
  * since libltc generated 8bit audio-data, the minimum dBFS

--- a/libs/panners/1in2out/panner_1in2out.cc
+++ b/libs/panners/1in2out/panner_1in2out.cc
@@ -350,7 +350,7 @@ Panner1in2out::value_as_string (boost::shared_ptr<const AutomationControl> ac) c
 			 * This is expressed as a pair of percentage values that ranges from (100,0)
 			 * (hard left) through (50,50) (hard center) to (0,100) (hard right).
 			 *
-			 * This is pretty wierd, but its the way audio engineers expect it. Just remember that
+			 * This is pretty weird, but its the way audio engineers expect it. Just remember that
 			 * the center of the USA isn't Kansas, its (50LA, 50NY) and it will all make sense.
 			 *
 			 * This is designed to be as narrow as possible. Dedicated

--- a/libs/panners/2in2out/panner_2in2out.cc
+++ b/libs/panners/2in2out/panner_2in2out.cc
@@ -495,7 +495,7 @@ Panner2in2out::value_as_string (boost::shared_ptr<const AutomationControl> ac) c
 			 * This is expressed as a pair of percentage values that ranges from (100,0)
 			 * (hard left) through (50,50) (hard center) to (0,100) (hard right).
 			 *
-			 * This is pretty wierd, but its the way audio engineers expect it. Just remember that
+			 * This is pretty weird, but its the way audio engineers expect it. Just remember that
 			 * the center of the USA isn't Kansas, its (50LA, 50NY) and it will all make sense.
 			 *
 			 * This is designed to be as narrow as possible. Dedicated

--- a/libs/panners/stereobalance/panner_balance.cc
+++ b/libs/panners/stereobalance/panner_balance.cc
@@ -283,7 +283,7 @@ Pannerbalance::value_as_string (boost::shared_ptr<const AutomationControl> ac) c
 			 * This is expressed as a pair of percentage values that ranges from (100,0)
 			 * (hard left) through (50,50) (hard center) to (0,100) (hard right).
 			 *
-			 * This is pretty wierd, but its the way audio engineers expect it. Just remember that
+			 * This is pretty weird, but its the way audio engineers expect it. Just remember that
 			 * the center of the USA isn't Kansas, its (50LA, 50NY) and it will all make sense.
 			 *
 			 * This is designed to be as narrow as possible. Dedicated

--- a/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
+++ b/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
@@ -759,7 +759,7 @@ work (LV2_Handle                  instance,
 		fluid_synth_all_notes_off (self->synth, -1);
 		fluid_synth_all_sounds_off (self->synth, -1);
 		self->panic = false;
-		// boostrap synth engine.
+		// bootstrap synth engine.
 		float l[1024];
 		float r[1024];
 		fluid_synth_write_float (self->synth, 1024, l, 0, 1, r, 0, 1);

--- a/libs/surfaces/cc121/cc121.cc
+++ b/libs/surfaces/cc121/cc121.cc
@@ -698,7 +698,7 @@ CC121::connect_session_signals()
 bool
 CC121::midi_input_handler (Glib::IOCondition ioc, boost::shared_ptr<ARDOUR::AsyncMIDIPort> port)
 {
-	DEBUG_TRACE (DEBUG::CC121, string_compose ("something happend on  %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
+	DEBUG_TRACE (DEBUG::CC121, string_compose ("something happened on  %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
 
 	if (ioc & ~IO_IN) {
 		return false;

--- a/libs/surfaces/faderport/faderport.cc
+++ b/libs/surfaces/faderport/faderport.cc
@@ -739,7 +739,7 @@ FaderPort::midi_input_handler (Glib::IOCondition ioc, boost::weak_ptr<ARDOUR::As
 		return false;
 	}
 
-	DEBUG_TRACE (DEBUG::FaderPort, string_compose ("something happend on  %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
+	DEBUG_TRACE (DEBUG::FaderPort, string_compose ("something happened on  %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
 
 	if (ioc & ~IO_IN) {
 		return false;

--- a/libs/surfaces/faderport8/faderport8.cc
+++ b/libs/surfaces/faderport8/faderport8.cc
@@ -513,7 +513,7 @@ FaderPort8::midi_input_handler (Glib::IOCondition ioc, boost::weak_ptr<ARDOUR::A
 	}
 
 #ifdef VERBOSE_DEBUG
-	DEBUG_TRACE (DEBUG::FaderPort8, string_compose ("something happend on %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
+	DEBUG_TRACE (DEBUG::FaderPort8, string_compose ("something happened on %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
 #endif
 
 	if (ioc & ~IO_IN) {

--- a/libs/surfaces/frontier/kernel_drivers/tranzport.c
+++ b/libs/surfaces/frontier/kernel_drivers/tranzport.c
@@ -880,7 +880,7 @@ static int usb_tranzport_probe(struct usb_interface *intf, const struct usb_devi
 	int true_size;
 	int retval = -ENOMEM;
 
-	/* allocate memory for our device state and intialize it */
+	/* allocate memory for our device state and initialize it */
 
 	dev = kzalloc(sizeof(*dev), GFP_KERNEL);
 	if (dev == NULL) {

--- a/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
+++ b/libs/surfaces/generic_midi/generic_midi_control_protocol.cc
@@ -1647,7 +1647,7 @@ GenericMidiControlProtocol::midi_input_handler (Glib::IOCondition ioc, boost::we
 		return false;
 	}
 
-	DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("something happend on  %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
+	DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("something happened on  %1\n", boost::shared_ptr<MIDI::Port>(port)->name()));
 
 	if (ioc & ~IO_IN) {
 		return false;

--- a/libs/surfaces/mackie/mackie_control_protocol.cc
+++ b/libs/surfaces/mackie/mackie_control_protocol.cc
@@ -1723,7 +1723,7 @@ MackieControlProtocol::midi_input_handler (IOCondition ioc, MIDI::Port* port)
 
 	if (ioc & IO_IN) {
 
-		// DEBUG_TRACE (DEBUG::MackieControl, string_compose ("something happend on  %1\n", port->name()));
+		// DEBUG_TRACE (DEBUG::MackieControl, string_compose ("something happened on  %1\n", port->name()));
 
 		/* Devices using regular JACK MIDI ports will need to have
 		   the x-thread FIFO drained to avoid burning endless CPU.

--- a/libs/surfaces/maschine2/maschine2.cc
+++ b/libs/surfaces/maschine2/maschine2.cc
@@ -224,12 +224,12 @@ Maschine2::start ()
 		case Mikro:
 			_hw = new Maschine2Mikro ();
 			_ctrl = new M2MapMikro ();
-			info << _("Maschine2 Mikro control surface intialized");
+			info << _("Maschine2 Mikro control surface initialized");
 			break;
 		case Maschine:
 			_hw = new Maschine2Mk2 ();
 			_ctrl = new M2MapMk2 ();
-			info << _("Maschine2 control surface intialized");
+			info << _("Maschine2 control surface initialized");
 			break;
 		case Studio:
 			error << _("Maschine2 Studio is not yet supported");

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -60,7 +60,7 @@ class Route;
 }
 
 /* this is mostly a placeholder because I suspect that at some
-   point we will want to add more members to accomodate
+   point we will want to add more members to accommodate
    certain types of requests to the OSC UI
 */
 

--- a/libs/surfaces/push2/knob.cc
+++ b/libs/surfaces/push2/knob.cc
@@ -277,7 +277,7 @@ Push2Knob::set_pan_azimuth_text (double pos)
 	   This is expressed as a pair of percentage values that ranges from (100,0)
 	   (hard left) through (50,50) (hard center) to (0,100) (hard right).
 
-	   This is pretty wierd, but its the way audio engineers expect it. Just remember that
+	   This is pretty weird, but its the way audio engineers expect it. Just remember that
 	   the center of the USA isn't Kansas, its (50LA, 50NY) and it will all make sense.
 	*/
 

--- a/libs/surfaces/push2/push2.cc
+++ b/libs/surfaces/push2/push2.cc
@@ -552,7 +552,7 @@ Push2::midi_input_handler (IOCondition ioc, MIDI::Port* port)
 
 	if (ioc & IO_IN) {
 
-		DEBUG_TRACE (DEBUG::Push2, string_compose ("something happend on  %1\n", port->name()));
+		DEBUG_TRACE (DEBUG::Push2, string_compose ("something happened on  %1\n", port->name()));
 
 		AsyncMIDIPort* asp = dynamic_cast<AsyncMIDIPort*>(port);
 		if (asp) {

--- a/libs/surfaces/us2400/us2400_control_protocol.cc
+++ b/libs/surfaces/us2400/us2400_control_protocol.cc
@@ -1339,7 +1339,7 @@ US2400Protocol::midi_input_handler (IOCondition ioc, MIDI::Port* port)
 
 	if (ioc & IO_IN) {
 
-		// DEBUG_TRACE (DEBUG::US2400, string_compose ("something happend on  %1\n", port->name()));
+		// DEBUG_TRACE (DEBUG::US2400, string_compose ("something happened on  %1\n", port->name()));
 
 		/* Devices using regular JACK MIDI ports will need to have
 		   the x-thread FIFO drained to avoid burning endless CPU.

--- a/libs/temporal/tempo.cc
+++ b/libs/temporal/tempo.cc
@@ -2317,7 +2317,7 @@ TempoMap::bbt_walk (BBT_Time const & bbt, BBT_Offset const & o) const
 		}
 	}
 
-	/* may have found tempo and/or meter precisely at the tiem given */
+	/* may have found tempo and/or meter precisely at the time given */
 
 	if (t != _tempos.end() && t->bbt() == bbt) {
 		prev_t = t;

--- a/libs/temporal/temporal/timeline.h
+++ b/libs/temporal/temporal/timeline.h
@@ -108,7 +108,7 @@ class LIBTEMPORAL_API timepos_t : public int62_t  {
 	timepos_t operator+(timecnt_t const & d) const;
 	timepos_t operator+(timepos_t const & d) const { if (is_beats() == d.is_beats()) return timepos_t (is_beats(), val() + d.val()); return expensive_add (d); }
 
-	/* donn't provide operator+(samplepos_t) or operator+(superclock_t)
+	/* don't provide operator+(samplepos_t) or operator+(superclock_t)
 	 * because the compiler can't disambiguate them and neither can we.
 	 * to add such types, create a timepo_t and then add that.
 	 */
@@ -228,7 +228,7 @@ class LIBTEMPORAL_API timepos_t : public int62_t  {
 
 	/* these can only be called after verifying that the time domain does
 	 * not match the relevant one i.e. call _beats() to get a Beats value
-	 * when this is using the audio time doamin
+	 * when this is using the audio time domain
 	 */
 
 	/* these three methods are to be called ONLY when we have already that

--- a/libs/widgets/pane.cc
+++ b/libs/widgets/pane.cc
@@ -221,7 +221,7 @@ Pane::on_size_allocate (Gtk::Allocation& alloc)
 	reallocate (alloc);
 	Container::on_size_allocate (alloc);
 
-	/* minumum pane size constraints */
+	/* minimum pane size constraints */
 	Dividers::size_type div = 0;
 	for (Dividers::const_iterator d = dividers.begin(); d != dividers.end(); ++d, ++div) {
 		// XXX skip dividers that were just hidden in reallocate()


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./.git,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch  -L ba,buss,busses,discreet,doubleclick,hsi,ontop,ro,scrollin,seh,siz,sord,sur,te,trough,ue`