### PR TITLE
Fix compile error introduced in rev. 7c029f5f.

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -3672,6 +3672,8 @@ Editor::begin_reversible_selection_op (string name)
 	}
 }
 
+#include "pbd/stacktrace.h"
+
 void
 Editor::abort_reversible_selection_op ()
 {
@@ -3789,8 +3791,6 @@ Editor::abort_reversible_command ()
 		_session->abort_reversible_command ();
 	}
 }
-
-#include "pbd/stacktrace.h"
 
 void
 Editor::commit_reversible_command ()


### PR DESCRIPTION
The new call of `PBD::stacktrace()` in rev. 7c029f5f trips a compile error (at least here on Arch Linux with gcc (GCC) 13.2.1 20230801), move the `#include "pbd/stacktrace.h"` in editor.cc up to avoid it.