### PR TITLE
Minor UI tweaks without structural changes

### DIFF
--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -282,7 +282,7 @@ style "inspector_processor_list" = "processor_list"
 
 style "time_info_box"
 {
-        bg[NORMAL] = { 0.00, 0.00, 0.00 }
+        bg[NORMAL] = @darkest
 }
 
 style "status_bar_box"

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -998,8 +998,7 @@ style "paler_bright_when_active" = "medium_text"
 
 style "selected_strip_frame"
 {
-	fg[NORMAL] = @bright_indicator
-	bg[NORMAL] = darker(@bright_indicator)
+	bg[NORMAL] = @bright_indicator
 }
 
 style "flashing_alert" = "very_small_text"

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -967,6 +967,12 @@ style "processor_list" = "very_small_text"
 	bg[ACTIVE] = shade (1.8, @fg_selected)
 	fg[ACTIVE] = @bases
 }
+style "processor_scroller"
+{
+	bg[ACTIVE] = @bases
+	ythickness = 1
+	xthickness = 0
+}
 
 # MixerPanZone:
 #
@@ -1255,6 +1261,7 @@ widget "*LocationEditRemoveButton*" style:highest "location_row_button"
 widget "*ChannelCountSelector" style:highest "medium_bold_entry"
 widget "*RegionListWholeFile" style:highest "treeview_parent_node"
 widget "*ProcessorList*" style:highest "processor_list"
+widget "*ProcessorScroller*" style:highest "processor_scroller"
 widget "*PortMatrixLabel*" style:highest "small_text"
 widget "*MainMenuBar" style:highest "status_bar_box"
 widget "*midi device" style:highest "midi_device"

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -897,7 +897,7 @@ style "track_name_editor" = "medium_text"
 
 style "track_separator"
 {
-	bg[NORMAL] = lighter(@background)
+	bg[NORMAL] = darker(@background)
 }
 
 # Plugin Editors

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -1051,6 +1051,7 @@ style "tooltip" = "medium_text"
 {
 	fg[NORMAL] = @fg_tooltip
 	bg[NORMAL] = @bg_tooltip
+	bg[SELECTED] = @bg_tooltip
 }
 
 style "default_toggle_button"

--- a/gtk2_ardour/editor_rulers.cc
+++ b/gtk2_ardour/editor_rulers.cc
@@ -717,8 +717,7 @@ Editor::update_ruler_visibility ()
 	}
 
 	ruler_separator->set_y_position ((int)(timebar_height * visible_timebars));
-
-	time_bars_vbox.set_size_request (-1, (int)(timebar_height * visible_timebars) + 1);
+	time_bars_vbox.set_size_request (-1, (int)(timebar_height * visible_timebars));
 
 	/* move hv_scroll_group (trackviews) to the end of the timebars */
 

--- a/gtk2_ardour/editor_rulers.cc
+++ b/gtk2_ardour/editor_rulers.cc
@@ -716,12 +716,13 @@ Editor::update_ruler_visibility ()
 		_selection_marker_group->hide ();
 	}
 
-	ruler_separator->set_y_position ((int)(timebar_height * visible_timebars));
-	time_bars_vbox.set_size_request (-1, (int)(timebar_height * visible_timebars));
+	int ruler_separator_y = std::max(1, (int)(timebar_height * visible_timebars));
+	ruler_separator->set_y_position (ruler_separator_y);
+	time_bars_vbox.set_size_request (-1, ruler_separator_y);
 
 	/* move hv_scroll_group (trackviews) to the end of the timebars */
 
-	hv_scroll_group->set_y_position ((int)(timebar_height * visible_timebars));
+	hv_scroll_group->set_y_position (ruler_separator_y);
 
 	compute_fixed_ruler_scale ();
 	update_fixed_rulers();

--- a/gtk2_ardour/foldback_strip.cc
+++ b/gtk2_ardour/foldback_strip.cc
@@ -510,7 +510,7 @@ FoldbackStrip::init ()
 		scrollbar.ensure_style ();
 		Gtk::Requisition requisition (scrollbar.size_request ());
 		scrollbar_height = requisition.height;
-		scrollbar_height += 3; // track_display_frame border/shadow
+		scrollbar_height -= 1;
 	}
 	_spacer.set_size_request (-1, scrollbar_height);
 	_global_vpacker.pack_end (_spacer, false, false);

--- a/gtk2_ardour/mixer_strip.cc
+++ b/gtk2_ardour/mixer_strip.cc
@@ -355,7 +355,7 @@ MixerStrip::init ()
 		scrollbar.ensure_style();
 		Gtk::Requisition requisition(scrollbar.size_request ());
 		scrollbar_height = requisition.height;
-		scrollbar_height += 3; // track_display_frame border/shadow
+		scrollbar_height -= 1;
 	}
 	spacer.set_size_request (-1, scrollbar_height);
 	spacer.set_name ("AudioBusStripBase");

--- a/gtk2_ardour/mixer_strip.cc
+++ b/gtk2_ardour/mixer_strip.cc
@@ -358,6 +358,7 @@ MixerStrip::init ()
 		scrollbar_height += 3; // track_display_frame border/shadow
 	}
 	spacer.set_size_request (-1, scrollbar_height);
+	spacer.set_name ("AudioBusStripBase");
 	global_vpacker.pack_end (spacer, false, false);
 #endif
 

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -414,6 +414,12 @@ Mixer_UI::Mixer_UI ()
 	group_display.show();
 	favorite_plugins_display.show();
 
+	// Remove strip scrollers shadow
+	Gtk::Viewport* pViewport = (Gtk::Viewport*) scroller.get_child();
+	pViewport->set_shadow_type(Gtk::SHADOW_NONE);
+	pViewport = (Gtk::Viewport*) vca_scroller.get_child();
+	pViewport->set_shadow_type(Gtk::SHADOW_NONE);
+
 	XMLNode* mnode = ARDOUR_UI::instance()->tearoff_settings (X_("monitor-section"));
 	if (mnode) {
 		_monitor_section.tearoff().set_state (*mnode);

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -343,8 +343,9 @@ Mixer_UI::Mixer_UI ()
 	_mixer_scene_frame.add(_mixer_scene_vbox);
 	list_vpacker.pack_start (_mixer_scene_frame, false, false);
 
-	vca_label_bar.set_size_request (-1, 16 + 1); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
+	vca_label_bar.set_size_request (-1, 16); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
 	vca_vpacker.pack_start (vca_label_bar, false, false);
+	vca_label_bar.set_name("VCALabelBar");
 
 	vca_scroller_base.add_events (Gdk::BUTTON_PRESS_MASK|Gdk::BUTTON_RELEASE_MASK);
 	vca_scroller_base.set_name (X_("MixerWindow"));

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -343,7 +343,7 @@ Mixer_UI::Mixer_UI ()
 	_mixer_scene_frame.add(_mixer_scene_vbox);
 	list_vpacker.pack_start (_mixer_scene_frame, false, false);
 
-	vca_label_bar.set_size_request (-1, PX_SCALE(16)); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
+	vca_label_bar.set_size_request (-1, PX_SCALE(16) + 1); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
 	vca_vpacker.pack_start (vca_label_bar, false, false);
 	vca_label_bar.set_name("VCALabelBar");
 

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -343,7 +343,7 @@ Mixer_UI::Mixer_UI ()
 	_mixer_scene_frame.add(_mixer_scene_vbox);
 	list_vpacker.pack_start (_mixer_scene_frame, false, false);
 
-	vca_label_bar.set_size_request (-1, PX_SCALE(16) + 1); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
+	vca_label_bar.set_size_request (-1, PX_SCALE(16)); /* must match height in GroupTabs::set_size_request()*/
 	vca_vpacker.pack_start (vca_label_bar, false, false);
 	vca_label_bar.set_name("VCALabelBar");
 

--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -343,7 +343,7 @@ Mixer_UI::Mixer_UI ()
 	_mixer_scene_frame.add(_mixer_scene_vbox);
 	list_vpacker.pack_start (_mixer_scene_frame, false, false);
 
-	vca_label_bar.set_size_request (-1, 16); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
+	vca_label_bar.set_size_request (-1, PX_SCALE(16)); /* must match height in GroupTabs::set_size_request()  + 1 border px*/
 	vca_vpacker.pack_start (vca_label_bar, false, false);
 	vca_label_bar.set_name("VCALabelBar");
 

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -1960,6 +1960,7 @@ ProcessorBox::ProcessorBox (ARDOUR::Session* sess, boost::function<PluginSelecto
 	no_processor_redisplay = false;
 
 	processor_scroller.set_policy (Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
+	processor_scroller.set_name ("ProcessorScroller");
 	processor_scroller.add (processor_display);
 	pack_start (processor_scroller, true, true);
 

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -1863,7 +1863,8 @@ ProcessorEntry::PluginInlineDisplay::update_height_alloc (uint32_t inline_height
 void
 ProcessorEntry::PluginInlineDisplay::display_frame (cairo_t* cr, double w, double h)
 {
-	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, w - 1, h + 1, 7);
+	Gtkmm2ext::rounded_rectangle (cr, 1.5, -0.5, w - 3, h - 1.0, 2.5);
+
 }
 
 ProcessorEntry::LuaPluginDisplay::LuaPluginDisplay (ProcessorEntry& e, std::shared_ptr<ARDOUR::LuaProc> p, uint32_t max_height)

--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -200,6 +200,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -91,6 +91,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -111,6 +111,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="neutral:foreground2"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="neutral:foreground2"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -94,6 +94,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -114,6 +114,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -203,6 +203,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/diehard3-ardour.colors
+++ b/gtk2_ardour/themes/diehard3-ardour.colors
@@ -93,6 +93,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/diehard3-ardour.colors
+++ b/gtk2_ardour/themes/diehard3-ardour.colors
@@ -113,6 +113,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/diehard3-ardour.colors
+++ b/gtk2_ardour/themes/diehard3-ardour.colors
@@ -202,6 +202,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/recbox-ardour.colors
+++ b/gtk2_ardour/themes/recbox-ardour.colors
@@ -202,6 +202,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:background"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/recbox-ardour.colors
+++ b/gtk2_ardour/themes/recbox-ardour.colors
@@ -113,6 +113,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:background"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/recbox-ardour.colors
+++ b/gtk2_ardour/themes/recbox-ardour.colors
@@ -93,6 +93,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:background"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -111,6 +111,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:blue"/>
+    <ColorAlias name="generic button: outline" alias="neutral:background"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -200,6 +200,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:background"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -91,6 +91,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:background"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="theme:bg2"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="theme:bg2"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:midground"/>

--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="theme:bg2"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/time_axis_view.cc
+++ b/gtk2_ardour/time_axis_view.cc
@@ -788,13 +788,11 @@ TimeAxisView::set_selected (bool yn)
 	AxisView::set_selected (yn);
 
 	if (_selected) {
-		time_axis_frame.set_shadow_type (Gtk::SHADOW_IN);
-		time_axis_frame.set_name ("MixerStripSelectedFrame");
+		time_axis_frame.set_name (controls_base_selected_name);
 		controls_ebox.set_name (controls_base_selected_name);
 		controls_vbox.set_name (controls_base_selected_name);
 		time_axis_vbox.set_name (controls_base_selected_name);
 	} else {
-		time_axis_frame.set_shadow_type (Gtk::SHADOW_NONE);
 		time_axis_frame.set_name (controls_base_unselected_name);
 		controls_ebox.set_name (controls_base_unselected_name);
 		controls_vbox.set_name (controls_base_unselected_name);

--- a/gtk2_ardour/vca_master_strip.cc
+++ b/gtk2_ardour/vca_master_strip.cc
@@ -128,7 +128,7 @@ VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
 	global_vpacker.set_spacing (0);
 	gain_meter.set_spacing(4);
 
-	global_vpacker.pack_start (number_label, false, false, 1);
+	global_vpacker.pack_start (number_label, false, false, 0);
 	global_vpacker.pack_start (hide_button, false, false, 1);
 	global_vpacker.pack_start (vertical_button, true, true, 1);
 	global_vpacker.pack_start (solo_mute_box, false, false, 1);

--- a/gtk2_ardour/vca_master_strip.cc
+++ b/gtk2_ardour/vca_master_strip.cc
@@ -129,7 +129,7 @@ VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
 	vertical_button.set_active_color (_vca->presentation_info().color ());
 	set_tooltip (vertical_button, _("Click to show assigned channels only")); /* tooltip updated dynamically */
 
-	global_vpacker.set_border_width (0);
+	global_vpacker.set_border_width (1);
 	global_vpacker.set_spacing (2);
 	gain_meter.set_spacing(4);
 

--- a/gtk2_ardour/vca_master_strip.cc
+++ b/gtk2_ardour/vca_master_strip.cc
@@ -130,7 +130,7 @@ VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
 	set_tooltip (vertical_button, _("Click to show assigned channels only")); /* tooltip updated dynamically */
 
 	global_vpacker.set_border_width (0);
-	global_vpacker.set_spacing (0);
+	global_vpacker.set_spacing (2);
 	gain_meter.set_spacing(4);
 
 	global_vpacker.pack_start (number_label, Gtk::PACK_SHRINK);

--- a/gtk2_ardour/vca_master_strip.cc
+++ b/gtk2_ardour/vca_master_strip.cc
@@ -51,6 +51,8 @@ using std::string;
 
 PBD::Signal1<void,VCAMasterStrip*> VCAMasterStrip::CatchDeletion;
 
+#define PX_SCALE(px) std::max((float)px, rintf((float)px * UIConfiguration::instance().get_ui_scale()))
+
 static bool no_propagate (GdkEventButton*) { return false; }
 
 VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
@@ -91,6 +93,8 @@ VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
 	mute_button.signal_button_release_event().connect (sigc::mem_fun (*this, &VCAMasterStrip::mute_release), false);
 
 	hide_button.set_icon (ArdourIcon::HideEye);
+	hide_button.set_size_request (-1, PX_SCALE(19));
+	
 	set_tooltip (&hide_button, _("Hide this VCA strip"));
 
 	hide_button.signal_clicked.connect (sigc::mem_fun(*this, &VCAMasterStrip::hide_clicked));
@@ -110,6 +114,7 @@ VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
 	number_label.set_fallthrough_to_parent (true);
 	number_label.set_inactive_color (_vca->presentation_info().color ());
 	number_label.signal_button_release_event().connect (sigc::mem_fun (*this, &VCAMasterStrip::number_button_press), false);
+	number_label.set_size_request (-1, PX_SCALE(19));
 
 	update_bottom_padding ();
 
@@ -128,14 +133,14 @@ VCAMasterStrip::VCAMasterStrip (Session* s, std::shared_ptr<VCA> v)
 	global_vpacker.set_spacing (0);
 	gain_meter.set_spacing(4);
 
-	global_vpacker.pack_start (number_label, false, false, 0);
-	global_vpacker.pack_start (hide_button, false, false, 1);
-	global_vpacker.pack_start (vertical_button, true, true, 1);
-	global_vpacker.pack_start (solo_mute_box, false, false, 1);
-	global_vpacker.pack_start (gain_meter, false, false, 1);
-	global_vpacker.pack_start (control_slave_ui, false, false, 1);
-	global_vpacker.pack_start (gain_meter.gain_automation_state_button, false, false, 1);
-	global_vpacker.pack_start (bottom_padding, false, false, 0);
+	global_vpacker.pack_start (number_label, Gtk::PACK_SHRINK);
+	global_vpacker.pack_start (hide_button, Gtk::PACK_SHRINK);
+	global_vpacker.pack_start (vertical_button, true, true);
+	global_vpacker.pack_start (solo_mute_box, Gtk::PACK_SHRINK);
+	global_vpacker.pack_start (gain_meter, Gtk::PACK_SHRINK);
+	global_vpacker.pack_start (control_slave_ui, Gtk::PACK_SHRINK);
+	global_vpacker.pack_start (gain_meter.gain_automation_state_button, Gtk::PACK_SHRINK);
+	global_vpacker.pack_start (bottom_padding,  Gtk::PACK_SHRINK);
 
 	global_frame.add (global_vpacker);
 	global_frame.set_shadow_type (Gtk::SHADOW_IN);
@@ -256,22 +261,26 @@ VCAMasterStrip::update_bottom_padding ()
 	}
 
 	int h = 0;
+	int n = 0;
 	if (viz.find ("Output") != std::string::npos) {
 		Gtk::Window window (WINDOW_TOPLEVEL);
 		window.add (output_button);
 		Gtk::Requisition requisition(output_button.size_request ());
-		h += requisition.height + 2;
+		h += requisition.height;
+		n++;
 	}
 	if (viz.find ("Comments") != std::string::npos) {
 		Gtk::Window window (WINDOW_TOPLEVEL);
 		window.add (comment_button);
 		Gtk::Requisition requisition(comment_button.size_request ());
-		h += requisition.height + 2;
+		h += requisition.height ;
+		n++;
 	}
 	if (h <= 0) {
-		bottom_padding.set_size_request (-1, 1);
+		bottom_padding.set_size_request (-1, 0);
 		bottom_padding.hide ();
 	} else {
+		h += 2 * (n - 1); // add 2px spacing per extra button (bottom_padding already adds 1 spacing)
 		bottom_padding.set_size_request (-1, h);
 		bottom_padding.show ();
 	}

--- a/libs/clearlooks-newer/clearlooks_style.c
+++ b/libs/clearlooks-newer/clearlooks_style.c
@@ -199,18 +199,27 @@ clearlooks_style_draw_shadow (DRAW_ARGS)
 	}
 	else if (DETAIL ("frame"))
 	{
-		WidgetParameters params;
-		FrameParameters  frame;
-		frame.shadow  = shadow_type;
-		frame.gap_x   = -1;                 /* No gap will be drawn */
-		frame.border  = &colors->shade[4];
+		// WidgetParameters params;
+		// FrameParameters  frame;
+		// frame.shadow  = shadow_type;
+		// frame.gap_x   = -1;                 /* No gap will be drawn */
+		// frame.border  = &colors->shade[4];
 
-		clearlooks_set_widget_parameters (widget, style, state_type, &params);
-		params.corners = CR_CORNER_NONE;
+		// clearlooks_set_widget_parameters (widget, style, state_type, &params);
+		// params.corners = CR_CORNER_NONE;
 
-		if (widget && !g_str_equal ("XfcePanelWindow", gtk_widget_get_name (gtk_widget_get_toplevel (widget))))
-			STYLE_FUNCTION(draw_frame) (cr, colors, &params, &frame,
-			                       x, y, width, height);
+		// if (widget && !g_str_equal ("XfcePanelWindow", gtk_widget_get_name (gtk_widget_get_toplevel (widget))))
+		// 	STYLE_FUNCTION(draw_frame) (cr, colors, &params, &frame,
+		// 	                       x, y, width, height);
+
+		// Draw a solid 1px inner border instead of a 2px beveled shadow
+		if (shadow_type != GTK_SHADOW_NONE) {
+			CairoColor *border = (CairoColor*)&colors->shade[4];
+			cairo_rectangle (cr, x+0.5, y+0.5, width-1, height-1);
+			ge_cairo_set_color (cr, border);
+			cairo_set_line_width (cr, 1);
+			cairo_stroke (cr);
+		}
 	}
 	else if (DETAIL ("scrolled_window") || DETAIL ("viewport") || detail == NULL)
 	{

--- a/libs/clearlooks-newer/clearlooks_style.c
+++ b/libs/clearlooks-newer/clearlooks_style.c
@@ -55,6 +55,26 @@
 static ClearlooksStyleClass *clearlooks_style_class;
 static GtkStyleClass *clearlooks_parent_class;
 
+static GtkShadowType
+clearlooks_get_scrollbar_shadow_type(GtkWidget *widget)
+{
+	// Attempt to find out what's the scroller container shadow type
+	// only works if the shadow is drawn by said container (not by an ancestor)
+	// We'll use this information to adjust how scrollbars are drawn and avoid
+	// conflicts between shadows and scrollbar outlines 
+	GtkWidget *container = widget->parent;
+	if (GTK_IS_SCROLLED_WINDOW(container)) {
+		return gtk_scrolled_window_get_shadow_type (container);
+	}
+
+	container = gtk_bin_get_child((GtkBin *)container);
+	if (GTK_IS_VIEWPORT(container)) {
+		return gtk_viewport_get_shadow_type (container);
+	}
+
+	return GTK_SHADOW_NONE;
+}
+
 static void
 clearlooks_set_widget_parameters (GtkWidget            *widget,
                                   const GtkStyle       *style,
@@ -663,15 +683,18 @@ clearlooks_style_draw_box (DRAW_ARGS)
 		if (GE_IS_RANGE (widget))
 			scrollbar.horizontal = GTK_RANGE (widget)->orientation == GTK_ORIENTATION_HORIZONTAL;
 
-		if (scrollbar.horizontal)
-		{
-			x += 2;
-			width -= 4;
-		}
-		else
-		{
-			y += 2;
-			height -= 4;
+		// If the container has a shadow, merge the gauge's border with the shadow
+		if (clearlooks_get_scrollbar_shadow_type(widget) != GTK_SHADOW_NONE) {
+			if (scrollbar.horizontal)
+			{
+				x -= 1;
+				width += 2;
+			}
+			else
+			{
+				y -= 1;
+				height += 2;
+			}
 		}
 
 		STYLE_FUNCTION(draw_scrollbar_trough) (cr, colors, &params, &scrollbar,
@@ -945,6 +968,21 @@ clearlooks_style_draw_slider (DRAW_ARGS, GtkOrientation orientation)
 		if ((clearlooks_style->style == CL_STYLE_GLOSSY || clearlooks_style->style == CL_STYLE_GUMMY)
 			&& !scrollbar.has_color)
 			scrollbar.color = colors->bg[0];
+
+		// Prevent the scrollbar slider from being cut by 1px when scroll is at max or min
+		// unless the container has a shadow in which case it will fill that 1px gap
+		if (clearlooks_get_scrollbar_shadow_type(widget) == GTK_SHADOW_NONE) {
+			if (scrollbar.horizontal)
+			{
+				x += 1;
+				width -= 2;
+			}
+			else
+			{
+				y += 1;
+				height -= 2;
+			}
+		}
 
 		STYLE_FUNCTION(draw_scrollbar_slider) (cr, colors, &params, &scrollbar,
 		                                       x, y, width, height);

--- a/libs/widgets/ardour_button.cc
+++ b/libs/widgets/ardour_button.cc
@@ -783,12 +783,17 @@ ArdourButton::set_colors ()
 {
 	_update_colors = false;
 
+	std::string name = get_name();
+	bool failed = false;
+
+	outline_color = UIConfigurationBase::instance().color (string_compose ("%1: outline", name), &failed);
+	if (failed) {
+		outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+	}
+
 	if (_fixed_colors_set == 0x3) {
 		return;
 	}
-
-	std::string name = get_name();
-	bool failed = false;
 
 	if (!(_fixed_colors_set & 0x1)) {
 		fill_active_color = UIConfigurationBase::instance().color (string_compose ("%1: fill active", name), &failed);
@@ -811,9 +816,6 @@ ArdourButton::set_colors ()
 	if (failed) {
 		led_active_color = UIConfigurationBase::instance().color ("generic button: led active");
 	}
-
-	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
-
 
 	/* The inactive color for the LED is just a fairly dark version of the
 	 * active color.

--- a/libs/widgets/ardour_button.cc
+++ b/libs/widgets/ardour_button.cc
@@ -130,6 +130,7 @@ ArdourButton::ArdourButton (const std::string& str, Element e, bool toggle)
 	, led_inactive_color(0)
 	, led_custom_color (0)
 	, use_custom_led_color (false)
+	, outline_color (0)
 	, convex_pattern (0)
 	, concave_pattern (0)
 	, led_inset_pattern (0)
@@ -320,7 +321,7 @@ ArdourButton::render (Cairo::RefPtr<Cairo::Context> const& ctx, cairo_rectangle_
 	// draw edge (filling a rect underneath, rather than stroking a border on top, allows the corners to be lighter-weight.
 	if ((_elements & (Body|Edge)) == (Body|Edge)) {
 		rounded_function (cr, 0, 0, get_width(), get_height(), corner_radius + 1.5);
-		cairo_set_source_rgba (cr, 0, 0, 0, 1);
+		Gtkmm2ext::set_source_rgba (cr, outline_color);
 		cairo_fill(cr);
 	}
 
@@ -810,6 +811,9 @@ ArdourButton::set_colors ()
 	if (failed) {
 		led_active_color = UIConfigurationBase::instance().color ("generic button: led active");
 	}
+
+	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+
 
 	/* The inactive color for the LED is just a fairly dark version of the
 	 * active color.

--- a/libs/widgets/ardour_fader.cc
+++ b/libs/widgets/ardour_fader.cc
@@ -84,7 +84,7 @@ ArdourFader::ArdourFader (Gtk::Adjustment& adj, int orientation, int fader_lengt
 		CairoWidget::set_size_request(_span, _girth);
 	}
 
-	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+	outline_color = UIConfigurationBase::instance().color ("fader outline");
 
 }
 

--- a/libs/widgets/ardour_fader.cc
+++ b/libs/widgets/ardour_fader.cc
@@ -29,6 +29,7 @@
 #include "gtkmm2ext/utils.h"
 
 #include "widgets/ardour_fader.h"
+#include "widgets/ui_config.h"
 
 using namespace Gtk;
 using namespace std;
@@ -60,6 +61,7 @@ ArdourFader::ArdourFader (Gtk::Adjustment& adj, int orientation, int fader_lengt
 	, _current_parent (0)
 	, have_explicit_bg (false)
 	, have_explicit_fg (false)
+	, outline_color (0)
 {
 	_default_value = _adjustment.get_value();
 	update_unity_position ();
@@ -81,6 +83,9 @@ ArdourFader::ArdourFader (Gtk::Adjustment& adj, int orientation, int fader_lengt
 	} else {
 		CairoWidget::set_size_request(_span, _girth);
 	}
+
+	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+
 }
 
 ArdourFader::~ArdourFader ()
@@ -280,7 +285,8 @@ ArdourFader::render (Cairo::RefPtr<Cairo::Context> const& ctx, cairo_rectangle_t
 	cairo_fill(cr);
 
 	cairo_set_line_width (cr, 2);
-	cairo_set_source_rgba (cr, 0, 0, 0, 1.0);
+	Gtkmm2ext::set_source_rgba (cr, outline_color);
+
 
 	cairo_matrix_t matrix;
 	Gtkmm2ext::rounded_rectangle (cr, CORNER_OFFSET, CORNER_OFFSET, w-CORNER_SIZE, h-CORNER_SIZE, CORNER_RADIUS);

--- a/libs/widgets/fastmeter.cc
+++ b/libs/widgets/fastmeter.cc
@@ -130,7 +130,7 @@ FastMeter::FastMeter (long hold, unsigned long dimen, Orientation o, int len,
 	request_width = pixrect.width + 2;
 	request_height= pixrect.height + 2;
 
-	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+	outline_color = UIConfigurationBase::instance().color ("meter outline");
 
 	clear ();
 }

--- a/libs/widgets/fastmeter.cc
+++ b/libs/widgets/fastmeter.cc
@@ -30,6 +30,9 @@
 #include "gtkmm2ext/utils.h"
 #include "widgets/fastmeter.h"
 
+#include "widgets/ui_config.h"
+
+
 #define UINT_TO_RGB(u,r,g,b) { (*(r)) = ((u)>>16)&0xff; (*(g)) = ((u)>>8)&0xff; (*(b)) = (u)&0xff; }
 #define UINT_TO_RGBA(u,r,g,b,a) { UINT_TO_RGB(((u)>>8),r,g,b); (*(a)) = (u)&0xff; }
 
@@ -69,6 +72,7 @@ FastMeter::FastMeter (long hold, unsigned long dimen, Orientation o, int len,
 	, current_level(0)
 	, current_peak(0)
 	, highlight(false)
+	, outline_color(0)
 {
 	last_peak_rect.width = 0;
 	last_peak_rect.height = 0;
@@ -125,6 +129,8 @@ FastMeter::FastMeter (long hold, unsigned long dimen, Orientation o, int len,
 
 	request_width = pixrect.width + 2;
 	request_height= pixrect.height + 2;
+
+	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
 
 	clear ();
 }
@@ -561,7 +567,7 @@ FastMeter::vertical_expose (cairo_t* cr, cairo_rectangle_t* area)
 	GdkRectangle background;
 	GdkRectangle eventarea;
 
-	cairo_set_source_rgb (cr, 0, 0, 0); // black
+	Gtkmm2ext::set_source_rgba (cr, outline_color);
 	rounded_rectangle (cr, 0, 0, pixwidth + 2, pixheight + 2, 2);
 	cairo_stroke (cr);
 
@@ -634,7 +640,7 @@ FastMeter::horizontal_expose (cairo_t* cr, cairo_rectangle_t* area)
 	GdkRectangle background;
 	GdkRectangle eventarea;
 
-	cairo_set_source_rgb (cr, 0, 0, 0); // black
+	Gtkmm2ext::set_source_rgba (cr, outline_color);
 	rounded_rectangle (cr, 0, 0, pixwidth + 2, pixheight + 2, 2);
 	cairo_stroke (cr);
 

--- a/libs/widgets/widgets/ardour_button.h
+++ b/libs/widgets/widgets/ardour_button.h
@@ -195,6 +195,9 @@ class LIBWIDGETS_API ArdourButton : public CairoWidget , public Gtkmm2ext::Activ
 	uint32_t led_custom_color;
 	bool     use_custom_led_color;
 
+	uint32_t outline_color;
+
+
 	cairo_pattern_t* convex_pattern;
 	cairo_pattern_t* concave_pattern;
 	cairo_pattern_t* led_inset_pattern;

--- a/libs/widgets/widgets/ardour_fader.h
+++ b/libs/widgets/widgets/ardour_fader.h
@@ -110,6 +110,8 @@ private:
 	Gtkmm2ext::Color explicit_fg;
 	bool have_explicit_fg;
 
+	uint32_t outline_color;
+
 	void create_patterns();
 	void adjustment_changed ();
 	void set_adjustment_from_event (GdkEventButton *);

--- a/libs/widgets/widgets/fastmeter.h
+++ b/libs/widgets/widgets/fastmeter.h
@@ -96,6 +96,8 @@ private:
 	float current_user_level;
 	bool highlight;
 
+	uint32_t outline_color;
+
 	void vertical_expose (cairo_t*, cairo_rectangle_t*);
 	void vertical_size_request (GtkRequisition*);
 	void vertical_size_allocate (Gtk::Allocation&);


### PR DESCRIPTION
This is PR #844 without structural changes (Gtk::Frame preserved) nor interaction modifications, only cosmetic tweaks:
- general: customizable outline colors (instead of hard coded black)
- mixer: aligned vca strip layout (with regular strips)
- editor: aligned track/canvas separators; darken background track separator (more visible than the current lighten version); removed track header inner border
- strip: inner shadow of processor box removed (aligns better with the rest of the strip)
- processor: consistent inline display border radius and spacing with the processor box
- fader: flat top in flat mode
- prevent scrollbar from cropping [before (cropped)](https://github.com/Ardour/ardour/assets/5261671/00c4a738-b4e3-4566-819e-9b9a9f4a8c33) / [after](https://github.com/Ardour/ardour/assets/5261671/4874c399-4c7e-4233-b1c5-b3285eaeaa3f), [before (misaligned)](https://github.com/Ardour/ardour/assets/5261671/d052c39d-714f-4f4a-850e-214f400fd3fb) / [after](https://github.com/Ardour/ardour/assets/5261671/6bb4eb19-81b7-4c43-9db1-e1b27fd16e06)
- replace the default frame shadow (2px, beveled) with a 1px solid inner shadow, this prevents the former from interfering with the strip layout and lets the track coloration (audio track vs bus vs midi) propagate from top to bottom.
