### PR TITLE
Calm grey tooltip - Update dark-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -125,7 +125,7 @@
     <ColorAlias name="gtk_background" alias="theme:bg"/>
     <ColorAlias name="gtk_bases" alias="theme:bg2"/>
     <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
-    <ColorAlias name="gtk_bg_tooltip" alias="neutral:backgroundest"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="neutral:midground"/>
     <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
     <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
@@ -136,7 +136,7 @@
     <ColorAlias name="gtk_darkest" alias="theme:bg2"/>
     <ColorAlias name="gtk_entry_cursor" alias="alert:red"/>
     <ColorAlias name="gtk_fg_selected" alias="theme:bg2"/>
-    <ColorAlias name="gtk_fg_tooltip" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_fg_tooltip" alias="neutral:backgroundest"/>
     <ColorAlias name="gtk_foldback_bg" alias="theme:bg1"/>
     <ColorAlias name="gtk_foreground" alias="neutral:foreground"/>
     <ColorAlias name="gtk_light_text_on_dark" alias="neutral:foreground2"/>


### PR DESCRIPTION
(Next try of PR)
This PR propose more calm grey background&black text instead off too much contrasting current black background&white text for tool-tip:
![calm_tooltip](https://user-images.githubusercontent.com/19673308/196004377-680ded62-9e26-4068-b452-925e0bf96174.png)
Current tool-tip colors are very strain on the eyes IMO.
@x42 Also this offer keeps the neutrality of colors..