### PR TITLE
Fedora ca - proposed fix for #9005

### DIFF
--- a/gtk2_ardour/ardour_http.cc
+++ b/gtk2_ardour/ardour_http.cc
@@ -55,18 +55,13 @@ const char* HttpGet::ca_info = NULL;
 void
 HttpGet::ca_setopt (CURL* c)
 {
-	if (ca_info && strlen (ca_info) > 0) {
+	if (ca_info) {
 		curl_easy_setopt (c, CURLOPT_CAINFO, ca_info);
 	}
 	if (ca_path) {
 		curl_easy_setopt (c, CURLOPT_CAPATH, ca_path);
 	}
-
-	if (ca_info && strlen (ca_info) == 0) {
-		/* not hat for you */
-		curl_easy_setopt (c, CURLOPT_SSL_VERIFYPEER, 0);
-		curl_easy_setopt (c, CURLOPT_SSL_VERIFYHOST, 0);
-	} else if (ca_info || ca_path) {
+	if (ca_info || ca_path) {
 		curl_easy_setopt (c, CURLOPT_SSL_VERIFYPEER, 1);
 	}
 }
@@ -99,9 +94,8 @@ HttpGet::setup_certificate_paths ()
 	else if (Glib::file_test ("/etc/pki/tls/cert.pem", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_REGULAR)) {
 		// GNU/TLS can keep extra stuff here
 		ca_info = "/etc/pki/tls/cert.pem";
-	} else {
-		ca_info = ""; // disable cert check
 	}
+	// else NULL: use default (currently) "/etc/ssl/certs/ca-certificates.crt" if it exists
 
 	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_DIR)) {
 		// we're on RHEL // https://bugzilla.redhat.com/show_bug.cgi?id=1053882
@@ -111,7 +105,7 @@ HttpGet::setup_certificate_paths ()
 		// Debian and derivs + OpenSuSe
 		ca_path = "/etc/ssl/certs";
 	} else {
-		ca_path = "/nonexistent_path";
+		ca_path = "/nonexistent_path"; // don't try -- just in case:
 	}
 
 	/* If we don't set anything defaults are used. at the time of writing we compile bundled curl on debian

--- a/gtk2_ardour/ardour_http.cc
+++ b/gtk2_ardour/ardour_http.cc
@@ -63,6 +63,7 @@ HttpGet::ca_setopt (CURL* c)
 	}
 
 	if (ca_info && strlen (ca_info) == 0) {
+		/* not hat for you */
 		curl_easy_setopt (c, CURLOPT_SSL_VERIFYPEER, 0);
 		curl_easy_setopt (c, CURLOPT_SSL_VERIFYHOST, 0);
 	} else if (ca_info || ca_path) {
@@ -102,9 +103,9 @@ HttpGet::setup_certificate_paths ()
 		ca_info = ""; // disable cert check
 	}
 
-	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_REGULAR)) {
+	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_DIR)) {
 		// we're on RHEL // https://bugzilla.redhat.com/show_bug.cgi?id=1053882
-		ca_path = "/nonexistent_path"; // don't try "/etc/ssl/certs" it's a trap
+		ca_path = "/nonexistent_path"; // don't try "/etc/ssl/certs" in case it's curl's default
 	}
 	else if (Glib::file_test ("/etc/ssl/certs", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_DIR)) {
 		// Debian and derivs + OpenSuSe

--- a/gtk2_ardour/ardour_http.cc
+++ b/gtk2_ardour/ardour_http.cc
@@ -97,19 +97,11 @@ HttpGet::setup_certificate_paths ()
 	}
 	// else NULL: use default (currently) "/etc/ssl/certs/ca-certificates.crt" if it exists
 
-	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_DIR)) {
-		// we're on RHEL // https://bugzilla.redhat.com/show_bug.cgi?id=1053882
-		ca_path = "/nonexistent_path"; // don't try "/etc/ssl/certs" in case it's curl's default
-	}
-	else if (Glib::file_test ("/etc/ssl/certs", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_DIR)) {
-		// Debian and derivs + OpenSuSe
-		ca_path = "/etc/ssl/certs";
-	} else {
-		ca_path = "/nonexistent_path"; // don't try -- just in case:
-	}
-
 	/* If we don't set anything defaults are used. at the time of writing we compile bundled curl on debian
 	 * and it'll default to  /etc/ssl/certs and /etc/ssl/certs/ca-certificates.crt
+	 * That works on Debian and derivs + openSUSE. It has historically not
+	 * worked on RHEL / Fedora, but worst case the directory exists and doesn't
+	 * prevent ca_info from working. https://bugzilla.redhat.com/show_bug.cgi?id=1053882
 	 */
 }
 

--- a/gtk2_ardour/ardour_http.cc
+++ b/gtk2_ardour/ardour_http.cc
@@ -80,6 +80,7 @@ HttpGet::setup_certificate_paths ()
 	 *
 	 * Short of this mess: we could simply bundle a .crt of
 	 * COMODO (ardour) and ghandi (freesound) and be done with it.
+	 * Alternatively, ship the Mozilla CA list, perhaps using https://mkcert.org/ .
 	 */
 	assert (!ca_path && !ca_info); // call once
 

--- a/gtk2_ardour/ardour_http.cc
+++ b/gtk2_ardour/ardour_http.cc
@@ -83,15 +83,15 @@ HttpGet::setup_certificate_paths ()
 	 */
 	assert (!ca_path && !ca_info); // call once
 
-	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_REGULAR)) {
+	if (Glib::file_test ("/etc/pki/tls/certs/ca-bundle.crt", Glib::FILE_TEST_IS_REGULAR)) {
 		// Fedora / RHEL, Arch
 		ca_info = "/etc/pki/tls/certs/ca-bundle.crt";
 	}
-	else if (Glib::file_test ("/etc/ssl/certs/ca-certificates.crt", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_REGULAR)) {
+	else if (Glib::file_test ("/etc/ssl/certs/ca-certificates.crt", Glib::FILE_TEST_IS_REGULAR)) {
 		// Debian and derivatives
 		ca_info = "/etc/ssl/certs/ca-certificates.crt";
 	}
-	else if (Glib::file_test ("/etc/pki/tls/cert.pem", Glib::FILE_TEST_EXISTS|Glib::FILE_TEST_IS_REGULAR)) {
+	else if (Glib::file_test ("/etc/pki/tls/cert.pem", Glib::FILE_TEST_IS_REGULAR)) {
 		// GNU/TLS can keep extra stuff here
 		ca_info = "/etc/pki/tls/cert.pem";
 	}


### PR DESCRIPTION
Note: Since I don't have the official Ardour debian build environment, this hasn't really been tested. Just like the existing fix attempts not had been tested on Fedora. I can test on Fedora 36/37 when the code has been built upstream.

The existing commits for https://tracker.ardour.org/view.php?id=9005 didn't solve the problem and didn't seem to move in the right direction. Plus they introduced an insecure fallback. I thus start by reverting them.

The main problem fixed here is that the check failed because setting capath to /non-existant made all checks fail. Experiments on Fedora 36 confirms that making capath point to /etc/ssl/certs works fine. I thus suggest using the default on all platforms.

The check for ca-bundle.crt with FILE_TEST_IS_DIR kind of worked before. That was because the tests specified with the bitfield are ORed. The code seemed to assume they were ANDed. That is fixed too.

I think it would be a very healthy fallback to use bundled root certs, and the comment about that is thus augmented to suggest using the mozilla approach.