### PR TITLE
Group system ports by common prefix.

### DIFF
--- a/gtk2_ardour/port_group.h
+++ b/gtk2_ardour/port_group.h
@@ -144,6 +144,7 @@ private:
 	void emit_changed ();
 	void emit_bundle_changed (ARDOUR::Bundle::Change);
 	boost::shared_ptr<ARDOUR::Bundle> make_bundle_from_ports (std::vector<std::string> const &, ARDOUR::DataType, bool, std::string const& bundle_name = std::string()) const;
+	void add_bundles_for_ports (std::vector<std::string> const &, ARDOUR::DataType, bool, bool, boost::shared_ptr<PortGroup>) const;
 	void maybe_add_processor_to_list (boost::weak_ptr<ARDOUR::Processor>, std::list<boost::shared_ptr<ARDOUR::IO> > *, bool, std::set<boost::shared_ptr<ARDOUR::IO> > &);
 
 	mutable PortGroup::BundleList _bundles;


### PR DESCRIPTION
Extra "other" ("External") ports were already being grouped by their common prefix into bundles to better display ports coming from different jack clients. This commit factors out that logic into a separate method to also apply this logic to extra "system" ("Hardware") ports. This way hardware ports from different devices/clients (for example when using pipewire as jack backend) are grouped by device rather than all being listed as one bundle.