### PR TITLE
Update cubasish-ardour.colors - generic button low contrast issue

### DIFF
--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -107,7 +107,7 @@
     <ColorAlias name="gain line" alias="alert:green"/>
     <ColorAlias name="gain line inactive" alias="theme:bg1"/>
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
-    <ColorAlias name="generic button: fill active" alias="alert:red"/>
+    <ColorAlias name="generic button: fill active" alias="neutral:foreground2"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>


### PR DESCRIPTION
This PR changes the text's color in the Pin Configuration window (sidechain button). It's made with some interesting ardour's behavior, which LAM (an author of cool "Xcolors" theme) advised:

(an excerpt from his letter)
>This problem is, according to my tests, caused by the "luminosity" code that check the color of "<ColorAlias name="generic button: fill active" alias="alert:red"/>" row 110 (in both Clear Gray and Cubasish theme). That color, "alert:red", is never shown, because the button will get the background color (fill) form another alias, but the code still checks this alias to calculate the "contrasting"  color, that in these cases is "wrong".

>A solution could be to set it to the same color of the alias defining the button background/fill color, so that the code can correctly calculate if it needs a "contrasting" color.

![cubasish_generic_button_fill_active](https://user-images.githubusercontent.com/19673308/201465267-8f3d8382-c7ad-412e-b766-16dad2565032.png)
Big thanx to LAM! :)
