### PR TITLE
Clean init process to prevent exceptions

### DIFF
--- a/libs/surfaces/console1/wscript
+++ b/libs/surfaces/console1/wscript
@@ -22,7 +22,7 @@ def build(bld):
     obj.includes     = [ '.', './console1']
     obj.name         = 'libardour_console1'
     obj.target       = 'ardour_console1'
-    obj.uselib       = 'SIGCPP XML OSX'
+    obj.uselib       = 'GTKMM SIGCPP XML OSX'
     obj.use          = 'libardour libardour_cp libardour_midisurface libgtkmm2ext libpbd libevoral libtemporal'
     obj.install_path = os.path.join(bld.env['LIBDIR'], 'surfaces')
 


### PR DESCRIPTION
As suggested by Robin I have moved nearly all initialization to "start_using_device" and remove all connections in "stop_using_device".
In addition I prevent updates when not connected. (And did some proper formatting...)