### PR TITLE
"Cardinal-like" tooltip - Update dark-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -125,7 +125,7 @@
     <ColorAlias name="gtk_background" alias="theme:bg"/>
     <ColorAlias name="gtk_bases" alias="theme:bg2"/>
     <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
-    <ColorAlias name="gtk_bg_tooltip" alias="neutral:backgroundest"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="neutral:background2"/>
     <ColorAlias name="gtk_bright_color" alias="widget:blue"/>
     <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
     <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
@@ -136,7 +136,7 @@
     <ColorAlias name="gtk_darkest" alias="theme:bg2"/>
     <ColorAlias name="gtk_entry_cursor" alias="alert:red"/>
     <ColorAlias name="gtk_fg_selected" alias="theme:bg2"/>
-    <ColorAlias name="gtk_fg_tooltip" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_fg_tooltip" alias="neutral:foreground2"/>
     <ColorAlias name="gtk_foldback_bg" alias="theme:bg1"/>
     <ColorAlias name="gtk_foreground" alias="neutral:foreground"/>
     <ColorAlias name="gtk_light_text_on_dark" alias="neutral:foreground2"/>


### PR DESCRIPTION
This is an alternative (inverted) PR to the previous - grey background&light grey text. An idea was inspired from the Cardinal GUI:
![grey+light-grey-tooltip](https://user-images.githubusercontent.com/19673308/196024448-e8a28399-f661-4f59-903b-52ae286cd274.png)

A Cardinal's example:
![cardinal_example](https://user-images.githubusercontent.com/19673308/196024491-890ff1d7-c053-4ce0-9985-09ac181b82b7.png)
