### PR TITLE
Add a new color theme inspired by Adwaita (GNOME desktop)

### DIFF
--- a/gtk2_ardour/themes/adwaita_dark-ardour.colors
+++ b/gtk2_ardour/themes/adwaita_dark-ardour.colors
@@ -1,0 +1,532 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Ardour theme-name="Adwaita Dark">
+  <Colors>
+    <Color name="alert:blue" value="3584e4ff"/>
+    <Color name="alert:cyan" value="62a0eaff"/>
+    <Color name="alert:green" value="2ec27eff"/>
+    <Color name="alert:orange" value="ff7800ff"/>
+    <Color name="alert:red" value="c01c28ff"/>
+    <Color name="alert:ruddy" value="e03131ff"/>
+    <Color name="alert:yellow" value="f5c211ff"/>
+    <Color name="meter color0" value="008800ff"/>
+    <Color name="meter color1" value="00aa00ff"/>
+    <Color name="meter color2" value="00ff00ff"/>
+    <Color name="meter color3" value="00ff00ff"/>
+    <Color name="meter color4" value="fff000ff"/>
+    <Color name="meter color5" value="fff000ff"/>
+    <Color name="meter color6" value="ff8800ff"/>
+    <Color name="meter color7" value="ff8800ff"/>
+    <Color name="meter color8" value="ff0000ff"/>
+    <Color name="meter color9" value="ff0000ff"/>
+    <Color name="midi meter 52" value="f8e45cff"/>
+    <Color name="midi meter 53" value="f8e45cff"/>
+    <Color name="midi meter 54" value="f6d32dff"/>
+    <Color name="midi meter 55" value="f6d32dff"/>
+    <Color name="midi meter 56" value="f5c211ff"/>
+    <Color name="neutral:background" value="1e1e1eff"/>
+    <Color name="neutral:background2" value="2a2a2afe"/>
+    <Color name="neutral:backgroundest" value="1e1e1eff"/>
+    <Color name="neutral:foreground" value="f1f3f5ff"/>
+    <Color name="neutral:foreground2" value="868e96ff"/>
+    <Color name="neutral:foregroundest" value="f8f9faff"/>
+    <Color name="neutral:midground" value="313131ff"/>
+    <Color name="theme:bg" value="242424ff"/>
+    <Color name="theme:bg1" value="313131ff"/>
+    <Color name="theme:bg2" value="161616ff"/>
+    <Color name="theme:contrasting" value="fa5252ff"/>
+    <Color name="theme:contrasting alt" value="fd7e14ff"/>
+    <Color name="theme:contrasting clock" value="66a3d8ff"/>
+    <Color name="theme:contrasting less" value="1c71d8ff"/>
+    <Color name="theme:contrasting selection" value="3584e4ff"/>
+    <Color name="widget:bg" value="393939ff"/>
+    <Color name="widget:blue" value="3584e4ff"/>
+    <Color name="widget:blue darker" value="495057ff"/>
+    <Color name="widget:gray" value="ced4daff"/>
+    <Color name="widget:green" value="b197fcff"/>
+    <Color name="widget:green darker" value="343a40ff"/>
+    <Color name="widget:green lighter" value="57e389ff"/>
+    <Color name="widget:orange" value="fd7e14ff"/>
+    <Color name="widget:ruddy" value="087f5bff"/>
+    <Color name="widget:yellow" value="f5c211ff"/>
+  </Colors>
+  <ColorAliases>
+    <ColorAlias name="active crossfade" alias="neutral:foreground"/>
+    <ColorAlias name="arrange base" alias="theme:bg1"/>
+    <ColorAlias name="arrangement marker bar" alias="neutral:background2"/>
+    <ColorAlias name="arrangement rect" alias="widget:blue"/>
+    <ColorAlias name="arrangement rect alt" alias="widget:blue darker"/>
+    <ColorAlias name="audio automation track fill" alias="theme:bg"/>
+    <ColorAlias name="audio bus base" alias="neutral:background"/>
+    <ColorAlias name="audio master bus base" alias="neutral:backgroundest"/>
+    <ColorAlias name="audio track base" alias="neutral:background"/>
+    <ColorAlias name="automation line" alias="alert:green"/>
+    <ColorAlias name="automation track outline" alias="theme:bg2"/>
+    <ColorAlias name="big clock active: background" alias="neutral:backgroundest"/>
+    <ColorAlias name="big clock active: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="big clock active: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="big clock active: text" alias="alert:red"/>
+    <ColorAlias name="big clock active:gtk_somewhat_bright_indicator background" alias="neutral:backgroundest"/>
+    <ColorAlias name="big clock: background" alias="theme:bg2"/>
+    <ColorAlias name="big clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="big clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="big clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="border color" alias="neutral:backgroundest"/>
+    <ColorAlias name="cd marker bar" alias="neutral:background2"/>
+    <ColorAlias name="clipped waveform" alias="alert:red"/>
+    <ColorAlias name="clock: background" alias="theme:bg2"/>
+    <ColorAlias name="clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="comment button: fill" alias="widget:bg"/>
+    <ColorAlias name="control point fill" alias="alert:green"/>
+    <ColorAlias name="control point outline" alias="alert:blue"/>
+    <ColorAlias name="control point selected fill" alias="alert:orange"/>
+    <ColorAlias name="control point selected outline" alias="alert:red"/>
+    <ColorAlias name="covered region" alias="neutral:background2"/>
+    <ColorAlias name="crossfade editor base" alias="neutral:foreground2"/>
+    <ColorAlias name="crossfade editor line" alias="neutral:backgroundest"/>
+    <ColorAlias name="crossfade editor line shading" alias="widget:blue"/>
+    <ColorAlias name="crossfade editor point fill" alias="alert:green"/>
+    <ColorAlias name="crossfade editor point outline" alias="alert:blue"/>
+    <ColorAlias name="crossfade editor wave" alias="neutral:foregroundest"/>
+    <ColorAlias name="crossfade line" alias="neutral:backgroundest"/>
+    <ColorAlias name="edit point" alias="alert:blue"/>
+    <ColorAlias name="entered automation line" alias="widget:orange"/>
+    <ColorAlias name="entered gain line" alias="widget:orange"/>
+    <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
+    <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
+    <ColorAlias name="feedback alert: fill active" alias="alert:red"/>
+    <ColorAlias name="feedback alert: led active" alias="alert:red"/>
+    <ColorAlias name="foldback knob" alias="widget:bg"/>
+    <ColorAlias name="foldback knob: arc end" alias="widget:blue"/>
+    <ColorAlias name="foldback knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="foldback knob: fill" alias="widget:bg"/>
+    <ColorAlias name="foldback postfader: fill" alias="widget:green"/>
+    <ColorAlias name="foldback postfader: fill active" alias="widget:green"/>
+    <ColorAlias name="foldback postfader: led active" alias="alert:green"/>
+    <ColorAlias name="foldback prefader: fill" alias="alert:cyan"/>
+    <ColorAlias name="foldback prefader: fill active" alias="alert:cyan"/>
+    <ColorAlias name="foldback prefader: led active" alias="alert:green"/>
+    <ColorAlias name="frame handle" alias="theme:bg1"/>
+    <ColorAlias name="gain line" alias="alert:blue"/>
+    <ColorAlias name="gain line inactive" alias="theme:bg1"/>
+    <ColorAlias name="generic button: fill" alias="widget:bg"/>
+    <ColorAlias name="generic button: fill active" alias="alert:red"/>
+    <ColorAlias name="generic button: led active" alias="alert:blue"/>
+    <ColorAlias name="ghost track base" alias="widget:green lighter"/>
+    <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
+    <ColorAlias name="ghost track wave" alias="neutral:midground"/>
+    <ColorAlias name="ghost track wave clip" alias="neutral:background"/>
+    <ColorAlias name="ghost track wave fill" alias="neutral:midground"/>
+    <ColorAlias name="ghost track zero line" alias="neutral:backgroundest"/>
+    <ColorAlias name="grid line major" alias="neutral:foreground2"/>
+    <ColorAlias name="grid line micro" alias="widget:bg"/>
+    <ColorAlias name="grid line minor" alias="widget:blue darker"/>
+    <ColorAlias name="gtk_arm" alias="alert:red"/>
+    <ColorAlias name="gtk_audio_bus" alias="neutral:background"/>
+    <ColorAlias name="gtk_audio_track" alias="theme:bg1"/>
+    <ColorAlias name="gtk_automation_track_header" alias="theme:bg"/>
+    <ColorAlias name="gtk_background" alias="theme:bg"/>
+    <ColorAlias name="gtk_bases" alias="theme:bg2"/>
+    <ColorAlias name="gtk_bg_selected" alias="theme:contrasting selection"/>
+    <ColorAlias name="gtk_bg_tooltip" alias="neutral:backgroundest"/>
+    <ColorAlias name="gtk_bright_color" alias="widget:blue darker"/>
+    <ColorAlias name="gtk_bright_indicator" alias="alert:red"/>
+    <ColorAlias name="gtk_clip_indicator" alias="alert:red"/>
+    <ColorAlias name="gtk_contrasting_indicator" alias="theme:contrasting selection"/>
+    <ColorAlias name="gtk_control_master" alias="theme:bg1"/>
+    <ColorAlias name="gtk_control_text" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_control_text2" alias="alert:ruddy"/>
+    <ColorAlias name="gtk_darkest" alias="theme:bg2"/>
+    <ColorAlias name="gtk_entry_cursor" alias="alert:red"/>
+    <ColorAlias name="gtk_fg_selected" alias="neutral:foregroundest"/>
+    <ColorAlias name="gtk_fg_tooltip" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_foldback_bg" alias="theme:bg1"/>
+    <ColorAlias name="gtk_foreground" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_light_text_on_dark" alias="neutral:foreground2"/>
+    <ColorAlias name="gtk_lightest" alias="neutral:foregroundest"/>
+    <ColorAlias name="gtk_midi_channel_selector" alias="widget:blue"/>
+    <ColorAlias name="gtk_midi_track" alias="neutral:background2"/>
+    <ColorAlias name="gtk_monitor" alias="alert:orange"/>
+    <ColorAlias name="gtk_mono" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_mute" alias="alert:yellow"/>
+    <ColorAlias name="gtk_not_so_bright_indicator" alias="theme:contrasting"/>
+    <ColorAlias name="gtk_processor_fader" alias="widget:gray"/>
+    <ColorAlias name="gtk_processor_fader_frame" alias="neutral:midground"/>
+    <ColorAlias name="gtk_processor_frame_selected" alias="theme:contrasting"/>
+    <ColorAlias name="gtk_processor_postfader" alias="widget:green"/>
+    <ColorAlias name="gtk_processor_postfader_frame" alias="widget:green"/>
+    <ColorAlias name="gtk_processor_prefader" alias="widget:ruddy"/>
+    <ColorAlias name="gtk_processor_prefader_frame" alias="widget:ruddy"/>
+    <ColorAlias name="gtk_send_bg" alias="theme:bg1"/>
+    <ColorAlias name="gtk_send_fg" alias="widget:blue"/>
+    <ColorAlias name="gtk_solo" alias="alert:green"/>
+    <ColorAlias name="gtk_somewhat_bright_indicator" alias="theme:contrasting alt"/>
+    <ColorAlias name="gtk_texts" alias="neutral:foreground"/>
+    <ColorAlias name="gtk_track_header_inactive" alias="theme:bg"/>
+    <ColorAlias name="gtk_track_header_selected" alias="theme:contrasting less"/>
+    <ColorAlias name="image track" alias="neutral:foreground2"/>
+    <ColorAlias name="inactive crossfade" alias="theme:contrasting"/>
+    <ColorAlias name="inactive fade handle" alias="neutral:foreground2"/>
+    <ColorAlias name="inactive group tab" alias="theme:bg"/>
+    <ColorAlias name="invert button: fill" alias="widget:bg"/>
+    <ColorAlias name="invert button: fill active" alias="alert:blue"/>
+    <ColorAlias name="invert button: led active" alias="alert:blue"/>
+    <ColorAlias name="latency button: fill" alias="widget:bg"/>
+    <ColorAlias name="latency button: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="latency button: led active" alias="alert:ruddy"/>
+    <ColorAlias name="location arrangement marker" alias="theme:contrasting alt"/>
+    <ColorAlias name="location cd marker" alias="widget:blue"/>
+    <ColorAlias name="location loop" alias="alert:green"/>
+    <ColorAlias name="location marker" alias="alert:yellow"/>
+    <ColorAlias name="location punch" alias="alert:red"/>
+    <ColorAlias name="location range" alias="alert:blue"/>
+    <ColorAlias name="lock button: fill active" alias="widget:bg"/>
+    <ColorAlias name="lock button: led active" alias="alert:red"/>
+    <ColorAlias name="lua action button: fill" alias="widget:bg"/>
+    <ColorAlias name="mapping bar" alias="neutral:background2"/>
+    <ColorAlias name="marker bar" alias="neutral:background2"/>
+    <ColorAlias name="marker bar separator" alias="theme:bg2"/>
+    <ColorAlias name="marker drag line" alias="theme:contrasting clock"/>
+    <ColorAlias name="marker label" alias="neutral:backgroundest"/>
+    <ColorAlias name="marker track" alias="neutral:foreground2"/>
+    <ColorAlias name="master monitor section button active: fill" alias="widget:ruddy"/>
+    <ColorAlias name="master monitor section button active: fill active" alias="alert:yellow"/>
+    <ColorAlias name="master monitor section button normal: fill active" alias="widget:bg"/>
+    <ColorAlias name="measure line bar" alias="neutral:foregroundest"/>
+    <ColorAlias name="measure line beat" alias="widget:blue"/>
+    <ColorAlias name="meter background bottom" alias="neutral:midground"/>
+    <ColorAlias name="meter background top" alias="neutral:background"/>
+    <ColorAlias name="meter bar" alias="theme:bg1"/>
+    <ColorAlias name="meter color BBC" alias="alert:orange"/>
+    <ColorAlias name="meter marker" alias="widget:orange"/>
+    <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
+    <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
+    <ColorAlias name="meterbridge label: led" alias="alert:red"/>
+    <ColorAlias name="meterbridge label: led active" alias="alert:red"/>
+    <ColorAlias name="meterbridge peakindicator: fill" alias="widget:bg"/>
+    <ColorAlias name="meterbridge peakindicator: fill active" alias="alert:red"/>
+    <ColorAlias name="meterbridge peakindicator: led" alias="alert:red"/>
+    <ColorAlias name="meterbridge peakindicator: led active" alias="alert:red"/>
+    <ColorAlias name="meterbridge peaklabel" alias="alert:red"/>
+    <ColorAlias name="meterstrip dpm bg" alias="theme:bg2"/>
+    <ColorAlias name="meterstrip dpm fg" alias="neutral:foreground2"/>
+    <ColorAlias name="meterstrip ppm bg" alias="theme:bg2"/>
+    <ColorAlias name="meterstrip ppm fg" alias="neutral:foreground2"/>
+    <ColorAlias name="meterstrip vu bg" alias="theme:contrasting"/>
+    <ColorAlias name="meterstrip vu fg" alias="neutral:backgroundest"/>
+    <ColorAlias name="midi automation track fill" alias="widget:green darker"/>
+    <ColorAlias name="midi bus base" alias="neutral:backgroundest"/>
+    <ColorAlias name="midi device: fill" alias="widget:bg"/>
+    <ColorAlias name="midi device: fill active" alias="theme:bg"/>
+    <ColorAlias name="midi device: led active" alias="alert:green"/>
+    <ColorAlias name="midi input button: fill active" alias="alert:green"/>
+    <ColorAlias name="midi input button: led active" alias="alert:red"/>
+    <ColorAlias name="midi meter color0" alias="midi meter 52"/>
+    <ColorAlias name="midi meter color1" alias="midi meter 53"/>
+    <ColorAlias name="midi meter color2" alias="midi meter 53"/>
+    <ColorAlias name="midi meter color3" alias="midi meter 54"/>
+    <ColorAlias name="midi meter color4" alias="midi meter 54"/>
+    <ColorAlias name="midi meter color5" alias="midi meter 55"/>
+    <ColorAlias name="midi meter color6" alias="midi meter 55"/>
+    <ColorAlias name="midi meter color7" alias="midi meter 56"/>
+    <ColorAlias name="midi meter color8" alias="midi meter 56"/>
+    <ColorAlias name="midi meter color9" alias="midi meter 56"/>
+    <ColorAlias name="midi note inactive channel" alias="neutral:backgroundest"/>
+    <ColorAlias name="midi note max" alias="alert:green"/>
+    <ColorAlias name="midi note mid" alias="alert:yellow"/>
+    <ColorAlias name="midi note min" alias="alert:orange"/>
+    <ColorAlias name="midi note selected" alias="widget:ruddy"/>
+    <ColorAlias name="midi note selected outline" alias="neutral:foregroundest"/>
+    <ColorAlias name="midi note velocity text" alias="theme:contrasting"/>
+    <ColorAlias name="midi patch change fill" alias="theme:contrasting selection"/>
+    <ColorAlias name="midi patch change outline" alias="neutral:foreground"/>
+    <ColorAlias name="midi select rect outline" alias="alert:red"/>
+    <ColorAlias name="midi sysex fill" alias="theme:contrasting"/>
+    <ColorAlias name="midi sysex outline" alias="theme:contrasting alt"/>
+    <ColorAlias name="midi track base" alias="widget:green darker"/>
+    <ColorAlias name="mixer strip button: fill" alias="widget:bg"/>
+    <ColorAlias name="mixer strip button: fill active" alias="alert:orange"/>
+    <ColorAlias name="mixer strip button: led active" alias="alert:green"/>
+    <ColorAlias name="mixer strip name button: fill active" alias="theme:bg2"/>
+    <ColorAlias name="mixer strip name button: led active" alias="alert:green"/>
+    <ColorAlias name="monitor button: fill" alias="widget:bg"/>
+    <ColorAlias name="monitor button: fill active" alias="alert:orange"/>
+    <ColorAlias name="monitor button: led active" alias="alert:ruddy"/>
+    <ColorAlias name="monitor section button: fill" alias="widget:bg"/>
+    <ColorAlias name="monitor section dim: fill" alias="widget:bg"/>
+    <ColorAlias name="monitor section dim: fill active" alias="alert:orange"/>
+    <ColorAlias name="monitor section dim: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section knob" alias="widget:bg"/>
+    <ColorAlias name="monitor section knob: arc end" alias="widget:blue"/>
+    <ColorAlias name="monitor section knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="monitor section mono: fill" alias="widget:bg"/>
+    <ColorAlias name="monitor section mono: fill active" alias="alert:blue"/>
+    <ColorAlias name="monitor section mono: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section processors present: fill" alias="alert:orange"/>
+    <ColorAlias name="monitor section processors toggle: fill" alias="theme:bg"/>
+    <ColorAlias name="monitor section processors toggle: fill active" alias="theme:bg"/>
+    <ColorAlias name="monitor section solo model: fill" alias="widget:bg"/>
+    <ColorAlias name="monitor section solo model: fill active" alias="theme:bg"/>
+    <ColorAlias name="monitor section solo model: led active" alias="alert:green"/>
+    <ColorAlias name="monitor section solo model:punch button: fill active fill" alias="widget:bg"/>
+    <ColorAlias name="monitor section solo option: fill" alias="widget:bg"/>
+    <ColorAlias name="monitor section solo option: fill active" alias="theme:bg"/>
+    <ColorAlias name="monitor section solo option: led active" alias="alert:green"/>
+    <ColorAlias name="mono panner bg" alias="theme:bg2"/>
+    <ColorAlias name="mono panner fill" alias="widget:blue"/>
+    <ColorAlias name="mono panner outline" alias="theme:bg"/>
+    <ColorAlias name="mono panner position fill" alias="neutral:foreground2"/>
+    <ColorAlias name="mono panner position outline" alias="theme:bg"/>
+    <ColorAlias name="mono panner text" alias="neutral:backgroundest"/>
+    <ColorAlias name="mouse mode button: fill" alias="widget:bg"/>
+    <ColorAlias name="mouse mode button: fill active" alias="alert:blue"/>
+    <ColorAlias name="mouse mode button: led active" alias="alert:green"/>
+    <ColorAlias name="mute button: fill" alias="widget:bg"/>
+    <ColorAlias name="mute button: fill active" alias="alert:yellow"/>
+    <ColorAlias name="mute button: led active" alias="alert:yellow"/>
+    <ColorAlias name="name highlight fill" alias="alert:blue"/>
+    <ColorAlias name="name highlight outline" alias="theme:bg1"/>
+    <ColorAlias name="nudge button: fill" alias="widget:bg"/>
+    <ColorAlias name="nudge button: fill active" alias="widget:bg"/>
+    <ColorAlias name="nudge button: led active" alias="alert:green"/>
+    <ColorAlias name="nudge clock: background" alias="theme:bg2"/>
+    <ColorAlias name="nudge clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="nudge clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="nudge clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="page switch button: fill" alias="widget:bg"/>
+    <ColorAlias name="page switch button: fill active" alias="alert:blue"/>
+    <ColorAlias name="pan knob" alias="widget:bg"/>
+    <ColorAlias name="pan knob: arc end" alias="widget:orange"/>
+    <ColorAlias name="pan knob: arc start" alias="widget:orange"/>
+    <ColorAlias name="patch change button unnamed: fill" alias="neutral:background2"/>
+    <ColorAlias name="patch change button unnamed: fill active" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill" alias="widget:bg"/>
+    <ColorAlias name="patch change button: fill acpunch button: fill activetive" alias="widget:blue"/>
+    <ColorAlias name="patch change button: fill active" alias="widget:blue"/>
+    <ColorAlias name="piano key black" alias="neutral:background2"/>
+    <ColorAlias name="piano key highlight" alias="alert:ruddy"/>
+    <ColorAlias name="piano key white" alias="neutral:foreground"/>
+    <ColorAlias name="piano roll black" alias="theme:bg2"/>
+    <ColorAlias name="piano roll black outline" alias="neutral:background"/>
+    <ColorAlias name="piano roll white" alias="neutral:foreground"/>
+    <ColorAlias name="pinrouting custom: led active" alias="alert:ruddy"/>
+    <ColorAlias name="pinrouting sidechain: led active" alias="alert:green"/>
+    <ColorAlias name="play head" alias="theme:contrasting"/>
+    <ColorAlias name="plugin automation state button: fill active" alias="alert:orange"/>
+    <ColorAlias name="plugin bypass button: led active" alias="alert:red"/>
+    <ColorAlias name="pluginlist filter button: fill active" alias="widget:bg"/>
+    <ColorAlias name="pluginlist hide button: led active" alias="alert:cyan"/>
+    <ColorAlias name="pluginlist radio button: led active" alias="alert:cyan"/>
+    <ColorAlias name="pluginui toggle: fill" alias="widget:bg"/>
+    <ColorAlias name="pluginui toggle: fill active" alias="widget:blue"/>
+    <ColorAlias name="preference highlight" alias="alert:yellow"/>
+    <ColorAlias name="processor automation line" alias="theme:bg1"/>
+    <ColorAlias name="processor auxfeedback: fill" alias="theme:contrasting alt"/>
+    <ColorAlias name="processor auxfeedback: led active" alias="alert:green"/>
+    <ColorAlias name="processor control button: fill" alias="neutral:background"/>
+    <ColorAlias name="processor control button: fill active" alias="neutral:background2"/>
+    <ColorAlias name="processor control button: led active" alias="widget:blue"/>
+    <ColorAlias name="processor control knob" alias="theme:bg"/>
+    <ColorAlias name="processor control knob: arc end" alias="widget:blue"/>
+    <ColorAlias name="processor control knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="processor fader: fill" alias="alert:blue"/>
+    <ColorAlias name="processor fader: fill active" alias="alert:blue"/>
+    <ColorAlias name="processor fader: led active" alias="alert:green"/>
+    <ColorAlias name="processor postfader: fill" alias="widget:green"/>
+    <ColorAlias name="processor postfader: fill active" alias="widget:green"/>
+    <ColorAlias name="processor postfader: led active" alias="alert:green"/>
+    <ColorAlias name="processor prefader: fill" alias="widget:ruddy"/>
+    <ColorAlias name="processor prefader: fill active" alias="widget:ruddy"/>
+    <ColorAlias name="processor prefader: led active" alias="alert:green"/>
+    <ColorAlias name="processor sidechain: fill" alias="alert:orange"/>
+    <ColorAlias name="processor sidechain: led active" alias="alert:green"/>
+    <ColorAlias name="processor stub: fill" alias="neutral:background2"/>
+    <ColorAlias name="processor stub: fill active" alias="neutral:background2"/>
+    <ColorAlias name="punch button: fill" alias="widget:bg"/>
+    <ColorAlias name="punch button: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="punch button: led active" alias="alert:red"/>
+    <ColorAlias name="punch clock: background" alias="theme:bg2"/>
+    <ColorAlias name="punch clock: cursor" alias="alert:ruddy"/>
+    <ColorAlias name="punch clock: edited text" alias="alert:ruddy"/>
+    <ColorAlias name="punch clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="punch line" alias="alert:ruddy"/>
+    <ColorAlias name="range drag bar rect" alias="neutral:midground"/>
+    <ColorAlias name="range drag rect" alias="alert:ruddy"/>
+    <ColorAlias name="range marker bar" alias="neutral:background2"/>
+    <ColorAlias name="record enable button: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="record enable button: led active" alias="alert:red"/>
+    <ColorAlias name="recording note" alias="neutral:foregroundest"/>
+    <ColorAlias name="recording rect" alias="alert:ruddy"/>
+    <ColorAlias name="recording waveform fill" alias="neutral:foregroundest"/>
+    <ColorAlias name="recording waveform outline" alias="neutral:foregroundest"/>
+    <ColorAlias name="region list automatic" alias="theme:contrasting less"/>
+    <ColorAlias name="region list missing source" alias="alert:red"/>
+    <ColorAlias name="region list whole file" alias="neutral:foreground"/>
+    <ColorAlias name="region mark" alias="theme:contrasting alt"/>
+    <ColorAlias name="route button: fill" alias="widget:bg"/>
+    <ColorAlias name="route button: fill active" alias="theme:bg2"/>
+    <ColorAlias name="route button: led active" alias="alert:green"/>
+    <ColorAlias name="route rec button: led active" alias="alert:red"/>
+    <ColorAlias name="rubber band rect" alias="neutral:foreground2"/>
+    <ColorAlias name="rude audition: fill" alias="widget:bg"/>
+    <ColorAlias name="rude audition: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="rude audition: led active" alias="alert:red"/>
+    <ColorAlias name="rude isolate: fill" alias="widget:bg"/>
+    <ColorAlias name="rude isolate: fill active" alias="theme:contrasting alt"/>
+    <ColorAlias name="rude isolate: led active" alias="alert:red"/>
+    <ColorAlias name="rude solo: fill" alias="widget:bg"/>
+    <ColorAlias name="rude solo: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="rude solo: led active" alias="alert:red"/>
+    <ColorAlias name="ruler base" alias="theme:bg2"/>
+    <ColorAlias name="ruler text" alias="neutral:foreground2"/>
+    <ColorAlias name="scroomer" alias="neutral:foreground"/>
+    <ColorAlias name="secondary clock: background" alias="theme:bg2"/>
+    <ColorAlias name="secondary clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="secondary clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="secondary clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="secondary delta clock: background" alias="theme:bg2"/>
+    <ColorAlias name="secondary delta clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="secondary delta clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="secondary delta clock: text" alias="theme:contrasting alt"/>
+    <ColorAlias name="selected midi note frame" alias="alert:ruddy"/>
+    <ColorAlias name="selected region base" alias="alert:ruddy"/>
+    <ColorAlias name="selected time axis frame" alias="alert:ruddy"/>
+    <ColorAlias name="selected waveform fill" alias="alert:orange"/>
+    <ColorAlias name="selected waveform outline" alias="theme:bg2"/>
+    <ColorAlias name="selection" alias="alert:red"/>
+    <ColorAlias name="selection clock: background" alias="theme:bg2"/>
+    <ColorAlias name="selection clock: cursor" alias="alert:ruddy"/>
+    <ColorAlias name="selection clock: edited text" alias="alert:ruddy"/>
+    <ColorAlias name="selection clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="selection rect" alias="neutral:foreground"/>
+    <ColorAlias name="send alert button: fill" alias="neutral:foreground"/>
+    <ColorAlias name="send alert button: fill active" alias="alert:cyan"/>
+    <ColorAlias name="send alert button: led active" alias="alert:red"/>
+    <ColorAlias name="send bg" alias="neutral:backgroundest"/>
+    <ColorAlias name="send pan" alias="theme:contrasting alt"/>
+    <ColorAlias name="shuttle" alias="widget:bg"/>
+    <ColorAlias name="shuttle bg" alias="neutral:backgroundest"/>
+    <ColorAlias name="silence" alias="theme:contrasting alt"/>
+    <ColorAlias name="silence text" alias="neutral:foreground"/>
+    <ColorAlias name="solo button: fill" alias="widget:bg"/>
+    <ColorAlias name="solo button: fill active" alias="alert:green"/>
+    <ColorAlias name="solo button: led active" alias="alert:green"/>
+    <ColorAlias name="solo isolate: fill" alias="widget:bg"/>
+    <ColorAlias name="solo isolate: fill active" alias="widget:bg"/>
+    <ColorAlias name="solo isolate: led active" alias="alert:ruddy"/>
+    <ColorAlias name="solo safe: fill" alias="widget:bg"/>
+    <ColorAlias name="solo safe: fill active" alias="widget:bg"/>
+    <ColorAlias name="solo safe: led active" alias="alert:ruddy"/>
+    <ColorAlias name="stereo panner bg" alias="theme:bg2"/>
+    <ColorAlias name="stereo panner fill" alias="widget:blue"/>
+    <ColorAlias name="stereo panner inverted bg" alias="theme:bg2"/>
+    <ColorAlias name="stereo panner inverted fill" alias="theme:contrasting less"/>
+    <ColorAlias name="stereo panner inverted outline" alias="alert:ruddy"/>
+    <ColorAlias name="stereo panner inverted text" alias="neutral:backgroundest"/>
+    <ColorAlias name="stereo panner mono bg" alias="theme:bg2"/>
+    <ColorAlias name="stereo panner mono fill" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono outline" alias="alert:orange"/>
+    <ColorAlias name="stereo panner mono text" alias="neutral:backgroundest"/>
+    <ColorAlias name="stereo panner outline" alias="theme:bg"/>
+    <ColorAlias name="stereo panner rule" alias="theme:bg"/>
+    <ColorAlias name="stereo panner text" alias="neutral:backgroundest"/>
+    <ColorAlias name="stretch clock: background" alias="theme:bg2"/>
+    <ColorAlias name="stretch clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="stretch clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="stretch clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="sync mark" alias="theme:contrasting clock"/>
+    <ColorAlias name="tempo bar" alias="neutral:background2"/>
+    <ColorAlias name="tempo curve" alias="widget:blue"/>
+    <ColorAlias name="tempo marker" alias="widget:orange"/>
+    <ColorAlias name="tempo marker music" alias="widget:orange"/>
+    <ColorAlias name="time axis frame" alias="neutral:backgroundest"/>
+    <ColorAlias name="time axis view item base" alias="widget:gray"/>
+    <ColorAlias name="time stretch fill" alias="theme:contrasting less"/>
+    <ColorAlias name="time stretch outline" alias="widget:gray"/>
+    <ColorAlias name="tracknumber label: fill" alias="theme:bg"/>
+    <ColorAlias name="tracknumber label: fill active" alias="neutral:background2"/>
+    <ColorAlias name="tracknumber label: led active" alias="alert:red"/>
+    <ColorAlias name="transport active option button: fill" alias="widget:bg"/>
+    <ColorAlias name="transport active option button: fill active" alias="alert:green"/>
+    <ColorAlias name="transport active option button: led active" alias="alert:green"/>
+    <ColorAlias name="transport button: fill" alias="widget:bg"/>
+    <ColorAlias name="transport button: fill active" alias="alert:blue"/>
+    <ColorAlias name="transport button: led active" alias="alert:blue"/>
+    <ColorAlias name="transport clock: background" alias="theme:bg2"/>
+    <ColorAlias name="transport clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="transport clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="transport clock: text" alias="theme:contrasting clock"/>
+    <ColorAlias name="transport delta clock: background" alias="theme:bg2"/>
+    <ColorAlias name="transport delta clock: cursor" alias="theme:contrasting alt"/>
+    <ColorAlias name="transport delta clock: edited text" alias="theme:contrasting alt"/>
+    <ColorAlias name="transport delta clock: text" alias="theme:contrasting alt"/>
+    <ColorAlias name="transport drag rect" alias="neutral:midground"/>
+    <ColorAlias name="transport loop rect" alias="alert:green"/>
+    <ColorAlias name="transport marker bar" alias="neutral:background2"/>
+    <ColorAlias name="transport option button: fill" alias="widget:bg"/>
+    <ColorAlias name="transport option button: fill active" alias="widget:bg"/>
+    <ColorAlias name="transport option button: led active" alias="alert:green"/>
+    <ColorAlias name="transport punch rect" alias="widget:ruddy"/>
+    <ColorAlias name="transport recenable button: fill" alias="widget:bg"/>
+    <ColorAlias name="transport recenable button: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="transport recenable button: led active" alias="alert:red"/>
+    <ColorAlias name="trim handle" alias="alert:blue"/>
+    <ColorAlias name="trim handle locked" alias="alert:ruddy"/>
+    <ColorAlias name="trim knob" alias="widget:bg"/>
+    <ColorAlias name="trim knob: arc end" alias="widget:blue"/>
+    <ColorAlias name="trim knob: arc start" alias="widget:blue"/>
+    <ColorAlias name="vari button: fill" alias="widget:bg"/>
+    <ColorAlias name="vari button: fill active" alias="alert:ruddy"/>
+    <ColorAlias name="vca assign button: fill" alias="widget:bg"/>
+    <ColorAlias name="verbose canvas cursor" alias="theme:contrasting clock"/>
+    <ColorAlias name="video timeline bar" alias="neutral:background2"/>
+    <ColorAlias name="waveform fill" alias="neutral:foregroundest"/>
+    <ColorAlias name="waveform outline" alias="neutral:midground"/>
+    <ColorAlias name="zero line" alias="neutral:midground"/>
+    <ColorAlias name="zoom button: fill" alias="widget:bg"/>
+    <ColorAlias name="zoom button: fill active" alias="alert:green"/>
+    <ColorAlias name="zoom button: led active" alias="alert:green"/>
+  </ColorAliases>
+  <Modifiers>
+    <Modifier name="audio bus base" modifier="= alpha:0.29999999999999999"/>
+    <Modifier name="audio track base" modifier="= alpha:0.29999999999999999"/>
+    <Modifier name="automation line fill" modifier="= alpha:0.29999999999999999"/>
+    <Modifier name="automation track fill" modifier="= alpha:0.5"/>
+    <Modifier name="covered region base" modifier="= alpha:0.69999999999999996"/>
+    <Modifier name="crossfade alpha" modifier="= alpha:0.20000000000000001"/>
+    <Modifier name="dragging region" modifier="= alpha:0.5"/>
+    <Modifier name="editable region" modifier="= alpha:0.10000000000000001"/>
+    <Modifier name="gain line inactive" modifier="= alpha:0.80000000000000004"/>
+    <Modifier name="ghost track base" modifier="= alpha:0.3"/>
+    <Modifier name="ghost track midi fill" modifier="= alpha:0.29999999999999999"/>
+    <Modifier name="grid line" modifier="= alpha:0.81945799457994584"/>
+    <Modifier name="inactive crossfade" modifier="= alpha:0.40000000000000002"/>
+    <Modifier name="loop rectangle" modifier="= alpha:0.5"/>
+    <Modifier name="marker bar" modifier="= alpha:0.49864498644986449"/>
+    <Modifier name="midi note" modifier="= alpha:0.91869918699186992"/>
+    <Modifier name="midi note velocity text" modifier="= alpha:0.69999999999999996"/>
+    <Modifier name="midi patch change fill" modifier="= alpha:0.59999999999999998"/>
+    <Modifier name="midi sysex fill" modifier="= alpha:0.5"/>
+    <Modifier name="midi track base" modifier="= alpha:0.29999999999999999"/>
+    <Modifier name="mono panner position fill" modifier="= alpha:0.80000000000000004"/>
+    <Modifier name="panner fill" modifier="= alpha:0.80000000000000004"/>
+    <Modifier name="piano roll black" modifier="= alpha:0.16531165311653118"/>
+    <Modifier name="piano roll white" modifier="= alpha:0.16531165311653118"/>
+    <Modifier name="recording rect" modifier="= alpha:0.25"/>
+    <Modifier name="region alpha" modifier="= alpha:0.75"/>
+    <Modifier name="region mark" modifier="= alpha:0.80000000000000004"/>
+    <Modifier name="scroomer alpha" modifier="= alpha:0.25"/>
+    <Modifier name="selected midi note" modifier="= alpha:1"/>
+    <Modifier name="selection rect" modifier="= alpha:0.13"/>
+    <Modifier name="silence" modifier="= alpha:0.5"/>
+    <Modifier name="stereo panner inverted" modifier="= alpha:0.69999999999999996"/>
+    <Modifier name="stereo panner inverted bg" modifier="= alpha:0.69999999999999996"/>
+    <Modifier name="time axis view item base" modifier="= alpha:0.69999999999999996"/>
+    <Modifier name="time stretch fill" modifier="= alpha:0.5"/>
+    <Modifier name="transparent region base" modifier="= alpha:1"/>
+    <Modifier name="verbose canvas cursor" modifier="= alpha:0.5"/>
+  </Modifiers>
+</Ardour>


### PR DESCRIPTION
This adds a new theme based on the Adwaita color palette for the GNOME desktop (See [GNOME HIG](https://developer.gnome.org/hig/resources.html)).

![Screenshot from 2024-01-03 11-36-20](https://github.com/Ardour/ardour/assets/123539/349522b3-dd45-4420-a926-f2e87103de56)
![Screenshot from 2024-01-03 11-36-51](https://github.com/Ardour/ardour/assets/123539/ff547ea0-d27c-4776-bb6e-8fbe9eea4fc4)

With the GNOME color palette and another GNOME app (Software) for comparison:
![Screenshot from 2024-01-03 11-37-49](https://github.com/Ardour/ardour/assets/123539/725cf5f3-64df-4cd4-8c43-ef15d74cd8d7)
