### PR TITLE
Automation line fixes

### DIFF
--- a/libs/canvas/poly_line.cc
+++ b/libs/canvas/poly_line.cc
@@ -153,6 +153,9 @@ PolyLine::covers (Duple const& point) const
 	Points::size_type i;
 	Points::size_type j;
 
+	double squared_threshold = _threshold + _outline_width;
+	squared_threshold *= squared_threshold;
+
 	/* repeat for each line segment */
 
 	const Rect visible (window_to_item (_canvas->visible_area ()));
@@ -180,7 +183,7 @@ PolyLine::covers (Duple const& point) const
 			continue;
 		}
 
-		if (d < _threshold + _outline_width) {
+		if (d < squared_threshold) {
 			return true;
 		}
 	}


### PR DESCRIPTION
The goal of this PR is to fix a couple of issues related to editing of automation lines:
- a bug preventing dragging some automation lines
- a usuability issue making dragging of automation lines hard - apparently harder than intended

One question to the existing code remains: Why do we need polyline clamping to upper bound but not to lower bound?