### PR TITLE
Akai MIDIMix mapping solo functionality adjustment

### DIFF
--- a/share/midi_maps/AKAI_MIDIMix_Normal_Mode.map
+++ b/share/midi_maps/AKAI_MIDIMix_Normal_Mode.map
@@ -11,45 +11,45 @@
   <DeviceInfo bank-size="8"/>
 
  
-<!-- The following binds Midimix's faders and mute/rec buttons to first eight tracks in Ardour. Note: "Solo" button on MidiMix will solo all tracks in current bank. It's useful when you have more than 8 tracks in a session. If you want to keep only one track in solo mode - press solo and then mute other tracks in that bank with "Mute" buttons. -->
+<!-- The following binds Midimix's faders and mute/rec buttons to first eight tracks in Ardour. Note: To solo a track - hold "solo" and press "mute" button of the desired track number, as in standard keyboard shortcut combinations. -->
 
   <Binding channel="1" note="1" uri="/route/mute B1"/>
-  <Binding channel="1" note="27" uri="/route/solo B1"/>
+  <Binding channel="1" note="2" uri="/route/solo B1"/>
   <Binding channel="1" note="3" uri="/route/recenable B1"/>
   <Binding channel="1" ctl="19" uri="/route/gain B1"/>
   
   <Binding channel="1" note="4" uri="/route/mute B2"/>
-  <Binding channel="1" note="27" uri="/route/solo B2"/>
+  <Binding channel="1" note="5" uri="/route/solo B2"/>
   <Binding channel="1" note="6" uri="/route/recenable B2"/>
   <Binding channel="1" ctl="23" uri="/route/gain B2"/>
   
   <Binding channel="1" note="7" uri="/route/mute B3"/>
-  <Binding channel="1" note="27" uri="/route/solo B3"/>
+  <Binding channel="1" note="8" uri="/route/solo B3"/>
   <Binding channel="1" note="9" uri="/route/recenable B3"/>
   <Binding channel="1" ctl="27" uri="/route/gain B3"/>
   
   <Binding channel="1" note="10" uri="/route/mute B4"/>
-  <Binding channel="1" note="27" uri="/route/solo B4"/>
+  <Binding channel="1" note="11" uri="/route/solo B4"/>
   <Binding channel="1" note="12" uri="/route/recenable B4"/>
   <Binding channel="1" ctl="31" uri="/route/gain B4"/>
   
   <Binding channel="1" note="13" uri="/route/mute B5"/>
-  <Binding channel="1" note="27" uri="/route/solo B5"/>
+  <Binding channel="1" note="14" uri="/route/solo B5"/>
   <Binding channel="1" note="15" uri="/route/recenable B5"/>
   <Binding channel="1" ctl="49" uri="/route/gain B5"/>
   
   <Binding channel="1" note="16" uri="/route/mute B6"/>
-  <Binding channel="1" note="27" uri="/route/solo B6"/>
+  <Binding channel="1" note="17" uri="/route/solo B6"/>
   <Binding channel="1" note="18" uri="/route/recenable B6"/>
   <Binding channel="1" ctl="53" uri="/route/gain B6"/>
   
   <Binding channel="1" note="19" uri="/route/mute B7"/>
-  <Binding channel="1" note="27" uri="/route/solo B7"/>
+  <Binding channel="1" note="20" uri="/route/solo B7"/>
   <Binding channel="1" note="21" uri="/route/recenable B7"/>
   <Binding channel="1" ctl="57" uri="/route/gain B7"/>
   
   <Binding channel="1" note="22" uri="/route/mute B8"/>
-  <Binding channel="1" note="27" uri="/route/solo B8"/>
+  <Binding channel="1" note="23" uri="/route/solo B8"/>
   <Binding channel="1" note="24" uri="/route/recenable B8"/>
   <Binding channel="1" ctl="61" uri="/route/gain B8"/>
 


### PR DESCRIPTION
Adjusted Akai MIDIMix mapping to make solo function as described on page 5 of of the original [user manual](https://cdn.inmusicbrands.com/akai/attachments/MIDIMIX/MIDImix-UserGuide-v1.0.pdf) provided by manufacturer.

Attaching small midi monitoring log, where the first message "ch1 note on  27 vel 127" is when i press and start holding solo button, then i go over pressing individual mutes for each of eight channels/tracks to gather their numbers and the last message "ch1 note off 27 vel 127" is when i release it.
[mutes_log.txt](https://github.com/Ardour/ardour/files/13785447/mutes_log.txt)
Some numbers are skipped - those are not mistakes, made that way by Akai.

Results work flawlessly with my midmix.

