### PR TITLE
Fix audio source names when importing files with > 2 and <= 26 channels.

### DIFF
--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -4908,9 +4908,9 @@ Session::format_audio_source_name (const string& legalized_base, uint32_t nchan,
 			sstr << "%R";
 		}
 	} else if (nchan > 2) {
-		if (nchan < 26) {
+		if (nchan <= 26) {
 			sstr << '%';
-			sstr << 'a' + chan;
+			sstr << static_cast<char>('a' + chan);
 		} else {
 			/* XXX what? more than 26 channels! */
 			sstr << '%';


### PR DESCRIPTION
This code presumably intended to name sources "foo%a", "foo%b" etc, but since it was incorrectly appending the character as an integer sources instead ended up being named "foo%97", "foo%98" etc.

Also changes the branching logic to use this branch upto 26 channels, rather than just upto 25 channels, as that seems to have been the intention.