### PR TITLE
Fix AutomationListPropertyTest.

### DIFF
--- a/libs/ardour/test/automation_list_property_test.cc
+++ b/libs/ardour/test/automation_list_property_test.cc
@@ -46,11 +46,17 @@ write_automation_list_xml (XMLNode* node, std::string filename)
 void
 AutomationListPropertyTest::setUp ()
 {
+	// The reference files were created with this superclock ticks per second
+	// value. Setting this here makes sure we don't need to update all the
+	// reference files whenever the default value changes.
+	saved_superclock_ticks_per_second_ = Temporal::superclock_ticks_per_second();
+	Temporal::set_superclock_ticks_per_second(56448000);
 }
 
 void
 AutomationListPropertyTest::tearDown ()
 {
+	Temporal::set_superclock_ticks_per_second(saved_superclock_ticks_per_second_);
 }
 
 void

--- a/libs/ardour/test/automation_list_property_test.cc
+++ b/libs/ardour/test/automation_list_property_test.cc
@@ -49,14 +49,14 @@ AutomationListPropertyTest::setUp ()
 	// The reference files were created with this superclock ticks per second
 	// value. Setting this here makes sure we don't need to update all the
 	// reference files whenever the default value changes.
-	saved_superclock_ticks_per_second_ = Temporal::superclock_ticks_per_second();
+	_saved_superclock_ticks_per_second = Temporal::superclock_ticks_per_second();
 	Temporal::set_superclock_ticks_per_second(56448000);
 }
 
 void
 AutomationListPropertyTest::tearDown ()
 {
-	Temporal::set_superclock_ticks_per_second(saved_superclock_ticks_per_second_);
+	Temporal::set_superclock_ticks_per_second(_saved_superclock_ticks_per_second);
 }
 
 void

--- a/libs/ardour/test/automation_list_property_test.h
+++ b/libs/ardour/test/automation_list_property_test.h
@@ -35,5 +35,5 @@ public:
 	void undoTest ();
 
 private:
-	Temporal::superclock_t saved_superclock_ticks_per_second_;
+	Temporal::superclock_t _saved_superclock_ticks_per_second;
 };

--- a/libs/ardour/test/automation_list_property_test.h
+++ b/libs/ardour/test/automation_list_property_test.h
@@ -19,6 +19,8 @@
 #include <cppunit/TestFixture.h>
 #include <cppunit/extensions/HelperMacros.h>
 
+#include "temporal/superclock.h"
+
 class AutomationListPropertyTest : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE (AutomationListPropertyTest);
@@ -31,4 +33,7 @@ public:
 	void tearDown ();
 	void basicTest ();
 	void undoTest ();
+
+private:
+	Temporal::superclock_t saved_superclock_ticks_per_second_;
 };


### PR DESCRIPTION
These tests use reference files that were generated with a particular value for superclock_ticks_per_second. The default for that has changed since the last time the reference files were updated though, causing tests to fail. Rather than updating the reference files for the new default value, this makes the test not depend on the default value by hardcoding the value that was used to generate the reference files.