### PR TITLE
Update Xcolors alert:cyan and widget:ruddy to Teal no. 9

### DIFF
--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -2,7 +2,7 @@
 <Ardour theme-name="Xcolors">
   <Colors>
     <Color name="alert:blue" value="3b5bdbff"/>
-    <Color name="alert:cyan" value="099268ff"/>
+    <Color name="alert:cyan" value="087f5bff"/>
     <Color name="alert:green" value="82c91eff"/>
     <Color name="alert:greenish" value="66a80fff"/>
     <Color name="alert:orange" value="fd7e14ff"/>
@@ -31,7 +31,7 @@
     <Color name="widget:green" value="b197fcff"/>  <!--gtk processor postfader,  gtk_midi_track-->
     <Color name="widget:green darker" value="343a40FF"/>  <!--midi track base-->
     <Color name="widget:orange" value="fd7e14ff"/>  <!--tempo marker-->
-    <Color name="widget:ruddy" value="099268ff"/>  <!--processor prefader-->
+    <Color name="widget:ruddy" value="087f5bff"/>  <!--processor prefader-->
     <Color name="meter color0" value="008800ff"/>
     <Color name="meter color1" value="00aa00ff"/>
     <Color name="meter color2" value="00ff00ff"/>


### PR DESCRIPTION
This PR change the processor and foldback prefader color to Teal no. 9 from Teal no. 8 (in OpenColor), to allow foreground white text.
![2022-11-19_17 47 50 691](https://user-images.githubusercontent.com/114294020/202862188-32607849-4bc2-4c53-87ba-9a20f9240e2b.png)
![2022-11-19_17 46 30 227](https://user-images.githubusercontent.com/114294020/202862191-e21dc65e-f8e0-45f7-9c49-75c7f103ecd5.png)
