### PR TITLE
Fix incorrect variable mistake

### DIFF
--- a/gtk2_ardour/mixer_strip.cc
+++ b/gtk2_ardour/mixer_strip.cc
@@ -195,7 +195,7 @@ MixerStrip::init ()
 	}
 
 	width_button.set_icon (ArdourIcon::StripWidth);
-	hide_button.set_tweaks (ArdourButton::Square);
+	width_button.set_tweaks (ArdourButton::Square);
 	set_tooltip (width_button, t);
 
 	hide_button.set_icon (ArdourIcon::HideEye);


### PR DESCRIPTION
Was poking around `mixer_strip.cc`, trying to hide the gain meters and found what I assume was a type/mistake: `hide_button` was used when `width_button` should've been