### PR TITLE
PulseAudio overflow fix ... and cleanup

### DIFF
--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -274,7 +274,6 @@ PulseAudioBackend::init_pulse ()
 		close_pulse (true);
 		return AudioDeviceOpenError;
 	}
-
 	/* Wait until the context is ready, context_state_cb will trigger this */
 	pa_threaded_mainloop_wait (p_mainloop);
 	if (pa_context_get_state (p_context) != PA_CONTEXT_READY) {
@@ -318,10 +317,8 @@ PulseAudioBackend::init_pulse ()
 		close_pulse (true);
 		return AudioDeviceOpenError;
 	}
-
 	/* Wait until the stream is ready */
 	pa_threaded_mainloop_wait (p_mainloop);
-
 	if (pa_stream_get_state (p_stream) != PA_STREAM_READY) {
 		PBD::error << _("PulseAudioBackend: Failed to start stream") << endmsg;
 		close_pulse (true);
@@ -1084,6 +1081,7 @@ PulseAudioBackend::main_process_thread ()
 				PBD::error << _("PulseAudioBackend::main_process_thread pa_stream_write failed.") << endmsg;
 				break;
 			}
+
 			pa_threaded_mainloop_unlock (p_mainloop);
 
 			_processed_samples += _samples_per_period;

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -1040,7 +1040,7 @@ PulseAudioBackend::main_process_thread ()
 			pa_threaded_mainloop_lock (p_mainloop);
 
 			size_t bytes_to_write = sizeof (float) * _samples_per_period * N_CHANNELS;
-			if (pa_stream_writable_size (p_stream) < bytes_to_write) {
+			while (pa_stream_writable_size (p_stream) < bytes_to_write) {
 				/* wait until stream_request_cb triggers */
 				pa_threaded_mainloop_wait (p_mainloop);
 			}

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -1000,6 +1000,7 @@ PulseAudioBackend::main_process_thread ()
 		if (_run) {
 			engine.halted_callback ("PulseAudio: cannot uncork stream");
 		}
+		return 0;
 	}
 
 	_dsp_load_calc.reset ();

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -1008,9 +1008,6 @@ PulseAudioBackend::main_process_thread ()
 		}
 	}
 
-	pa_threaded_mainloop_lock (p_mainloop);
-	sync_pulse (pa_stream_drain (p_stream, stream_operation_cb, this));
-
 	_dsp_load_calc.reset ();
 	stream_latency_update_cb (p_stream, this);
 

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -1073,8 +1073,7 @@ PulseAudioBackend::main_process_thread ()
 
 			/* interleave */
 			for (std::vector<BackendPortPtr>::const_iterator it = _system_outputs.begin (); it != _system_outputs.end (); ++it, ++i) {
-				BackendPortPtr port = boost::dynamic_pointer_cast<BackendPort> (*it);
-				const float* src = (const float*) port->get_buffer (_samples_per_period);
+				const float* src = (const float*) (*it)->get_buffer (_samples_per_period);
 				for (size_t n = 0; n < _samples_per_period; ++n) {
 					buf[N_CHANNELS * n + i] = src[n];
 				}

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -1233,7 +1233,7 @@ PulseAudioPort::get_buffer (pframes_t n_samples)
 			while (++it != connections.end ()) {
 				source = boost::dynamic_pointer_cast<PulseAudioPort> (*it);
 				assert (source && source->is_output ());
-				Sample*       dst = buffer ();
+				Sample*       dst = _buffer;
 				const Sample* src = source->const_buffer ();
 				for (uint32_t s = 0; s < n_samples; ++s, ++dst, ++src) {
 					*dst += *src;

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -633,7 +633,6 @@ PulseAudioBackend::_start (bool /*for_latency_measurement*/)
 		if (pbd_pthread_create (PBD_RT_STACKSIZE_PROC, &_main_thread, pthread_process, this)) {
 			PBD::error << _("PulseAudioBackend: failed to create process thread.") << endmsg;
 			stop ();
-			_run = false;
 			return ProcessThreadStartError;
 		} else {
 			PBD::warning << _("PulseAudioBackend: cannot acquire realtime permissions.") << endmsg;

--- a/libs/backends/pulseaudio/pulseaudio_backend.cc
+++ b/libs/backends/pulseaudio/pulseaudio_backend.cc
@@ -582,7 +582,7 @@ int
 PulseAudioBackend::_start (bool /*for_latency_measurement*/)
 {
 	if (!_active && _run) {
-		PBD::error << _("PulseAudioBackend: already active.") << endmsg;
+		PBD::error << _("PulseAudioBackend: restarting.") << endmsg;
 		/* recover from 'halted', reap threads */
 		stop ();
 	}


### PR DESCRIPTION
The PulseAudio backend used to be great for my usecase of editing/mixing live recordings on my desktop pc. But it has been unusable for me for a while, with lots of xruns. It seems to be a regression in PipeWire, but Ardour seems to be pushing it unnecessarily hard into a territory of undefined behaviour. With a simple and reasonable fix it works again.

After the fix comes some minor but nice cleanup and improvements from diving into the PA backend.