### PR TITLE
Windows build tweaks

### DIFF
--- a/tools/x-win/compile.sh
+++ b/tools/x-win/compile.sh
@@ -25,7 +25,7 @@ fi
 
 if test -z "${ARDOURCFG}"; then
 	if test -f ${PREFIX}/include/pa_asio.h; then
-		ARDOURCFG="--windows-vst --with-backends=jack,dummy,wavesaudio"
+		ARDOURCFG="--windows-vst --with-backends=jack,dummy,portaudio"
 	else
 		ARDOURCFG="--windows-vst --with-backends=jack,dummy"
 	fi

--- a/tools/x-win/package.sh
+++ b/tools/x-win/package.sh
@@ -91,7 +91,7 @@ fi
 export SRCCACHE
 
 if [ "$(id -u)" = "0" ]; then
-	apt-get -y install nsis curl wget
+	apt-get -y install nsis curl wget ca-certificates rsync zip unzip
 fi
 
 

--- a/tools/x-win/package.sh
+++ b/tools/x-win/package.sh
@@ -33,6 +33,7 @@ PRODUCT_VERSION=${major_version}
 WITH_HARRISON_LV2=1 ;
 WITH_COMMERCIAL_X42_LV2=
 WITH_GRATIS_X42_LV2=
+QUICKZIP=1
 
 # TODO: grep from build/config.log instead
 while [ $# -gt 0 ] ; do


### PR DESCRIPTION
This PR contains a set of changes I had to make to the build tooling to enable compilation of Ardour 7.5 for Windows.

Of note, the script was referencing the old wavesaudio backend. I've replaced it with the portaudio backend.

Also, in the cowbuilder environment we were missing a few packages for successful packaging:
 * `ca-certificates`, for the calls to `curl`
 * `rsync` to copy some assets
 * `zip`/`unzip` for file extraction