### PR TITLE
LUA EditorAction script to reverse MIDI notes and regions

### DIFF
--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -50,7 +50,6 @@ function factory () return function ()
 		local rend = rstart + rlength
 
 		-- Iterate over all notes of the MIDI region and reverse them
-		-- TODO: make sure it works for regions with hidden notes
 		local mm = mr:midi_source(0):model ()
 		local midi_command = mm:new_note_diff_command ("Reverse MIDI Events")
 		for note in ARDOUR.LuaAPI.note_list (mm):iter () do

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -5,32 +5,25 @@ ardour { ["type"] = "EditorAction", name = "Reverse MIDI events",
 }
 
 function factory () return function ()
-	print ("Reverse MIDI regions, man!")
+	print ("Reverse MIDI regions")
 	-- Reverse all selected MIDI regions
 	local sel = Editor:get_selection ()
 	for r in sel.regions:regionlist ():iter () do
-		print ("Iterating through selected regions baby!")
+		-- Get start and length of MIDI region
 		local mr = r:to_midiregion ()
 		if mr:isnil () then goto next end
+		start = mr:start ():beats ()
+		length = mr:length ():beats ()
 
-		print ("mr =", mr, ", mr:position () =", mr:position ())
+		-- Iterate over all notes of the MIDI region and reverse them
+		-- TODO: make sure it works for regions with hidden notes
 		local mm = mr:midi_source(0):model ()
-		print ("mm =", mm)
-		-- Look for NotePtr in luabindings.cc
-		
-		-- -- get list of MIDI-CC events for the given channel and parameter
-		-- local ec = mr:control (Evoral.Parameter (ARDOUR.AutomationType.MidiCCAutomation, midi_channel, cc_param), false)
-		-- if ec:isnil () then goto next end
-		-- if ec:list ():events ():size () == 0 then goto next end
+		for note in ARDOUR.LuaAPI.note_list (mm):iter () do
+			local new_time = start + start + length - note:time () - note:length ()
+			print ("new_time =", new_time)
+		end
 
-		-- -- iterate over CC-events
-		-- for av in ec:list ():events ():iter () do
-		-- 	-- re-scale event to target range
-		-- 	local val = pd.lower + (pd.upper - pd.lower) * av.value / 127
-		-- 	-- and add it to the target-parameter automation-list
-		-- 	al:add (r:position () - r:start () + av.when, val, false, true)
-		-- 	add_undo = true
-		-- end
+		-- TODO: support other MIDI events
 		::next::
 	end
 

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -8,8 +8,7 @@ function factory () return function ()
 	-- Calculate the minimal position and the maximum length of the
 	-- selection, ignoring non-MIDI region.
 	local sel = Editor:get_selection ()
-	-- local sel_position = Temporal.timepos_t.max (TimeDomain.BeatTime)
-	local sel_position = Temporal.timepos_t (9000000)
+	local sel_position = Temporal.timepos_t.max (Temporal.TimeDomain.BeatTime)
 	local sel_end = Temporal.timepos_t.zero ()
 	for r in sel.regions:regionlist ():iter () do
 		-- Skip non-MIDI region

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -5,16 +5,17 @@ ardour { ["type"] = "EditorAction", name = "Reverse MIDI events",
 }
 
 function factory () return function ()
-	print("Reverse MIDI regions, man!")
+	print ("Reverse MIDI regions, man!")
 	-- Reverse all selected MIDI regions
 	local sel = Editor:get_selection ()
 	for r in sel.regions:regionlist ():iter () do
-		print("Iterating through selected regions baby!")
+		print ("Iterating through selected regions baby!")
 		local mr = r:to_midiregion ()
 		if mr:isnil () then goto next end
 
-		print("mr =", mr, ", mr:position () =", mr:position ())
-		local mm = mr:midi_source(0):model()
+		print ("mr =", mr, ", mr:position () =", mr:position ())
+		local mm = mr:midi_source(0):model ()
+		print ("mm =", mm)
 		-- Look for NotePtr in luabindings.cc
 		
 		-- -- get list of MIDI-CC events for the given channel and parameter

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -5,8 +5,32 @@ ardour { ["type"] = "EditorAction", name = "Reverse MIDI Events",
 }
 
 function factory () return function ()
-	-- Reverse all selected MIDI regions
+	-- Calculate the minimal position and the maximum length of the
+	-- selection, ignoring non-MIDI region.
 	local sel = Editor:get_selection ()
+	-- local sel_position = Temporal.timepos_t.max (TimeDomain.BeatTime)
+	local sel_position = Temporal.timepos_t (9000000)
+	local sel_end = Temporal.timepos_t.zero ()
+	for r in sel.regions:regionlist ():iter () do
+		-- local mr = r:to_midiregion ()
+		-- if mr:isnil () then goto next end
+		if r:position () < sel_position then sel_position = r:position () end
+		r_end = r:position () + r:length ()
+		if sel_end < r_end then sel_end = r_end end
+		-- ::next::
+	end
+	local sel_length = sel_end - sel_position
+
+	-- Reverse the order of selected MIDI regions
+	for r in sel.regions:regionlist ():iter () do
+		-- local mr = r:to_midiregion ()
+		-- if mr:isnil () then goto next end
+		local new_position = sel_position + sel_position + sel_length - r:position () - r:length ()
+		r:set_position (new_position)
+		-- ::next::
+	end
+
+	-- Reverse the content inside selected MIDI regions
 	for r in sel.regions:regionlist ():iter () do
 		-- Get start and length of MIDI region
 		local mr = r:to_midiregion ()

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -1,0 +1,54 @@
+ardour { ["type"] = "EditorAction", name = "Reverse MIDI events",
+	license     = "MIT",
+	author      = "Nil Geisweiller",
+	description = [[Reverse MIDI events of selected MIDI regions, so that events at the end appear at the beginning and so on.  Reverse the order of MIDI regions as well, so that MIDI regions at the end appear at the beginning and so on.  Reverse individual notes as well, so the ending of a note corresponds to its beginning.  Thus, for this effect to yeld good results, the notes should rather be quantized.]]
+}
+
+function factory () return function ()
+	print("Reverse MIDI regions, man!")
+	-- Reverse all selected MIDI regions
+	local sel = Editor:get_selection ()
+	for r in sel.regions:regionlist ():iter () do
+		print("Iterating through selected regions baby!")
+		local mr = r:to_midiregion ()
+		if mr:isnil () then goto next end
+
+		print("mr =", mr, ", mr:position () =", mr:position ())
+		local mm = mr:midi_source(0):model()
+		-- Look for NotePtr in luabindings.cc
+		
+		-- -- get list of MIDI-CC events for the given channel and parameter
+		-- local ec = mr:control (Evoral.Parameter (ARDOUR.AutomationType.MidiCCAutomation, midi_channel, cc_param), false)
+		-- if ec:isnil () then goto next end
+		-- if ec:list ():events ():size () == 0 then goto next end
+
+		-- -- iterate over CC-events
+		-- for av in ec:list ():events ():iter () do
+		-- 	-- re-scale event to target range
+		-- 	local val = pd.lower + (pd.upper - pd.lower) * av.value / 127
+		-- 	-- and add it to the target-parameter automation-list
+		-- 	al:add (r:position () - r:start () + av.when, val, false, true)
+		-- 	add_undo = true
+		-- end
+		::next::
+	end
+
+	-- -- save undo
+	-- if add_undo then
+	-- 	local after = al:get_state ()
+	-- 	Session:add_command (al:memento_command (before, after))
+	-- 	Session:commit_reversible_command (nil)
+	-- else
+	-- 	Session:abort_reversible_command ()
+	-- 	LuaDialog.Message ("Reverse MIDI events", "No event was reversed, was any non-empty region selected?", LuaDialog.MessageType.Info, LuaDialog.ButtonType.Close):run ()
+	-- end
+end end
+
+function icon (params) return function (ctx, width, height, fg)
+	local txt = Cairo.PangoLayout (ctx, "ArdourMono ".. math.ceil (height / 3) .. "px")
+	txt:set_text ("Rev")
+	local tw, th = txt:get_pixel_size ()
+	ctx:set_source_rgba (ARDOUR.LuaAPI.color_to_rgba (fg))
+	ctx:move_to (.5 * (width - tw), .5 * (height - th))
+	txt:show_in_cairo_context (ctx)
+end end

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -12,29 +12,39 @@ function factory () return function ()
 	local sel_position = Temporal.timepos_t (9000000)
 	local sel_end = Temporal.timepos_t.zero ()
 	for r in sel.regions:regionlist ():iter () do
-		-- local mr = r:to_midiregion ()
-		-- if mr:isnil () then goto next end
+		-- Skip non-MIDI region
+		local mr = r:to_midiregion ()
+		if mr:isnil () then goto continue1 end
+
+		-- Update sel_position and sel_end
 		if r:position () < sel_position then sel_position = r:position () end
-		r_end = r:position () + r:length ()
+		local r_end = r:position () + r:length ()
 		if sel_end < r_end then sel_end = r_end end
-		-- ::next::
+
+		::continue1::
 	end
 	local sel_length = sel_end - sel_position
 
 	-- Reverse the order of selected MIDI regions
 	for r in sel.regions:regionlist ():iter () do
-		-- local mr = r:to_midiregion ()
-		-- if mr:isnil () then goto next end
+		-- Skip non-MIDI region
+		local mr = r:to_midiregion ()
+		if mr:isnil () then goto continue2 end
+
+		-- Reverse region position
 		local new_position = sel_position + sel_position + sel_length - r:position () - r:length ()
 		r:set_position (new_position)
-		-- ::next::
+
+		::continue2::
 	end
 
 	-- Reverse the content inside selected MIDI regions
 	for r in sel.regions:regionlist ():iter () do
-		-- Get start and length of MIDI region
+		-- Skip non-MIDI region
 		local mr = r:to_midiregion ()
-		if mr:isnil () then goto next end
+		if mr:isnil () then goto continue3 end
+
+		-- Get start and length of MIDI region
 		start = mr:start ():beats ()
 		length = mr:length ():beats ()
 
@@ -51,7 +61,7 @@ function factory () return function ()
 		mm:apply_command (Session, midi_command)
 
 		-- TODO: support other MIDI events
-		::next::
+		::continue3::
 	end
 end end
 

--- a/share/scripts/reverse_midi.lua
+++ b/share/scripts/reverse_midi.lua
@@ -1,7 +1,7 @@
 ardour { ["type"] = "EditorAction", name = "Reverse MIDI Events",
 	license     = "MIT",
 	author      = "Nil Geisweiller",
-	description = [[Reverse MIDI events of selected MIDI regions, so that events at the end appear at the beginning and so on.  Reverse the order of MIDI regions as well, so that MIDI regions at the end appear at the beginning and so on.  Reverse individual notes as well, so the ending of a note corresponds to its beginning.  Thus the notes should rather be quantized for this effect to yeld good results.  Note that track automations are not reversed, only region automations are.]]
+	description = [[Chronologically reverse MIDI notes of selected MIDI regions.  The positions of the MIDI regions are reversed as well, meaning regions at the end appear at the beginning and so on.  Individual notes are reversed so the ending of a note corresponds to its beginning.  Thus notes should be quantized for this effect to yield good results.  Note that only MIDI notes are reversed.  Other MIDI events such as CC or SYSEX are left unchanged.]]
 }
 
 function factory () return function ()


### PR DESCRIPTION
## Description

LUA EditorAction script to chronologically reverse MIDI notes of selected MIDI regions, alongside MIDI region positions.

* The positions of the MIDI regions are reversed as well, meaning regions at the end appear at the beginning and so on.
* Individual notes are reversed so the ending of a note corresponds to its beginning.  Thus notes should be quantized for this effect to yield good results.
* Note that only MIDI notes are reversed.  Other MIDI events such as CC or SYSEX are left unchanged.