### PR TITLE
Add binding maps for the AKAI APC mini (mk1 and mk2) and the MPK miniplus

### DIFF
--- a/share/midi_maps/AKAI_APCmini.map
+++ b/share/midi_maps/AKAI_APCmini.map
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="AKAI APC mini">
+
+<!-- Created 2023-07-12 by Albert Gräf. This is a bare-bones implementation
+     which at least makes all buttons and faders on the APC mini do something
+     useful. If you need something more comprehensive, have a look at
+     https://github.com/agraef/apcmini/tree/clip-launcher.
+
+     Limitations:
+     - Ardour doesn't seem to send feedback to any of the buttons even if it
+       is enabled in the protocol settings, so the scene buttons and the 8x8
+       grid buttons won't light up.
+     - The APC mini has the bank switch buttons on shifted keys, which as
+       far as I can tell aren't supported in binding maps, so you'll have to
+       use a secondary device to switch banks if you'd like to utilize the
+       fader bindings.
+-->
+
+<DeviceInfo bank-size="8"/>
+
+<!-- faders 1-9 control 8 channels and the master gain -->
+
+<Binding channel="1" ctl="48"  uri="/route/gain B1"/>
+<Binding channel="1" ctl="49"  uri="/route/gain B2"/>
+<Binding channel="1" ctl="50"  uri="/route/gain B3"/>
+<Binding channel="1" ctl="51"  uri="/route/gain B4"/>
+<Binding channel="1" ctl="52"  uri="/route/gain B5"/>
+<Binding channel="1" ctl="53"  uri="/route/gain B6"/>
+<Binding channel="1" ctl="54"  uri="/route/gain B7"/>
+<Binding channel="1" ctl="55"  uri="/route/gain B8"/>
+<Binding channel="1" ctl="56"  uri="/bus/gain master"/>
+
+<!-- trigger cues in the session view using the scene launch buttons -->
+
+<Binding channel="1" note="82" action="Cues/trigger-cue-0"/>
+<Binding channel="1" note="83" action="Cues/trigger-cue-1"/>
+<Binding channel="1" note="84" action="Cues/trigger-cue-2"/>
+<Binding channel="1" note="85" action="Cues/trigger-cue-3"/>
+<Binding channel="1" note="86" action="Cues/trigger-cue-4"/>
+<Binding channel="1" note="87" action="Cues/trigger-cue-5"/>
+<Binding channel="1" note="88" action="Cues/trigger-cue-6"/>
+<Binding channel="1" note="89" action="Cues/trigger-cue-7"/>
+
+<!-- trigger individual slots using the 8x8 grid buttons -->
+
+<Binding channel="1" note="56" action="Cues/trigger-slot-0-0"/>
+<Binding channel="1" note="57" action="Cues/trigger-slot-1-0"/>
+<Binding channel="1" note="58" action="Cues/trigger-slot-2-0"/>
+<Binding channel="1" note="59" action="Cues/trigger-slot-3-0"/>
+<Binding channel="1" note="60" action="Cues/trigger-slot-4-0"/>
+<Binding channel="1" note="61" action="Cues/trigger-slot-5-0"/>
+<Binding channel="1" note="62" action="Cues/trigger-slot-6-0"/>
+<Binding channel="1" note="63" action="Cues/trigger-slot-7-0"/>
+
+<Binding channel="1" note="48" action="Cues/trigger-slot-0-1"/>
+<Binding channel="1" note="49" action="Cues/trigger-slot-1-1"/>
+<Binding channel="1" note="50" action="Cues/trigger-slot-2-1"/>
+<Binding channel="1" note="51" action="Cues/trigger-slot-3-1"/>
+<Binding channel="1" note="52" action="Cues/trigger-slot-4-1"/>
+<Binding channel="1" note="53" action="Cues/trigger-slot-5-1"/>
+<Binding channel="1" note="54" action="Cues/trigger-slot-6-1"/>
+<Binding channel="1" note="55" action="Cues/trigger-slot-7-1"/>
+
+<Binding channel="1" note="40" action="Cues/trigger-slot-0-2"/>
+<Binding channel="1" note="41" action="Cues/trigger-slot-1-2"/>
+<Binding channel="1" note="42" action="Cues/trigger-slot-2-2"/>
+<Binding channel="1" note="43" action="Cues/trigger-slot-3-2"/>
+<Binding channel="1" note="44" action="Cues/trigger-slot-4-2"/>
+<Binding channel="1" note="45" action="Cues/trigger-slot-5-2"/>
+<Binding channel="1" note="46" action="Cues/trigger-slot-6-2"/>
+<Binding channel="1" note="47" action="Cues/trigger-slot-7-2"/>
+
+<Binding channel="1" note="32" action="Cues/trigger-slot-0-3"/>
+<Binding channel="1" note="33" action="Cues/trigger-slot-1-3"/>
+<Binding channel="1" note="34" action="Cues/trigger-slot-2-3"/>
+<Binding channel="1" note="35" action="Cues/trigger-slot-3-3"/>
+<Binding channel="1" note="36" action="Cues/trigger-slot-4-3"/>
+<Binding channel="1" note="37" action="Cues/trigger-slot-5-3"/>
+<Binding channel="1" note="38" action="Cues/trigger-slot-6-3"/>
+<Binding channel="1" note="39" action="Cues/trigger-slot-7-3"/>
+
+<Binding channel="1" note="24" action="Cues/trigger-slot-0-4"/>
+<Binding channel="1" note="25" action="Cues/trigger-slot-1-4"/>
+<Binding channel="1" note="26" action="Cues/trigger-slot-2-4"/>
+<Binding channel="1" note="27" action="Cues/trigger-slot-3-4"/>
+<Binding channel="1" note="28" action="Cues/trigger-slot-4-4"/>
+<Binding channel="1" note="29" action="Cues/trigger-slot-5-4"/>
+<Binding channel="1" note="30" action="Cues/trigger-slot-6-4"/>
+<Binding channel="1" note="31" action="Cues/trigger-slot-7-4"/>
+
+<Binding channel="1" note="16" action="Cues/trigger-slot-0-5"/>
+<Binding channel="1" note="17" action="Cues/trigger-slot-1-5"/>
+<Binding channel="1" note="18" action="Cues/trigger-slot-2-5"/>
+<Binding channel="1" note="19" action="Cues/trigger-slot-3-5"/>
+<Binding channel="1" note="20" action="Cues/trigger-slot-4-5"/>
+<Binding channel="1" note="21" action="Cues/trigger-slot-5-5"/>
+<Binding channel="1" note="22" action="Cues/trigger-slot-6-5"/>
+<Binding channel="1" note="23" action="Cues/trigger-slot-7-5"/>
+
+<Binding channel="1" note="8" action="Cues/trigger-slot-0-6"/>
+<Binding channel="1" note="9" action="Cues/trigger-slot-1-6"/>
+<Binding channel="1" note="10" action="Cues/trigger-slot-2-6"/>
+<Binding channel="1" note="11" action="Cues/trigger-slot-3-6"/>
+<Binding channel="1" note="12" action="Cues/trigger-slot-4-6"/>
+<Binding channel="1" note="13" action="Cues/trigger-slot-5-6"/>
+<Binding channel="1" note="14" action="Cues/trigger-slot-6-6"/>
+<Binding channel="1" note="15" action="Cues/trigger-slot-7-6"/>
+
+<Binding channel="1" note="0" action="Cues/trigger-slot-0-7"/>
+<Binding channel="1" note="1" action="Cues/trigger-slot-1-7"/>
+<Binding channel="1" note="2" action="Cues/trigger-slot-2-7"/>
+<Binding channel="1" note="3" action="Cues/trigger-slot-3-7"/>
+<Binding channel="1" note="4" action="Cues/trigger-slot-4-7"/>
+<Binding channel="1" note="5" action="Cues/trigger-slot-5-7"/>
+<Binding channel="1" note="6" action="Cues/trigger-slot-6-7"/>
+<Binding channel="1" note="7" action="Cues/trigger-slot-7-7"/>
+
+<!-- stop cues using the buttons in the bottom row -->
+
+<Binding channel="1" note="64" action="Cues/stop-cues-0-soon"/>
+<Binding channel="1" note="65" action="Cues/stop-cues-1-soon"/>
+<Binding channel="1" note="66" action="Cues/stop-cues-2-soon"/>
+<Binding channel="1" note="67" action="Cues/stop-cues-3-soon"/>
+<Binding channel="1" note="68" action="Cues/stop-cues-4-soon"/>
+<Binding channel="1" note="69" action="Cues/stop-cues-5-soon"/>
+<Binding channel="1" note="70" action="Cues/stop-cues-6-soon"/>
+<Binding channel="1" note="71" action="Cues/stop-cues-7-soon"/>
+
+<!-- stop *all* cues using the SHIFT key -->
+
+<Binding channel="1" note="98" action="Cues/stop-all-cues-soon"/>
+
+</ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_APCmini_mk2.map
+++ b/share/midi_maps/AKAI_APCmini_mk2.map
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="AKAI APC mini mk2">
+
+<!-- Created 2023-07-12 by Albert Gräf. This is for the mk2 version of the
+     controller. -->
+
+<DeviceInfo bank-size="8"/>
+
+<!-- faders 1-9 control 8 channels and the master gain -->
+
+<Binding channel="1" ctl="48"  uri="/route/gain B1"/>
+<Binding channel="1" ctl="49"  uri="/route/gain B2"/>
+<Binding channel="1" ctl="50"  uri="/route/gain B3"/>
+<Binding channel="1" ctl="51"  uri="/route/gain B4"/>
+<Binding channel="1" ctl="52"  uri="/route/gain B5"/>
+<Binding channel="1" ctl="53"  uri="/route/gain B6"/>
+<Binding channel="1" ctl="54"  uri="/route/gain B7"/>
+<Binding channel="1" ctl="55"  uri="/route/gain B8"/>
+<Binding channel="1" ctl="56"  uri="/bus/gain master"/>
+
+<!-- trigger cues in the session view using the scene launch buttons -->
+
+<Binding channel="1" note="112" action="Cues/trigger-cue-0"/>
+<Binding channel="1" note="113" action="Cues/trigger-cue-1"/>
+<Binding channel="1" note="114" action="Cues/trigger-cue-2"/>
+<Binding channel="1" note="115" action="Cues/trigger-cue-3"/>
+<Binding channel="1" note="116" action="Cues/trigger-cue-4"/>
+<Binding channel="1" note="117" action="Cues/trigger-cue-5"/>
+<Binding channel="1" note="118" action="Cues/trigger-cue-6"/>
+<Binding channel="1" note="119" action="Cues/trigger-cue-7"/>
+
+<!-- trigger individual slots using the 8x8 grid buttons -->
+
+<Binding channel="1" note="56" action="Cues/trigger-slot-0-0"/>
+<Binding channel="1" note="57" action="Cues/trigger-slot-1-0"/>
+<Binding channel="1" note="58" action="Cues/trigger-slot-2-0"/>
+<Binding channel="1" note="59" action="Cues/trigger-slot-3-0"/>
+<Binding channel="1" note="60" action="Cues/trigger-slot-4-0"/>
+<Binding channel="1" note="61" action="Cues/trigger-slot-5-0"/>
+<Binding channel="1" note="62" action="Cues/trigger-slot-6-0"/>
+<Binding channel="1" note="63" action="Cues/trigger-slot-7-0"/>
+
+<Binding channel="1" note="48" action="Cues/trigger-slot-0-1"/>
+<Binding channel="1" note="49" action="Cues/trigger-slot-1-1"/>
+<Binding channel="1" note="50" action="Cues/trigger-slot-2-1"/>
+<Binding channel="1" note="51" action="Cues/trigger-slot-3-1"/>
+<Binding channel="1" note="52" action="Cues/trigger-slot-4-1"/>
+<Binding channel="1" note="53" action="Cues/trigger-slot-5-1"/>
+<Binding channel="1" note="54" action="Cues/trigger-slot-6-1"/>
+<Binding channel="1" note="55" action="Cues/trigger-slot-7-1"/>
+
+<Binding channel="1" note="40" action="Cues/trigger-slot-0-2"/>
+<Binding channel="1" note="41" action="Cues/trigger-slot-1-2"/>
+<Binding channel="1" note="42" action="Cues/trigger-slot-2-2"/>
+<Binding channel="1" note="43" action="Cues/trigger-slot-3-2"/>
+<Binding channel="1" note="44" action="Cues/trigger-slot-4-2"/>
+<Binding channel="1" note="45" action="Cues/trigger-slot-5-2"/>
+<Binding channel="1" note="46" action="Cues/trigger-slot-6-2"/>
+<Binding channel="1" note="47" action="Cues/trigger-slot-7-2"/>
+
+<Binding channel="1" note="32" action="Cues/trigger-slot-0-3"/>
+<Binding channel="1" note="33" action="Cues/trigger-slot-1-3"/>
+<Binding channel="1" note="34" action="Cues/trigger-slot-2-3"/>
+<Binding channel="1" note="35" action="Cues/trigger-slot-3-3"/>
+<Binding channel="1" note="36" action="Cues/trigger-slot-4-3"/>
+<Binding channel="1" note="37" action="Cues/trigger-slot-5-3"/>
+<Binding channel="1" note="38" action="Cues/trigger-slot-6-3"/>
+<Binding channel="1" note="39" action="Cues/trigger-slot-7-3"/>
+
+<Binding channel="1" note="24" action="Cues/trigger-slot-0-4"/>
+<Binding channel="1" note="25" action="Cues/trigger-slot-1-4"/>
+<Binding channel="1" note="26" action="Cues/trigger-slot-2-4"/>
+<Binding channel="1" note="27" action="Cues/trigger-slot-3-4"/>
+<Binding channel="1" note="28" action="Cues/trigger-slot-4-4"/>
+<Binding channel="1" note="29" action="Cues/trigger-slot-5-4"/>
+<Binding channel="1" note="30" action="Cues/trigger-slot-6-4"/>
+<Binding channel="1" note="31" action="Cues/trigger-slot-7-4"/>
+
+<Binding channel="1" note="16" action="Cues/trigger-slot-0-5"/>
+<Binding channel="1" note="17" action="Cues/trigger-slot-1-5"/>
+<Binding channel="1" note="18" action="Cues/trigger-slot-2-5"/>
+<Binding channel="1" note="19" action="Cues/trigger-slot-3-5"/>
+<Binding channel="1" note="20" action="Cues/trigger-slot-4-5"/>
+<Binding channel="1" note="21" action="Cues/trigger-slot-5-5"/>
+<Binding channel="1" note="22" action="Cues/trigger-slot-6-5"/>
+<Binding channel="1" note="23" action="Cues/trigger-slot-7-5"/>
+
+<Binding channel="1" note="8" action="Cues/trigger-slot-0-6"/>
+<Binding channel="1" note="9" action="Cues/trigger-slot-1-6"/>
+<Binding channel="1" note="10" action="Cues/trigger-slot-2-6"/>
+<Binding channel="1" note="11" action="Cues/trigger-slot-3-6"/>
+<Binding channel="1" note="12" action="Cues/trigger-slot-4-6"/>
+<Binding channel="1" note="13" action="Cues/trigger-slot-5-6"/>
+<Binding channel="1" note="14" action="Cues/trigger-slot-6-6"/>
+<Binding channel="1" note="15" action="Cues/trigger-slot-7-6"/>
+
+<Binding channel="1" note="0" action="Cues/trigger-slot-0-7"/>
+<Binding channel="1" note="1" action="Cues/trigger-slot-1-7"/>
+<Binding channel="1" note="2" action="Cues/trigger-slot-2-7"/>
+<Binding channel="1" note="3" action="Cues/trigger-slot-3-7"/>
+<Binding channel="1" note="4" action="Cues/trigger-slot-4-7"/>
+<Binding channel="1" note="5" action="Cues/trigger-slot-5-7"/>
+<Binding channel="1" note="6" action="Cues/trigger-slot-6-7"/>
+<Binding channel="1" note="7" action="Cues/trigger-slot-7-7"/>
+
+<!-- stop cues using the buttons in the bottom row -->
+
+<Binding channel="1" note="100" action="Cues/stop-cues-0-soon"/>
+<Binding channel="1" note="101" action="Cues/stop-cues-1-soon"/>
+<Binding channel="1" note="102" action="Cues/stop-cues-2-soon"/>
+<Binding channel="1" note="103" action="Cues/stop-cues-3-soon"/>
+<Binding channel="1" note="104" action="Cues/stop-cues-4-soon"/>
+<Binding channel="1" note="105" action="Cues/stop-cues-5-soon"/>
+<Binding channel="1" note="106" action="Cues/stop-cues-6-soon"/>
+<Binding channel="1" note="107" action="Cues/stop-cues-7-soon"/>
+
+<!-- stop *all* cues using the SHIFT key -->
+
+<Binding channel="1" note="122" action="Cues/stop-all-cues-soon"/>
+
+</ArdourMIDIBindings>

--- a/share/midi_maps/AKAI_MPKminiplus.map
+++ b/share/midi_maps/AKAI_MPKminiplus.map
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ArdourMIDIBindings version="1.0.0" name="AKAI MPK miniplus">
+
+<!-- Created 2023-07-12 by Albert Gräf. This assumes the default factory
+     settings, otherwise you may have to adjust the controller numbers. The
+     map should also work with the MPK mini (which lacks the transport control
+     buttons, so that functionality won't be available, but the encoders
+     should work the same). -->
+
+<DeviceInfo bank-size="8"/>
+
+<!-- Transport Control (uncomment Rewind/Forward if you need those, otherwise we abuse them for bank switches below) -->
+
+<!--
+<Binding channel="1" ctl="115" action="Transport/Rewind"/>
+<Binding channel="1" ctl="116" action="Transport/Forward"/>
+-->
+<Binding channel="1" ctl="117" function="transport-stop"/>
+<Binding channel="1" ctl="118" function="transport-roll"/>
+<Binding channel="1" ctl="119" function="toggle-rec-enable"/>
+
+<!-- Gain controls -->
+
+<Binding channel="1" ctl="70" uri="/route/gain B1"/>
+<Binding channel="1" ctl="71" uri="/route/gain B2"/>
+<Binding channel="1" ctl="72" uri="/route/gain B3"/>
+<Binding channel="1" ctl="73" uri="/route/gain B4"/>
+<Binding channel="1" ctl="74" uri="/route/gain B5"/>
+<Binding channel="1" ctl="75" uri="/route/gain B6"/>
+<Binding channel="1" ctl="76" uri="/route/gain B7"/>
+<Binding channel="1" ctl="77" uri="/route/gain B8"/>
+<!-- <Binding channel="1" ctl="7" uri="/bus/gain master"/> -->
+
+<!-- Bank Control (the MPK doesn't have those, use the Rewind/Forward buttons instead) -->
+
+<Binding channel="1" ctl="115" function="prev-bank"/>
+<Binding channel="1" ctl="116" function="next-bank"/>
+
+</ArdourMIDIBindings>


### PR DESCRIPTION
Some binding maps for these popular controllers. There are two different variants for the APC mini (the new mk2 version of the device uses different note numbers for the scene and track buttons). The MPK miniplus map will also work with the original MPK mini.