### PR TITLE
Console1: With larger projects, the session was not initialised at this time

### DIFF
--- a/libs/surfaces/console1/console1.cc
+++ b/libs/surfaces/console1/console1.cc
@@ -165,10 +165,6 @@ Console1::begin_using_device ()
 	create_strip_invetory ();
 	connect_internal_signals ();
 	map_shift (false);
-	if (!first_selected_stripable ()) {
-		select_rid_by_index (0);
-	}
-	stripable_selection_changed ();
 	return 0;
 }
 


### PR DESCRIPTION
I worked on a large project and was not able to load it after the first saving. It turned out that  the session was not valid at this point.
So a npe occured.
Still strange, that it was only with large projects...
BTW: Selection still works.