### PR TITLE
Fix ardour not loading Moog Subsequence 37 midnam

### DIFF
--- a/share/patchfiles/Moog_Subsequent_37.midnam
+++ b/share/patchfiles/Moog_Subsequent_37.midnam
@@ -47,7 +47,7 @@
       <UsesControlNameList Name="Controls"/>
       <PatchBank Name="Factory Presets">
         <!-- Placeholder for future content -->
-        <UsesPatchNameList Name="Factory Preset Names"/>
+        <!-- <UsesPatchNameList Name="Factory Preset Names"/> -->
       </PatchBank>
     </ChannelNameSet>
     <ValueNameList Name="Switch">


### PR DESCRIPTION
Realized ardour was not loading the midnam config as expected.
This ensures it does.