### PR TITLE
Fix CPUID to detect AVX512F

### DIFF
--- a/libs/pbd/fpu.cc
+++ b/libs/pbd/fpu.cc
@@ -37,6 +37,8 @@
 #include <intrin.h>
 #elif defined(__GNUC__) || defined(__clang__)
 #include <cpuid.h>
+#else
+#error "Unsupported compiler: need __cpuid and __cpuidex for CPU detection"
 #endif
 
 #include "pbd/compose.h"


### PR DESCRIPTION
CPUID is part of x86_64 ISA to query CPU features. In order to determine `AVX512F` ISA extension, `EAX` and `ECX` needs to be set to `7` and `0` respectively before invoking `cpuid` instruction. This commit also removes inline assembly for `__cpuid` in favor of using compiler provided intrinsic functions. Both GCC and clang provides `__cpuid` like function via `__cpuid_count` intrinsic.

This commit also creates a portable wrapper over compiler intrinsic functions, __cpuid and __cpuidex. `cpuid` provides base level ISA query and `cpuidex` provides extra extension information like `AVX512F`. These wrappers lean towards MSVC like API.

References:
CPUID Docs: https://en.wikipedia.org/wiki/CPUID

GCC's "docs" on __cpuid_count:
https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/config/i386/cpuid.h

Clang's docs on __cpuid_count:
https://clang.llvm.org/doxygen/cpuid_8h.html

MSVC's docs on __cpuid and __cpuidex:
https://learn.microsoft.com/en-us/cpp/intrinsics/cpuid-cpuidex