### PR TITLE
Update clear_gray-ardour.colors - generic button low contrast issue

### DIFF
--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -107,7 +107,7 @@
     <ColorAlias name="gain line" alias="alert:green"/>
     <ColorAlias name="gain line inactive" alias="theme:bg1"/>
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
-    <ColorAlias name="generic button: fill active" alias="alert:red"/>
+    <ColorAlias name="generic button: fill active" alias="neutral:foreground2"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>


### PR DESCRIPTION
This PR (the same as previous "Cubasish") changes the text's color in the Pin Configuration window (sidechain button). It's made with some interesting Ardour's behavior, which LAM (an author of cool "Xcolors" theme) advised:

(an excerpt from his letter)
>This problem is, according to my tests, caused by the "luminosity" code that check the color of "<ColorAlias name="generic button: fill active" alias="alert:red"/>" row 110 (in both Clear Gray and Cubasish theme). That color, "alert:red", is never shown, because the button will get the background color (fill) form another alias, but the code still checks this alias to calculate the "contrasting"  color, that in these cases is "wrong".

>A solution could be to set it to the same color of the alias defining the button background/fill color, so that the code can correctly calculate if it needs a "contrasting" color.

![clear_gray_generic_button_fill_active](https://user-images.githubusercontent.com/19673308/201466415-379331a6-e0c1-402b-b648-82eabd44c2ea.png)


Thanks to LAM!