### PR TITLE
Nice labels for export analysis spectrogram

### DIFF
--- a/gtk2_ardour/export_analysis_graphs.cc
+++ b/gtk2_ardour/export_analysis_graphs.cc
@@ -496,6 +496,7 @@ ArdourGraphs::time_axis (Glib::RefPtr<Pango::Context> pctx, int width, int m_l, 
 
 	for (int i = 0; i <= n_labels; ++i) {
 		const float fract  = (float)i / n_labels;
+		const int label_pos = width * fract;
 		const float xalign = (i == n_labels) ? 1.f : (i == 0) ? 0 : .5f;
 
 		char buf[16];
@@ -503,15 +504,15 @@ ArdourGraphs::time_axis (Glib::RefPtr<Pango::Context> pctx, int width, int m_l, 
 
 		layout->set_text (&buf[1]);
 		layout->get_pixel_size (w, h);
-		cr->move_to (rint (m_l + width * fract - w * xalign), rint (.5 * (height - h)));
+		cr->move_to (rint (m_l + label_pos - w * xalign), rint (.5 * (height - h)));
 		cr->set_source_rgba (.9, .9, .9, 1.0);
 		layout->show_in_cairo_context (cr);
 
 		cr->set_source_rgba (.7, .7, .7, 1.0);
-		cr->move_to (rint (m_l + width * fract) - .5, 0);
-		cr->line_to (rint (m_l + width * fract) - .5, ceil  (height * .15));
-		cr->move_to (rint (m_l + width * fract) - .5, floor (height * .85));
-		cr->line_to (rint (m_l + width * fract) - .5, height);
+		cr->move_to (rint (m_l + label_pos) - .5, 0);
+		cr->line_to (rint (m_l + label_pos) - .5, ceil  (height * .15));
+		cr->move_to (rint (m_l + label_pos) - .5, floor (height * .85));
+		cr->line_to (rint (m_l + label_pos) - .5, height);
 		cr->stroke ();
 	}
 

--- a/gtk2_ardour/export_analysis_graphs.cc
+++ b/gtk2_ardour/export_analysis_graphs.cc
@@ -497,14 +497,14 @@ ArdourGraphs::time_axis (Glib::RefPtr<Pango::Context> pctx, int width, int m_l, 
 	for (int i = 0; i <= n_labels; ++i) {
 		const float fract  = (float)i / n_labels;
 		const int label_pos = width * fract;
-		const float xalign = (i == n_labels) ? 1.f : (i == 0) ? 0 : .5f;
 
 		char buf[16];
 		AudioClock::print_minsec (start + length * fract, buf, sizeof (buf), sample_rate, 1);
 
 		layout->set_text (&buf[1]);
 		layout->get_pixel_size (w, h);
-		cr->move_to (rint (m_l + label_pos - w * xalign), rint (.5 * (height - h)));
+		cr->move_to (rint (m_l + std::min(std::max(0, label_pos - w / 2), width - w)),
+			rint (.5 * (height - h)));
 		cr->set_source_rgba (.9, .9, .9, 1.0);
 		layout->show_in_cairo_context (cr);
 


### PR DESCRIPTION
The goal of this PR is to make the time labels on the export analysis spectrogram use nice round 1/2/5 units so it is easier to interpolate the location of events found by inspection or listening.

Before, the X-axis labels would be placed in nice even positions, but
with whatever odd time corresponded to that. That made it harder than
necessary to read the graph and approximate when things happened.

Instead, round the interval down to nearest power of ten ... and if
suitable, scale that up with a factor of 2 or 5. That will (with the
necessary handling of how seconds/minutes/hours relate) make sure that
the time labels are nice with a minimal amount of non-zero digits. That
makes it easy to do math and interpolate when reading the graph.

After a couple of refactorings, the actual change is simple.