### PR TITLE
Fix various typos

### DIFF
--- a/gtk2_ardour/automation_line.cc
+++ b/gtk2_ardour/automation_line.cc
@@ -545,7 +545,7 @@ AutomationLine::ContiguousControlPoints::clamp_dt (timecnt_t const & dt, timepos
 	 * - it is not before the origin (zero)
 	 * - it is not beyond the line's own limit (e.g. for region automation)
 	 * - it is not before the preceding point
-	 * - it is not after the folloing point
+	 * - it is not after the following point
 	 */
 
 	possible_pos = max (possible_pos, Temporal::timepos_t (possible_pos.time_domain()));

--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -4358,7 +4358,7 @@ MidiRegionView::data_recorded (boost::weak_ptr<MidiSource> w)
 				// - then calculate the distance from that relative to src->natural_position ()
 				// - and then take the samples() value of that and convert it to pixels
 				//
-				// Much simpler to just use ev.time() which is alredy the absolute position (in sample-time)
+				// Much simpler to just use ev.time() which is already the absolute position (in sample-time)
 				_active_notes[note]->set_x1 (trackview.editor().sample_to_pixel ((src->time_since_capture_start (timepos_t (ev.time ()))).samples()));
 				_active_notes[note]->set_outline_all ();
 				_active_notes[note] = 0;

--- a/gtk2_ardour/preference-metadata
+++ b/gtk2_ardour/preference-metadata
@@ -523,7 +523,7 @@
 [processor-usage]
   cpu threads usage distribute parallel
 [quieten-at-speed]
-  volume gain level reduce quieten cut speed fast foward rewind ffwd
+  volume gain level reduce quieten cut speed fast forward rewind ffwd
 [range-location-minimum]
 [range-selection-after-split]
   editing split selection range after split 

--- a/gtk2_ardour/sfdb_ui.cc
+++ b/gtk2_ardour/sfdb_ui.cc
@@ -1928,7 +1928,7 @@ SoundFileOmega::SoundFileOmega (string title, ARDOUR::Session* s,
 	options.attach (smf_tempo_btn, 4, 5, 2, 3, FILL, SHRINK, 2, 0);
 	options.attach (smf_marker_btn, 4, 5, 3, 4, FILL, SHRINK, 2, 0);
 
-	/* 3nd col (Audio-only) */
+	/* 3rd col (Audio-only) */
 	vspace = manage (new Alignment ());
 	vspace->set_size_request (16, 2);
 	options.attach (*vspace, 5, 6, 6, 7, SHRINK, SHRINK, 0, 0);


### PR DESCRIPTION
Found via `codespell`