### PR TITLE
Fix failure to build with libxml2 version 2.12

### DIFF
--- a/gtk2_ardour/ardour_ui.cc
+++ b/gtk2_ardour/ardour_ui.cc
@@ -255,7 +255,7 @@ libxml_generic_error_func (void* /* parsing_context*/,
 
 static void
 libxml_structured_error_func (void* /* parsing_context*/,
-                              xmlErrorPtr err)
+                              const xmlError *err)
 {
 	string msg;
 
@@ -403,7 +403,11 @@ ARDOUR_UI::ARDOUR_UI (int *argcp, char **argvp[], const char* localedir)
 	/* stop libxml from spewing to stdout/stderr */
 
 	xmlSetGenericErrorFunc (this, libxml_generic_error_func);
-	xmlSetStructuredErrorFunc (this, libxml_structured_error_func);
+
+	/* Cast to xmlStructuredErrorFunc to cope with different constness in different
+	 * versions of libxml2. */
+
+	xmlSetStructuredErrorFunc (this, (xmlStructuredErrorFunc)libxml_structured_error_func);
 
 	/* Set this up early */
 

--- a/libs/pbd/xml++.cc
+++ b/libs/pbd/xml++.cc
@@ -170,7 +170,7 @@ XMLTree::write() const
 	result = xmlSaveFormatFileEnc(_filename.c_str(), doc, "UTF-8", 1);
 #ifndef NDEBUG
 	if (result == -1) {
-		xmlErrorPtr xerr = xmlGetLastError ();
+		const xmlError *xerr = xmlGetLastError ();
 		if (!xerr) {
 			std::cerr << "unknown XML error during xmlSaveFormatFileEnc()." << std::endl;
 		} else {


### PR DESCRIPTION
This made one argument of xmlStructuredErrorFunc() const, which wasn’t previously so.