### PR TITLE
Fix build on FreeBSD/powerpc64*

### DIFF
--- a/libs/ardour/ardour/cycles.h
+++ b/libs/ardour/ardour/cycles.h
@@ -72,13 +72,23 @@ static inline cycles_t get_cycles (void)
 
 #elif defined(__powerpc64__)
 
+#ifdef __linux__
 #include <sys/platform/ppc.h>
 typedef uint64_t cycles_t;
 static inline cycles_t get_cycles(void)
 {
 	return __ppc_get_timebase();
 }
-
+#elif defined(__FreeBSD__)
+typedef uint64_t cycles_t;
+static inline cycles_t get_cycles(void)
+{
+       cycles_t tbr;
+       asm volatile("mfspr %0, 268" : "=r"(tbr));
+       return tbr;
+}
+#endif
+	
 #elif defined(__powerpc__)
 
 #define CPU_FTR_601 0x00000100


### PR DESCRIPTION
Only glibc has __ppc_get_timebase() function. On FreeBSD use the same assembly call that __ppc_get_timebase() actually executes.

This probably should be extended to musl and OpenBSD, but I have no way of checking that.