### PR TITLE
When exporting with .cue file, use latin1 for filename as well

### DIFF
--- a/libs/ardour/export_handler.cc
+++ b/libs/ardour/export_handler.cc
@@ -715,7 +715,7 @@ ExportHandler::write_cue_header (CDMarkerStatus & status)
 		We try to use these file types whenever appropriate and
 		default to our own names otherwise.
 	*/
-	status.out << "FILE \"" << Glib::path_get_basename(status.filename) << "\" ";
+	status.out << "FILE " << cue_escape_cdtext (Glib::path_get_basename(status.filename)) << " ";
 	if (!status.format->format_name().compare ("WAV")  || !status.format->format_name().compare ("BWF")) {
 		status.out  << "WAVE";
 	} else if (status.format->format_id() == ExportFormatBase::F_RAW &&


### PR DESCRIPTION
Before, the .cue file could end up with a mix of latin1 and utf-8 encodings. Utf-8 works better for many things, but that doesn't matter when the .cue file has to be in latin-1.