### PR TITLE
Fix getmntent check with -Werror.

### DIFF
--- a/libs/pbd/mountpoint.cc
+++ b/libs/pbd/mountpoint.cc
@@ -110,6 +110,10 @@ mountpoint (string path)
 
 #else // !HAVE_GETMNTENT
 
+#ifdef __linux__
+#error "getmntent is supported on Linux. Is this a configuration error?"
+#endif
+
 #include <sys/param.h>
 #include <sys/ucred.h>
 #include <sys/mount.h>

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -122,7 +122,7 @@ def configure(conf):
                 define_name='HAVE_POSIX_MEMALIGN', execute = False, mandatory=False)
     conf.check_cc(
             msg="Checking for function 'getmntent' in mntent.h",
-            fragment = "#include <mntent.h>\n int main(void) { return (int)getmntent(0); }\n",
+            fragment = "#include <mntent.h>\n int main(void) { getmntent(0); }\n",
             define_name='HAVE_GETMNTENT', execute = False, mandatory=False)
     conf.check_cc(
             msg="Checking for function 'localtime_r' in time.h",


### PR DESCRIPTION
Fix a warning. The test is just compile tested and the return value is not used anyway.
Also, in my private build I compile with "-Werror" and without this patch this fails.

It also fails to build:
`../libs/pbd/mountpoint.cc:114:10: fatal error: sys/ucred.h: Datei oder Verzeichnis nicht gefunden
  114 | #include <sys/ucred.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
`