### PR TITLE
ace-fluidsynth: fix free_path initialization in save

### DIFF
--- a/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
+++ b/libs/plugins/a-fluidsynth.lv2/a-fluidsynth.cc
@@ -858,6 +858,11 @@ save (LV2_Handle                instance,
 		if (!strcmp (features[i]->URI, LV2_STATE__mapPath)) {
 			map_path = (LV2_State_Map_Path*)features[i]->data;
 		}
+#ifdef LV2_STATE__freePath
+		else if (!strcmp (features[i]->URI, LV2_STATE__freePath)) {
+			free_path = (LV2_State_Free_Path*)features[i]->data;
+		}
+#endif
 	}
 
 	if (!map_path) {


### PR DESCRIPTION
I saw that free_path was assigned to NULL during save, but never really initialized, here is a fix.