### PR TITLE
Fix Legatize::operator() by not removing 1 tick

### DIFF
--- a/libs/ardour/legatize.cc
+++ b/libs/ardour/legatize.cc
@@ -43,7 +43,7 @@ Legatize::operator()(std::shared_ptr<ARDOUR::MidiModel> model,
 				break;
 			}
 
-			const Temporal::Beats new_end = (*next)->time() - Temporal::Beats::one_tick();
+			const Temporal::Beats new_end = (*next)->time();
 			if ((*i)->end_time() > new_end ||
 			    (!_shrink_only && (*i)->end_time() < new_end)) {
 				const Temporal::Beats new_length(new_end - (*i)->time());


### PR DESCRIPTION
Please find the following video as complementary explanation

https://odysee.com/@ngeiswei:d/fix-legatize:5
