### PR TITLE
Use <atomic> instead of <stdatomic.h> in libc++ fix

### DIFF
--- a/libs/vst3/pluginterfaces/base/funknown.cpp
+++ b/libs/vst3/pluginterfaces/base/funknown.cpp
@@ -44,9 +44,9 @@
 #endif
 
 #if SMTG_OS_LINUX
-#if !defined (SMTG_USE_STDATOMIC_H)
+#if !defined (SMTG_USE_ATOMIC)
 #if defined (_LIBCPP_VERSION)
-#define SMTG_USE_STDATOMIC_H 1
+#define SMTG_USE_ATOMIC 1
 #else
 #include <ext/atomicity.h>
 #endif
@@ -57,8 +57,8 @@
 #include <boost/uuid/uuid_generators.hpp>
 #endif
 
-#if defined (SMTG_USE_STDATOMIC_H) && SMTG_USE_STDATOMIC_H
-#include <stdatomic.h>
+#if defined (SMTG_USE_ATOMIC) && SMTG_USE_ATOMIC
+#include <atomic>
 #endif
 
 namespace Steinberg {
@@ -89,8 +89,8 @@ namespace FUnknownPrivate {
 //------------------------------------------------------------------------
 int32 PLUGIN_API atomicAdd (int32& var, int32 d)
 {
-#if SMTG_USE_STDATOMIC_H
-	return atomic_fetch_add (reinterpret_cast<atomic_int_least32_t*> (&var), d) +d;
+#if SMTG_USE_ATOMIC
+	return atomic_fetch_add (reinterpret_cast<std::atomic_int_least32_t*> (&var), d) +d;
 #elif SMTG_OS_WINDOWS
 	return InterlockedExchangeAdd ((volatile long int*)&var, d) + d;
 #elif SMTG_OS_MACOS


### PR DESCRIPTION
The definitions from <stdatomic.h> conflict with <atomic>, which causes a build failure since <atomic> is included previously.

Follow up to https://github.com/Ardour/ardour/pull/822.