### PR TITLE
Use pretty names of ports not just for mono bundles, but also stereo.

### DIFF
--- a/libs/ardour/session_bundles.cc
+++ b/libs/ardour/session_bundles.cc
@@ -165,8 +165,14 @@ Session::setup_bundles ()
 
 	for (uint32_t np = 0; np < outputs[DataType::AUDIO].size(); np += 2) {
 		if (np + 1 < outputs[DataType::AUDIO].size()) {
-			char buf[32];
-			snprintf (buf, sizeof(buf), _("out %" PRIu32 "+%" PRIu32), np + 1, np + 2);
+			char buf[64];
+			std::string pn1 = _engine.get_pretty_name_by_name (outputs[DataType::AUDIO][np]);
+			std::string pn2 = _engine.get_pretty_name_by_name (outputs[DataType::AUDIO][np+1]);
+			if (!pn1.empty() && !pn2.empty()) {
+				snprintf (buf, sizeof(buf), _("out %s+%s"), pn1.c_str(), pn2.c_str());
+			} else {
+				snprintf (buf, sizeof(buf), _("out %" PRIu32 "+%" PRIu32), np + 1, np + 2);
+			}
 			boost::shared_ptr<Bundle> c (new Bundle (buf, true));
 			c->add_channel (_("L"), DataType::AUDIO);
 			c->set_port (0, outputs[DataType::AUDIO][np]);
@@ -199,8 +205,14 @@ Session::setup_bundles ()
 
 	for (uint32_t np = 0; np < inputs[DataType::AUDIO].size(); np += 2) {
 		if (np + 1 < inputs[DataType::AUDIO].size()) {
-			char buf[32];
-			snprintf (buf, sizeof(buf), _("in %" PRIu32 "+%" PRIu32), np + 1, np + 2);
+			char buf[64];
+			std::string pn1 = _engine.get_pretty_name_by_name (inputs[DataType::AUDIO][np]);
+			std::string pn2 = _engine.get_pretty_name_by_name (inputs[DataType::AUDIO][np+1]);
+			if (!pn1.empty() && !pn2.empty()) {
+				snprintf (buf, sizeof(buf), _("in %s+%s"), pn1.c_str(), pn2.c_str());
+			} else {
+				snprintf (buf, sizeof(buf), _("in %" PRIu32 "+%" PRIu32), np + 1, np + 2);
+			}
 
 			boost::shared_ptr<Bundle> c (new Bundle (buf, false));
 			c->add_channel (_("L"), DataType::AUDIO);


### PR DESCRIPTION
Session::setup_bundles() creates mono and stereo bundles from hardware inputs and outputs. For mono bundles the name of the bundle was based on the pretty name of the port (if the port has a pretty name), however stereo bundles always used the indices of ports to make the name. When using pipewire (or otherwise having multiple jack clients exposing physical ports) the indices are even less meaningful than otherwise (as different devices could appear in arbitrary order), so also using pretty names for stereo bundles makes the UI less confusing in places where these bundle names are used (for example the menu when clicking on an IOButton).