### PR TITLE
Fix typos

### DIFF
--- a/gtk2_ardour/cuebox_ui.cc
+++ b/gtk2_ardour/cuebox_ui.cc
@@ -139,7 +139,7 @@ CueEntry::_size_allocate (ArdourCanvas::Rect const& alloc)
 	name_button->set_center ( Duple(height/2, height/2) );
 	name_button->set_radius ( (height/2)- 1*scale );
 
-	/* have to do this in the size-allocate if we want to dynmaically respond to scale-changes */
+	/* have to do this in the size-allocate if we want to dynamically respond to scale-changes */
 	jump_text->set_font_description (UIConfiguration::instance().get_NormalFont());
 	jump_text->set_alignment (Pango::ALIGN_CENTER);
 

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -1999,7 +1999,7 @@ private:
 	Glib::RefPtr<Gtk::RadioAction> draw_velocity_action (int);
 	Glib::RefPtr<Gtk::RadioAction> draw_channel_action (int);
 
-	//zoom focus meu stuff
+	//zoom focus menu stuff
 	ArdourWidgets::ArdourDropdown	zoom_focus_selector;
 	void zoom_focus_selection_done (Editing::ZoomFocus);
 	void build_zoom_focus_menu ();

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -461,7 +461,7 @@ def configure(conf):
     if sys.platform == 'darwin':
         if conf.env['build_target'] in ['bigsur', 'monterey']:
             # we cannot execute test code when x-compiling ARM on Intel,
-            # besides, NSWindowWillStartLiveResizeNotification is definitly available
+            # besides, NSWindowWillStartLiveResizeNotification is definitely available
             conf.define('HAVE_COCOA_LIVE_RESIZING', 1)
         else:
             conf.check(

--- a/libs/audiographer/private/gdither/gdither.cc
+++ b/libs/audiographer/private/gdither/gdither.cc
@@ -396,7 +396,7 @@ void gdither_runf(GDither s, uint32_t channel, uint32_t length,
         return;
     }
 
-    /* some common case handling code - looks a bit wierd, but it allows
+    /* some common case handling code - looks a bit weird, but it allows
      * the compiler to optimise out the branches in the inner loop */
     if (s->bit_depth == 8 && s->dither_depth == 8) {
 	switch (s->type) {

--- a/libs/pbd/xml++.cc
+++ b/libs/pbd/xml++.cc
@@ -103,12 +103,12 @@ XMLTree::read_internal(bool validate)
 		_doc = xmlCtxtReadFile(ctxt, _filename.c_str(), NULL, XML_PARSE_HUGE);
 	}
 
-	/* check if parsing suceeded */
+	/* check if parsing succeeded */
 	if (_doc == NULL) {
 		xmlFreeParserCtxt(ctxt);
 		return false;
 	} else {
-		/* check if validation suceeded */
+		/* check if validation succeeded */
 		if (validate && ctxt->valid == 0) {
 			xmlFreeParserCtxt(ctxt);
 			throw XMLException("Failed to validate document " + _filename);

--- a/libs/vamp-pyin/MonoNoteParameters.h
+++ b/libs/vamp-pyin/MonoNoteParameters.h
@@ -31,7 +31,7 @@ public:
     size_t nPPS; // number of pitches per semitone
     size_t nS; // number of semitones
     size_t nSPP; // number of states per pitch
-    size_t n; // number of states (will be calcualted from other parameters)
+    size_t n; // number of states (will be calculated from other parameters)
 
     // initial state probabilities
     vector<double> initPi;

--- a/libs/vamp-pyin/MonoPitch.cpp
+++ b/libs/vamp-pyin/MonoPitch.cpp
@@ -58,7 +58,7 @@ MonoPitch::process(const vector<vector<pair<double, double> > > pitchProb)
         if (hmmFreq > 0)
         {
             // This was a Yin estimate, so try to get original pitch estimate back
-            // ... a bit hacky, since we could have direclty saved the frequency
+            // ... a bit hacky, since we could have directly saved the frequency
             // that was assigned to the HMM bin in hmm.calculateObsProb -- but would
             // have had to rethink the interface of that method.
             for (size_t iPitch = 0; iPitch < pitchProb[iFrame].size(); ++iPitch)


### PR DESCRIPTION
Found via `codespell -q 3 -S *.po,./.git,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch  -L acount,ba,buss,busses,discreet,doubleclick,hsi,ontop,retrn,ro,scrollin,seh,siz,sord,sur,te,trough,ue`