### PR TITLE
Fix #9421: F7 tied to velocity 96 which is not an option in the velocity drop down

### DIFF
--- a/gtk2_ardour/virtual_keyboard_window.cc
+++ b/gtk2_ardour/virtual_keyboard_window.cc
@@ -74,6 +74,7 @@ VirtualKeyboardWindow::VirtualKeyboardWindow ()
 	_piano_velocity.append_text_item ("32");
 	_piano_velocity.append_text_item ("64");
 	_piano_velocity.append_text_item ("82");
+	_piano_velocity.append_text_item ("96");
 	_piano_velocity.append_text_item ("100");
 	_piano_velocity.append_text_item ("127");
 #endif


### PR DESCRIPTION
This fixes [Mantis 9421](https://tracker.ardour.org/view.php?id=9421)

# Issue
Switching velocity in the virtual keyboard via the F(5-8) does not work when trying to go from F7 to F8, once F8 has been selected. Specifically trying to go F5 (32), F6 (64), F7 (96), F8 (127), in that order works. However, going back to F7 (96), and then attempting to go to F8 (127), leaves the actual velocity at 96 instead of 127. The reason for this is in `ArdourDropdown::set_active` which iterates through the menu items and 96 is not an available option.

# Fix
The fix is to add '96' to the menu items.
