### PR TITLE
Fixes around export, ending up with libsndfile MP3 support

### DIFF
--- a/gtk2_ardour/export_format_dialog.cc
+++ b/gtk2_ardour/export_format_dialog.cc
@@ -1113,6 +1113,7 @@ ExportFormatDialog::change_encoding_options (ExportFormatPtr ptr)
 	boost::shared_ptr<ARDOUR::ExportFormatOggVorbis> ogg_ptr;
 	boost::shared_ptr<ARDOUR::ExportFormatFLAC>      flac_ptr;
 	boost::shared_ptr<ARDOUR::ExportFormatBWF>       bwf_ptr;
+	boost::shared_ptr<ARDOUR::ExportFormatMPEG>      mpeg_ptr;
 	boost::shared_ptr<ARDOUR::ExportFormatFFMPEG>    ffmpeg_ptr;
 
 	if ((linear_ptr = boost::dynamic_pointer_cast<ExportFormatLinear> (ptr))) {
@@ -1123,6 +1124,8 @@ ExportFormatDialog::change_encoding_options (ExportFormatPtr ptr)
 		show_flac_enconding_options (flac_ptr);
 	} else if ((bwf_ptr = boost::dynamic_pointer_cast<ExportFormatBWF> (ptr))) {
 		show_bwf_enconding_options (bwf_ptr);
+	} else if ((mpeg_ptr = boost::dynamic_pointer_cast<ExportFormatMPEG> (ptr))) {
+		show_mpeg_enconding_options (mpeg_ptr);
 	} else if ((ffmpeg_ptr = boost::dynamic_pointer_cast<ExportFormatFFMPEG> (ptr))) {
 		show_ffmpeg_enconding_options (ffmpeg_ptr);
 	} else {
@@ -1201,6 +1204,17 @@ ExportFormatDialog::show_bwf_enconding_options (boost::shared_ptr<ARDOUR::Export
 	encoding_options_table.attach (dither_type_view, 1, 2, 1, 2);
 
 	fill_sample_format_lists (boost::dynamic_pointer_cast<HasSampleFormat> (ptr));
+
+	show_all_children ();
+}
+
+void
+ExportFormatDialog::show_mpeg_enconding_options (boost::shared_ptr<ARDOUR::ExportFormatMPEG> ptr)
+{
+	encoding_options_label.set_label (_("Variable bit rate quality"));
+	encoding_options_table.resize (1, 1);
+	encoding_options_table.attach (codec_quality_combo, 0, 1, 0, 1);
+	fill_codec_quality_lists (ptr);
 
 	show_all_children ();
 }

--- a/gtk2_ardour/export_format_dialog.h
+++ b/gtk2_ardour/export_format_dialog.h
@@ -168,6 +168,7 @@ private:
 	void show_ogg_enconding_options (boost::shared_ptr<ARDOUR::ExportFormatOggVorbis> ptr);
 	void show_flac_enconding_options (boost::shared_ptr<ARDOUR::ExportFormatFLAC> ptr);
 	void show_bwf_enconding_options (boost::shared_ptr<ARDOUR::ExportFormatBWF> ptr);
+	void show_mpeg_enconding_options (boost::shared_ptr<ARDOUR::ExportFormatMPEG> ptr);
 	void show_ffmpeg_enconding_options (boost::shared_ptr<ARDOUR::ExportFormatFFMPEG> ptr);
 
 	void fill_sample_format_lists (boost::shared_ptr<ARDOUR::HasSampleFormat> ptr);

--- a/libs/ardour/ardour/export_format_base.h
+++ b/libs/ardour/ardour/export_format_base.h
@@ -59,6 +59,7 @@ class LIBARDOUR_API ExportFormatBase {
 		F_RAW = SF_FORMAT_RAW,
 		F_FLAC = SF_FORMAT_FLAC,
 		F_Ogg = SF_FORMAT_OGG,
+		F_MPEG = 0x230000,  /* hardcode SF_FORMAT_MPEG from libsndfile 1.1.0+ */
 		F_FFMPEG = 0xF10000
 	};
 
@@ -78,7 +79,8 @@ class LIBARDOUR_API ExportFormatBase {
 		SF_U8 = SF_FORMAT_PCM_U8,
 		SF_Float = SF_FORMAT_FLOAT,
 		SF_Double = SF_FORMAT_DOUBLE,
-		SF_Vorbis = SF_FORMAT_VORBIS
+		SF_Vorbis = SF_FORMAT_VORBIS,
+		SF_MPEG_LAYER_III = 0x0082  /* SF_FORMAT_MPEG_LAYER_III */
 	};
 
 	enum DitherType {

--- a/libs/ardour/ardour/export_formats.h
+++ b/libs/ardour/ardour/export_formats.h
@@ -355,6 +355,32 @@ public:
 	}
 };
 
+class LIBARDOUR_API ExportFormatMPEG : public ExportFormat, public HasSampleFormat, public HasCodecQuality
+{
+public:
+	ExportFormatMPEG (std::string const& name, std::string const& ext);
+	~ExportFormatMPEG (){};
+
+	bool set_compatibility_state (ExportFormatCompatibility const& compatibility);
+
+	Type get_type () const
+	{
+		return T_Sndfile;
+	}
+	SampleFormat default_sample_format () const
+	{
+		return SF_MPEG_LAYER_III;
+	}
+	int default_codec_quality () const
+	{
+		return 40;
+	}
+	virtual bool supports_tagging () const
+	{
+		return true;
+	}
+};
+
 class LIBARDOUR_API ExportFormatFFMPEG : public ExportFormat, public HasCodecQuality
 {
 public:

--- a/libs/ardour/enums.cc
+++ b/libs/ardour/enums.cc
@@ -634,6 +634,7 @@ setup_enum_writer ()
 	REGISTER_CLASS_ENUM (ExportFormatBase, F_Ogg);
 	REGISTER_CLASS_ENUM (ExportFormatBase, F_CAF);
 	REGISTER_CLASS_ENUM (ExportFormatBase, F_FFMPEG);
+	REGISTER_CLASS_ENUM (ExportFormatBase, F_MPEG);
 	REGISTER (_ExportFormatBase_FormatId);
 
 	REGISTER_CLASS_ENUM (ExportFormatBase, E_FileDefault);
@@ -651,6 +652,7 @@ setup_enum_writer ()
 	REGISTER_CLASS_ENUM (ExportFormatBase, SF_Float);
 	REGISTER_CLASS_ENUM (ExportFormatBase, SF_Double);
 	REGISTER_CLASS_ENUM (ExportFormatBase, SF_Vorbis);
+	REGISTER_CLASS_ENUM (ExportFormatBase, SF_MPEG_LAYER_III);
 	REGISTER (_ExportFormatBase_SampleFormat);
 
 	REGISTER_CLASS_ENUM (ExportFormatBase, D_None);

--- a/libs/ardour/export_format_manager.cc
+++ b/libs/ardour/export_format_manager.cc
@@ -218,6 +218,11 @@ ExportFormatManager::init_formats ()
 	if (ArdourVideoToolPaths::transcoder_exe (unused, unused)) {
 		f_ptr.reset (new ExportFormatFFMPEG ("MP3", "mp3"));
 		add_format (f_ptr);
+	} else {
+		try {
+			f_ptr.reset (new ExportFormatMPEG ("MP3", "mp3"));
+			add_format (f_ptr);
+		} catch (ExportFormatIncompatible & e) {}
 	}
 }
 

--- a/libs/ardour/export_formats.cc
+++ b/libs/ardour/export_formats.cc
@@ -382,6 +382,44 @@ ExportFormatBWF::set_compatibility_state (ExportFormatCompatibility const & comp
 }
 
 
+/*** MPEG / MP3 ***/
+
+ExportFormatMPEG::ExportFormatMPEG (std::string const& name, std::string const& ext) :
+  HasSampleFormat (sample_formats)
+{
+	SF_INFO sf_info;
+	sf_info.channels = 2;
+	sf_info.samplerate = SR_44_1;
+	sf_info.format = F_MPEG | SF_MPEG_LAYER_III;
+	if (sf_format_check (&sf_info) != SF_TRUE) {
+		throw ExportFormatIncompatible();
+	}
+
+	set_name (name);
+	set_format_id (F_MPEG);
+	add_sample_format (SF_MPEG_LAYER_III);
+
+	add_endianness (E_FileDefault);
+
+	// libsndfile doesn't expose direct quality control - use these coarse approximations
+	add_codec_quality ("Low (0%)",            0);
+	add_codec_quality ("Default (40%)",      40);
+	add_codec_quality ("High (60%)",         60);
+	add_codec_quality ("Very High (100%)",  100);
+
+	set_extension (ext);
+	set_quality (Q_LossyCompression);
+}
+
+bool
+ExportFormatMPEG::set_compatibility_state (ExportFormatCompatibility const & compatibility)
+{
+	bool compatible = compatibility.has_format (F_MPEG);
+	set_compatible (compatible);
+	return compatible;
+}
+
+
 /*** FFMPEG Pipe ***/
 
 ExportFormatFFMPEG::ExportFormatFFMPEG (std::string const& name, std::string const& ext)

--- a/libs/ardour/export_formats.cc
+++ b/libs/ardour/export_formats.cc
@@ -179,6 +179,8 @@ HasSampleFormat::get_sample_format_name (ExportFormatBase::SampleFormat format)
 		return _("8-bit unsigned");
 	  case ExportFormatBase::SF_Vorbis:
 		return _("Vorbis sample format");
+	  case ExportFormatBase::SF_MPEG_LAYER_III:
+		return _("MPEG-2 Audio Layer III");
 	  case ExportFormatBase::SF_None:
 		return _("No sample format");
 	}

--- a/libs/ardour/export_graph_builder.cc
+++ b/libs/ardour/export_graph_builder.cc
@@ -344,7 +344,8 @@ ExportGraphBuilder::Encoder::init_writer (boost::shared_ptr<AudioGrapher::Sndfil
 
 	writer.reset (new AudioGrapher::SndfileWriter<T> (writer_filename, format, channels, config.format->sample_rate(), config.broadcast_info));
 	writer->FileWritten.connect_same_thread (copy_files_connection, boost::bind (&ExportGraphBuilder::Encoder::copy_files, this, _1));
-	if ((format & SF_FORMAT_SUBMASK) == ExportFormatBase::SF_Vorbis) {
+	if ((format & SF_FORMAT_SUBMASK) == ExportFormatBase::SF_Vorbis ||
+	    (format & SF_FORMAT_TYPEMASK) == ExportFormatBase::F_MPEG) {
 		/* libsndfile uses range 0..1 (worst.. best) for
 		 * SFC_SET_VBR_ENCODING_QUALITY and maps
 		 * SFC_SET_COMPRESSION_LEVEL = 1.0 - VBR_ENCODING_QUALITY

--- a/libs/ardour/sndfile_helpers.cc
+++ b/libs/ardour/sndfile_helpers.cc
@@ -20,6 +20,7 @@
 
 #include <sndfile.h>
 #include "ardour/sndfile_helpers.h"
+#include "ardour/export_format_base.h"
 
 using namespace std;
 
@@ -40,6 +41,7 @@ sndfile_data_width (int format)
 		return 32;
 	case SF_FORMAT_FLOAT:
 	case SF_FORMAT_DOUBLE:
+	case ARDOUR::ExportFormatBase::SF_MPEG_LAYER_III:
 		return 1; /* ridiculous but used as a magic value */
 	default:
 		// we don't handle anything else within ardour


### PR DESCRIPTION
The goal of this PR is to make mp3 export available without external harvid_ffmpeg ... for example when using Fedora system package. Libsndfile introduced mp3 support in version 1.1.0 - that should "of course" be used when available. It seems like you are happy with ffmpeg mp3 support, but using libsndfile seems like a good, simple, and reliable alternative.

(The problem with the format bitmasks was a tough one blocking getting mp3 working correctly. I'm  happy I nailed it ;-) )

One question: is sample rate conversion really relevant for mp3. I guess it "always" will be better to use session sample rate and leave it to the encoder to do whatever it takes to reduce bandwidth.

The main (pre-existing) TODO is a more generic way to handle quality control in ExportGraphBuilder::Encoder::init_writer .

(Also, I wonder why Vorbis quality UI enums go from 0 to 10 when vorbis_encode_init_vbr (like libsndfile) goes from (approximately) 0 to 1. It seems more intuitive to explain it as 0 to 100%. And perhaps use approximated size reduction instead of linear mapping.

