### PR TITLE
RFC: Automation control point operations

### DIFF
--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -231,7 +231,7 @@ double
 AutomationLine::control_point_box_size ()
 {
 	float uiscale = UIConfiguration::instance().get_ui_scale();
-	uiscale = std::max<float> (1.f, powf (uiscale, 1.71));
+	uiscale = std::max<float> (1.f, powf (uiscale, 1.71)) * 2;
 
 	if (_height > TimeAxisView::preset_height (HeightLarger)) {
 		return rint (8.0 * uiscale);

--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -394,25 +394,57 @@ AutomationLine::delta_to_string (double delta) const
  *  @return Corresponding y fraction.
  */
 double
-AutomationLine::string_to_fraction (string const & s) const
+AutomationLine::string_to_fraction (string const & s, double const old_fraction) const
 {
-	double v;
-	sscanf (s.c_str(), "%lf", &v);
-
+	bool is_db = false;
 	switch (_desc.type) {
 		case GainAutomation:
 		case BusSendLevel:
 		case EnvelopeAutomation:
 		case TrimAutomation:
 		case InsertReturnLevel:
-			if (s == "-inf") { /* translation */
-				v = 0;
-			} else {
-				v = dB_to_coefficient (v);
-			}
+			is_db = true;
 			break;
 		default:
 			break;
+	}
+	double v;
+	if ((s.length() > 2) && index("+-*/", s[0]) && (s[1] == '=')) {
+		v = old_fraction;
+		view_to_model_coord_y (v);
+		if (is_db) {
+			v = accurate_coefficient_to_dB(v);
+		}
+		double op_v;
+		sscanf (s.c_str() + 2, "%lf", &op_v);
+		if (op_v != 0.f) {
+			switch (s[0]) {
+				case '+':
+					v += op_v;
+					break;
+				case '-':
+					v -= op_v;
+					break;
+				case '*':
+					v *= op_v;
+					break;
+				case '/':
+					if (op_v > 1.0) {
+						v /= op_v;
+					}
+					break;
+			}
+		}
+	} else {
+		sscanf (s.c_str(), "%lf", &v);
+	}
+
+	if (is_db) {
+		if (s == "-inf") { /* translation */
+			v = 0;
+		} else {
+			v = dB_to_coefficient (v);
+		}
 	}
 	return model_to_view_coord_y (v);
 }

--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -926,13 +926,21 @@ AutomationLine::is_first_point (ControlPoint& cp)
 
 // This is copied into AudioRegionGainLine
 void
-AutomationLine::remove_point (ControlPoint& cp)
+AutomationLine::remove_points (std::vector<ControlPoint*> const& cps)
 {
 	trackview.editor().begin_reversible_command (_("remove control point"));
 	XMLNode &before = alist->get_state();
 
 	trackview.editor ().get_selection ().clear_points ();
-	alist->erase (cp.model());
+
+	// Extract models before the ControlPoints iterator mutates on ControlPoint deletion
+	std::list<Evoral::ControlList::iterator> models;
+	for (auto const & cp : cps) {
+		models.push_back(cp->model());
+	}
+	for (auto const & model : models) {
+		alist->erase (model);
+	}
 
 	trackview.editor().session()->add_command(
 		new MementoCommand<AutomationList> (memento_command_binder (), &before, &alist->get_state()));

--- a/gtk2_ardour/automation_line.h
+++ b/gtk2_ardour/automation_line.h
@@ -125,7 +125,7 @@ public:
 	std::string get_verbose_cursor_relative_string (double, double) const;
 	std::string fraction_to_string (double) const;
 	std::string delta_to_string (double) const;
-	double string_to_fraction (std::string const &) const;
+	double string_to_fraction (std::string const &, double old_fraction) const;
 
 	void   view_to_model_coord_y (double &) const;
 

--- a/gtk2_ardour/automation_line.h
+++ b/gtk2_ardour/automation_line.h
@@ -85,7 +85,6 @@ public:
 	void get_selectables (Temporal::timepos_t const &, Temporal::timepos_t const &, double, double, std::list<Selectable*>&);
 	void get_inverted_selectables (Selection&, std::list<Selectable*>& results);
 
-	virtual void remove_point (ControlPoint&);
 	bool control_points_adjacent (double xval, uint32_t& before, uint32_t& after);
 
 	/* dragging API */
@@ -150,6 +149,7 @@ public:
 	void set_colors();
 
 	void modify_points_y (std::vector<ControlPoint*> const&, double);
+	virtual void remove_points (std::vector<ControlPoint*> const& cps);
 
 	virtual MementoCommandBinder<ARDOUR::AutomationList>* memento_command_binder ();
 

--- a/gtk2_ardour/control_point.cc
+++ b/gtk2_ardour/control_point.cc
@@ -45,8 +45,7 @@ ControlPoint::ControlPoint (AutomationLine& al)
 	_size = 4.0;
 
 	_item = new ArdourCanvas::Rectangle (&_line.canvas_group());
-	_item->set_fill (true);
-	_item->set_fill_color (UIConfiguration::instance().color ("control point fill"));
+	_item->set_fill (false);
 	_item->set_outline_color (UIConfiguration::instance().color ("control point outline"));
 	_item->set_data ("control_point", this);
 	_item->Event.connect (sigc::mem_fun (this, &ControlPoint::event_handler));
@@ -122,10 +121,8 @@ ControlPoint::set_color ()
 {
 	if (_selected) {
 		_item->set_outline_color(UIConfiguration::instance().color ("control point selected outline"));;
-		_item->set_fill_color(UIConfiguration::instance().color ("control point selected fill"));
 	} else {
 		_item->set_outline_color(UIConfiguration::instance().color ("control point outline"));
-		_item->set_fill_color(UIConfiguration::instance().color ("control point fill"));
 	}
 }
 

--- a/gtk2_ardour/control_point_dialog.cc
+++ b/gtk2_ardour/control_point_dialog.cc
@@ -90,9 +90,11 @@ ControlPointDialog::ControlPointDialog (ControlPoint* p, bool multi)
 }
 
 double
-ControlPointDialog::get_y_fraction () const
+ControlPointDialog::get_y_fraction (ControlPoint* p) const
 {
-	return point_->line().string_to_fraction (value_.get_text ());
+	double const old_fraction = 1.0 - (p->get_y () / p->line().height ());
+
+	return point_->line().string_to_fraction (value_.get_text (), old_fraction);
 }
 
 bool

--- a/gtk2_ardour/control_point_dialog.h
+++ b/gtk2_ardour/control_point_dialog.h
@@ -29,7 +29,7 @@ class ControlPointDialog : public ArdourDialog
 public:
 	ControlPointDialog (ControlPoint *, bool multi);
 
-	double get_y_fraction () const;
+	double get_y_fraction (ControlPoint *) const;
 
 	bool all_selected_points () const;
 

--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -6812,9 +6812,8 @@ Editor::popup_control_point_context_menu (ArdourCanvas::Item* item, GdkEvent* ev
 
 	items.push_back (MenuElem (_("Edit..."), sigc::bind (sigc::mem_fun (*this, &Editor::edit_control_point), item)));
 	items.push_back (MenuElem (_("Delete"), sigc::bind (sigc::mem_fun (*this, &Editor::remove_control_point), item)));
-	if (!can_remove_control_point (item)) {
-		items.back().set_sensitive (false);
-	}
+	ControlPoint * control_point = reinterpret_cast<ControlPoint *> (item->get_data ("control_point"));
+	items.back().set_sensitive ((control_point != 0) && can_remove_control_point (*control_point));
 
 	_control_point_context_menu.popup (event->button.button, event->button.time);
 }

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -1718,7 +1718,7 @@ private:
 
 	void region_view_item_click (AudioRegionView&, GdkEventButton*);
 
-	bool can_remove_control_point (ArdourCanvas::Item*);
+	bool can_remove_control_point (ControlPoint& control_point);
 	void remove_control_point (ArdourCanvas::Item*);
 
 	/* Canvas event handlers */

--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -4845,9 +4845,10 @@ ControlPointDrag::motion (GdkEvent* event, bool first_motion)
 	/* Now x axis */
 
 	timecnt_t dt;
-
-	if (_point->can_slide ()) {
+	// alternatively, drag horizontally but use initial vertical position
+	if (_point->can_slide () && (abs(_drags->current_pointer_x() - grab_x()) > abs(cy - _fixed_grab_y))) {
 		dt = total_dt (event);
+		cy = _fixed_grab_y;
 	}
 
 	cy = max (0.0, cy);

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -2476,11 +2476,15 @@ Editor::remove_control_point (ArdourCanvas::Item* item)
 		abort(); /*NOTREACHED*/
 	}
 
-	if (!can_remove_control_point (*control_point)) {
-		return;
+	std::vector<ControlPoint*> cps;
+
+	for (auto const& cp : selection->points) {
+		if ((&cp->line() == &control_point->line ()) && can_remove_control_point (*cp)) {
+			cps.push_back (cp);
+		}
 	}
 
-	control_point->line().remove_point (*control_point);
+	control_point->line().remove_points (cps);
 }
 
 void

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -2514,11 +2514,11 @@ Editor::edit_control_point (ArdourCanvas::Item* item)
 	}
 
 	if (d.all_selected_points ()) {
-		p->line().modify_points_y (cps, d.get_y_fraction ());
+		p->line().modify_points_y (cps, d.get_y_fraction (p)); // FIXME: multi edit somehow?
 	} else {
 		cps.clear ();
 		cps.push_back (p);
-		p->line().modify_points_y (cps, d.get_y_fraction ());
+		p->line().modify_points_y (cps, d.get_y_fraction (p));
 	}
 }
 

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -2453,19 +2453,12 @@ Editor::motion_handler (ArdourCanvas::Item* item, GdkEvent* event, bool from_aut
 }
 
 bool
-Editor::can_remove_control_point (ArdourCanvas::Item* item)
+Editor::can_remove_control_point (ControlPoint& control_point)
 {
-	ControlPoint* control_point;
-
-	if ((control_point = reinterpret_cast<ControlPoint *> (item->get_data ("control_point"))) == 0) {
-		fatal << _("programming error: control point canvas item has no control point object pointer!") << endmsg;
-		abort(); /*NOTREACHED*/
-	}
-
-	AutomationLine& line = control_point->line ();
+	AutomationLine& line = control_point.line ();
 	if (dynamic_cast<AudioRegionGainLine*> (&line)) {
 		/* we shouldn't remove the first or last gain point in region gain lines */
-		if (line.is_last_point(*control_point) || line.is_first_point(*control_point)) {
+		if (line.is_last_point(control_point) || line.is_first_point(control_point)) {
 			return false;
 		}
 	}
@@ -2476,15 +2469,15 @@ Editor::can_remove_control_point (ArdourCanvas::Item* item)
 void
 Editor::remove_control_point (ArdourCanvas::Item* item)
 {
-	if (!can_remove_control_point (item)) {
-		return;
-	}
+	ControlPoint* control_point = reinterpret_cast<ControlPoint *> (item->get_data ("control_point"));
 
-	ControlPoint* control_point;
-
-	if ((control_point = reinterpret_cast<ControlPoint *> (item->get_data ("control_point"))) == 0) {
+	if (control_point == 0) {
 		fatal << _("programming error: control point canvas item has no control point object pointer!") << endmsg;
 		abort(); /*NOTREACHED*/
+	}
+
+	if (!can_remove_control_point (*control_point)) {
+		return;
 	}
 
 	control_point->line().remove_point (*control_point);

--- a/gtk2_ardour/region_gain_line.cc
+++ b/gtk2_ardour/region_gain_line.cc
@@ -79,7 +79,7 @@ AudioRegionGainLine::start_drag_single (ControlPoint* cp, double x, float fracti
 
 // This is an extended copy from AutomationList
 void
-AudioRegionGainLine::remove_point (ControlPoint& cp)
+AudioRegionGainLine::remove_points (std::vector<ControlPoint*> const& cps)
 {
 	trackview.editor().begin_reversible_command (_("remove control point"));
 	XMLNode &before = alist->get_state();
@@ -91,7 +91,15 @@ AudioRegionGainLine::remove_point (ControlPoint& cp)
 	}
 
 	trackview.editor ().get_selection ().clear_points ();
-	alist->erase (cp.model());
+
+	// Extract models before the ControlPoints iterator mutates on ControlPoint deletion
+	std::list<Evoral::ControlList::iterator> models;
+	for (auto const & cp : cps) {
+		models.push_back(cp->model());
+	}
+	for (auto const & model : models) {
+		alist->erase (model);
+	}
 
 	trackview.editor().session()->add_command (new MementoCommand<AutomationList>(*alist.get(), &before, &alist->get_state()));
 	trackview.editor().commit_reversible_command ();

--- a/gtk2_ardour/region_gain_line.h
+++ b/gtk2_ardour/region_gain_line.h
@@ -47,7 +47,7 @@ public:
 	void start_drag_single (ControlPoint*, double, float);
 	void end_drag (bool with_push, uint32_t final_index);
 
-	void remove_point (ControlPoint&);
+	void remove_points (std::vector<ControlPoint*> const& cps);
 	AudioRegionView& region_view () { return rv; }
 
 private:


### PR DESCRIPTION
The goal of this PR is to make automation editing more smooth. Nothing big, but some workflow improvements I would enjoy.

See the individual clean changesets.

I think some of the changesets are good, ready to be cherry-picked.

I would like some feedback on whether these changes operate on the right levels, or if I violate some MVC-ish or code structure pattern that I haven't realized? For example, it would be nice to pass model objects to AutomationLine::remove_points instead of Items or ControlPoints ... but that doesn't seem to fit in.

More experimental: Make it possible to enter operands like "+= 3" when editing (multiple) control points to increase them all with 3 dB. This could be an advanced feature, documented in the manual but not cluttering the UI.

