### PR TITLE
UI tweaks

### DIFF
--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -1058,6 +1058,8 @@ style "tooltip" = "medium_text"
 	fg[NORMAL] = @fg_tooltip
 	bg[NORMAL] = @bg_tooltip
 	bg[SELECTED] = @bg_tooltip
+	xthickness = 4
+	ythickness = 4
 }
 
 style "default_toggle_button"

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -282,7 +282,7 @@ style "inspector_processor_list" = "processor_list"
 
 style "time_info_box"
 {
-        bg[NORMAL] = { 0.00, 0.00, 0.00 }
+        bg[NORMAL] = @darkest
 }
 
 style "status_bar_box"

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -967,6 +967,12 @@ style "processor_list" = "very_small_text"
 	bg[ACTIVE] = shade (1.8, @fg_selected)
 	fg[ACTIVE] = @bases
 }
+style "processor_scroller"
+{
+	bg[ACTIVE] = @bases
+	ythickness = 1
+	xthickness = 0
+}
 
 # MixerPanZone:
 #
@@ -1255,6 +1261,7 @@ widget "*LocationEditRemoveButton*" style:highest "location_row_button"
 widget "*ChannelCountSelector" style:highest "medium_bold_entry"
 widget "*RegionListWholeFile" style:highest "treeview_parent_node"
 widget "*ProcessorList*" style:highest "processor_list"
+widget "*ProcessorScroller*" style:highest "processor_scroller"
 widget "*PortMatrixLabel*" style:highest "small_text"
 widget "*MainMenuBar" style:highest "status_bar_box"
 widget "*midi device" style:highest "midi_device"

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -897,7 +897,7 @@ style "track_name_editor" = "medium_text"
 
 style "track_separator"
 {
-	bg[NORMAL] = lighter(@background)
+	bg[NORMAL] = darker(@background)
 }
 
 # Plugin Editors

--- a/gtk2_ardour/clearlooks.rc.in
+++ b/gtk2_ardour/clearlooks.rc.in
@@ -1051,6 +1051,7 @@ style "tooltip" = "medium_text"
 {
 	fg[NORMAL] = @fg_tooltip
 	bg[NORMAL] = @bg_tooltip
+	bg[SELECTED] = @bg_tooltip
 }
 
 style "default_toggle_button"

--- a/gtk2_ardour/editor_rulers.cc
+++ b/gtk2_ardour/editor_rulers.cc
@@ -716,13 +716,13 @@ Editor::update_ruler_visibility ()
 		_selection_marker_group->hide ();
 	}
 
-	ruler_separator->set_y_position ((int)(timebar_height * visible_timebars));
-
-	time_bars_vbox.set_size_request (-1, (int)(timebar_height * visible_timebars) + 1);
+	int ruler_separator_y = std::max(1, (int)(timebar_height * visible_timebars));
+	ruler_separator->set_y_position (ruler_separator_y);
+	time_bars_vbox.set_size_request (-1, ruler_separator_y);
 
 	/* move hv_scroll_group (trackviews) to the end of the timebars */
 
-	hv_scroll_group->set_y_position ((int)(timebar_height * visible_timebars));
+	hv_scroll_group->set_y_position (ruler_separator_y);
 
 	compute_fixed_ruler_scale ();
 	update_fixed_rulers();

--- a/gtk2_ardour/mixer_strip.cc
+++ b/gtk2_ardour/mixer_strip.cc
@@ -358,6 +358,7 @@ MixerStrip::init ()
 		scrollbar_height += 3; // track_display_frame border/shadow
 	}
 	spacer.set_size_request (-1, scrollbar_height);
+	spacer.set_name ("AudioBusStripBase");
 	global_vpacker.pack_end (spacer, false, false);
 #endif
 

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -1961,6 +1961,7 @@ ProcessorBox::ProcessorBox (ARDOUR::Session* sess, boost::function<PluginSelecto
 	no_processor_redisplay = false;
 
 	processor_scroller.set_policy (Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
+	processor_scroller.set_name ("ProcessorScroller");
 	processor_scroller.add (processor_display);
 	pack_start (processor_scroller, true, true);
 

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -1864,7 +1864,8 @@ ProcessorEntry::PluginInlineDisplay::update_height_alloc (uint32_t inline_height
 void
 ProcessorEntry::PluginInlineDisplay::display_frame (cairo_t* cr, double w, double h)
 {
-	Gtkmm2ext::rounded_rectangle (cr, .5, -1.5, w - 1, h + 1, 7);
+	Gtkmm2ext::rounded_rectangle (cr, 1.5, -0.5, w - 3, h - 1.0, 2.5);
+
 }
 
 ProcessorEntry::LuaPluginDisplay::LuaPluginDisplay (ProcessorEntry& e, std::shared_ptr<ARDOUR::LuaProc> p, uint32_t max_height)

--- a/gtk2_ardour/themes/adwaita_dark-ardour.colors
+++ b/gtk2_ardour/themes/adwaita_dark-ardour.colors
@@ -94,6 +94,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>
@@ -114,6 +115,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:blue"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="widget:green lighter"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:midground"/>
@@ -202,6 +204,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -200,6 +200,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -91,6 +91,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/blueberry_milk-ardour.colors
+++ b/gtk2_ardour/themes/blueberry_milk-ardour.colors
@@ -111,6 +111,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/caineville-ardour.colors
+++ b/gtk2_ardour/themes/caineville-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="neutral:foreground2"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/clear_gray-ardour.colors
+++ b/gtk2_ardour/themes/clear_gray-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="neutral:foreground2"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/cubasish-ardour.colors
+++ b/gtk2_ardour/themes/cubasish-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -94,6 +94,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -114,6 +114,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/dark-ardour.colors
+++ b/gtk2_ardour/themes/dark-ardour.colors
@@ -203,6 +203,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/diehard3-ardour.colors
+++ b/gtk2_ardour/themes/diehard3-ardour.colors
@@ -93,6 +93,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:backgroundest"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/diehard3-ardour.colors
+++ b/gtk2_ardour/themes/diehard3-ardour.colors
@@ -113,6 +113,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/diehard3-ardour.colors
+++ b/gtk2_ardour/themes/diehard3-ardour.colors
@@ -202,6 +202,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:backgroundest"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/recbox-ardour.colors
+++ b/gtk2_ardour/themes/recbox-ardour.colors
@@ -202,6 +202,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:background"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/recbox-ardour.colors
+++ b/gtk2_ardour/themes/recbox-ardour.colors
@@ -113,6 +113,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="neutral:background"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/recbox-ardour.colors
+++ b/gtk2_ardour/themes/recbox-ardour.colors
@@ -93,6 +93,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:background"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -111,6 +111,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:blue"/>
+    <ColorAlias name="generic button: outline" alias="neutral:background"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:background"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -200,6 +200,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="neutral:background"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/themes/unastudia-ardour.colors
+++ b/gtk2_ardour/themes/unastudia-ardour.colors
@@ -91,6 +91,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="neutral:background"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -92,6 +92,7 @@
     <ColorAlias name="entered automation line" alias="widget:orange"/>
     <ColorAlias name="entered gain line" alias="widget:orange"/>
     <ColorAlias name="entered marker" alias="widget:orange"/>
+    <ColorAlias name="fader outline" alias="theme:bg2"/>
     <ColorAlias name="feedback alert: alt active" alias="alert:ruddy"/>
     <ColorAlias name="feedback alert: fill" alias="widget:bg"/>
     <ColorAlias name="feedback alert: fill active" alias="alert:red"/>

--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -112,6 +112,7 @@
     <ColorAlias name="generic button: fill" alias="widget:bg"/>
     <ColorAlias name="generic button: fill active" alias="alert:red"/>
     <ColorAlias name="generic button: led active" alias="alert:green"/>
+    <ColorAlias name="generic button: outline" alias="theme:bg2"/>
     <ColorAlias name="ghost track base" alias="neutral:background2"/>
     <ColorAlias name="ghost track midi outline" alias="neutral:backgroundest"/>
     <ColorAlias name="ghost track wave" alias="neutral:midground"/>

--- a/gtk2_ardour/themes/xcolors-ardour.colors
+++ b/gtk2_ardour/themes/xcolors-ardour.colors
@@ -201,6 +201,7 @@
     <ColorAlias name="meter color BBC" alias="alert:orange"/>
     <ColorAlias name="meter marker" alias="widget:orange"/>
     <ColorAlias name="meter marker music" alias="widget:orange"/>
+    <ColorAlias name="meter outline" alias="theme:bg2"/>
     <ColorAlias name="meterbridge label: fill" alias="theme:bg"/>
     <ColorAlias name="meterbridge label: fill active" alias="neutral:background2"/>
     <ColorAlias name="meterbridge label: led" alias="alert:red"/>

--- a/gtk2_ardour/time_axis_view.cc
+++ b/gtk2_ardour/time_axis_view.cc
@@ -788,13 +788,11 @@ TimeAxisView::set_selected (bool yn)
 	AxisView::set_selected (yn);
 
 	if (_selected) {
-		time_axis_frame.set_shadow_type (Gtk::SHADOW_IN);
-		time_axis_frame.set_name ("MixerStripSelectedFrame");
+		time_axis_frame.set_name (controls_base_selected_name);
 		controls_ebox.set_name (controls_base_selected_name);
 		controls_vbox.set_name (controls_base_selected_name);
 		time_axis_vbox.set_name (controls_base_selected_name);
 	} else {
-		time_axis_frame.set_shadow_type (Gtk::SHADOW_NONE);
 		time_axis_frame.set_name (controls_base_unselected_name);
 		controls_ebox.set_name (controls_base_unselected_name);
 		controls_vbox.set_name (controls_base_unselected_name);

--- a/libs/widgets/ardour_button.cc
+++ b/libs/widgets/ardour_button.cc
@@ -783,12 +783,17 @@ ArdourButton::set_colors ()
 {
 	_update_colors = false;
 
+	std::string name = get_name();
+	bool failed = false;
+
+	outline_color = UIConfigurationBase::instance().color (string_compose ("%1: outline", name), &failed);
+	if (failed) {
+		outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+	}
+
 	if (_fixed_colors_set == 0x3) {
 		return;
 	}
-
-	std::string name = get_name();
-	bool failed = false;
 
 	if (!(_fixed_colors_set & 0x1)) {
 		fill_active_color = UIConfigurationBase::instance().color (string_compose ("%1: fill active", name), &failed);
@@ -811,9 +816,6 @@ ArdourButton::set_colors ()
 	if (failed) {
 		led_active_color = UIConfigurationBase::instance().color ("generic button: led active");
 	}
-
-	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
-
 
 	/* The inactive color for the LED is just a fairly dark version of the
 	 * active color.

--- a/libs/widgets/ardour_button.cc
+++ b/libs/widgets/ardour_button.cc
@@ -130,6 +130,7 @@ ArdourButton::ArdourButton (const std::string& str, Element e, bool toggle)
 	, led_inactive_color(0)
 	, led_custom_color (0)
 	, use_custom_led_color (false)
+	, outline_color (0)
 	, convex_pattern (0)
 	, concave_pattern (0)
 	, led_inset_pattern (0)
@@ -320,7 +321,7 @@ ArdourButton::render (Cairo::RefPtr<Cairo::Context> const& ctx, cairo_rectangle_
 	// draw edge (filling a rect underneath, rather than stroking a border on top, allows the corners to be lighter-weight.
 	if ((_elements & (Body|Edge)) == (Body|Edge)) {
 		rounded_function (cr, 0, 0, get_width(), get_height(), corner_radius + 1.5);
-		cairo_set_source_rgba (cr, 0, 0, 0, 1);
+		Gtkmm2ext::set_source_rgba (cr, outline_color);
 		cairo_fill(cr);
 	}
 
@@ -810,6 +811,9 @@ ArdourButton::set_colors ()
 	if (failed) {
 		led_active_color = UIConfigurationBase::instance().color ("generic button: led active");
 	}
+
+	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+
 
 	/* The inactive color for the LED is just a fairly dark version of the
 	 * active color.

--- a/libs/widgets/ardour_fader.cc
+++ b/libs/widgets/ardour_fader.cc
@@ -84,7 +84,7 @@ ArdourFader::ArdourFader (Gtk::Adjustment& adj, int orientation, int fader_lengt
 		CairoWidget::set_size_request(_span, _girth);
 	}
 
-	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+	outline_color = UIConfigurationBase::instance().color ("fader outline");
 
 }
 

--- a/libs/widgets/ardour_fader.cc
+++ b/libs/widgets/ardour_fader.cc
@@ -29,6 +29,7 @@
 #include "gtkmm2ext/utils.h"
 
 #include "widgets/ardour_fader.h"
+#include "widgets/ui_config.h"
 
 using namespace Gtk;
 using namespace std;
@@ -60,6 +61,7 @@ ArdourFader::ArdourFader (Gtk::Adjustment& adj, int orientation, int fader_lengt
 	, _current_parent (0)
 	, have_explicit_bg (false)
 	, have_explicit_fg (false)
+	, outline_color (0)
 {
 	_default_value = _adjustment.get_value();
 	update_unity_position ();
@@ -81,6 +83,9 @@ ArdourFader::ArdourFader (Gtk::Adjustment& adj, int orientation, int fader_lengt
 	} else {
 		CairoWidget::set_size_request(_span, _girth);
 	}
+
+	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+
 }
 
 ArdourFader::~ArdourFader ()
@@ -280,7 +285,8 @@ ArdourFader::render (Cairo::RefPtr<Cairo::Context> const& ctx, cairo_rectangle_t
 	cairo_fill(cr);
 
 	cairo_set_line_width (cr, 2);
-	cairo_set_source_rgba (cr, 0, 0, 0, 1.0);
+	Gtkmm2ext::set_source_rgba (cr, outline_color);
+
 
 	cairo_matrix_t matrix;
 	Gtkmm2ext::rounded_rectangle (cr, CORNER_OFFSET, CORNER_OFFSET, w-CORNER_SIZE, h-CORNER_SIZE, CORNER_RADIUS);

--- a/libs/widgets/fastmeter.cc
+++ b/libs/widgets/fastmeter.cc
@@ -130,7 +130,7 @@ FastMeter::FastMeter (long hold, unsigned long dimen, Orientation o, int len,
 	request_width = pixrect.width + 2;
 	request_height= pixrect.height + 2;
 
-	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
+	outline_color = UIConfigurationBase::instance().color ("meter outline");
 
 	clear ();
 }

--- a/libs/widgets/fastmeter.cc
+++ b/libs/widgets/fastmeter.cc
@@ -30,6 +30,9 @@
 #include "gtkmm2ext/utils.h"
 #include "widgets/fastmeter.h"
 
+#include "widgets/ui_config.h"
+
+
 #define UINT_TO_RGB(u,r,g,b) { (*(r)) = ((u)>>16)&0xff; (*(g)) = ((u)>>8)&0xff; (*(b)) = (u)&0xff; }
 #define UINT_TO_RGBA(u,r,g,b,a) { UINT_TO_RGB(((u)>>8),r,g,b); (*(a)) = (u)&0xff; }
 
@@ -69,6 +72,7 @@ FastMeter::FastMeter (long hold, unsigned long dimen, Orientation o, int len,
 	, current_level(0)
 	, current_peak(0)
 	, highlight(false)
+	, outline_color(0)
 {
 	last_peak_rect.width = 0;
 	last_peak_rect.height = 0;
@@ -125,6 +129,8 @@ FastMeter::FastMeter (long hold, unsigned long dimen, Orientation o, int len,
 
 	request_width = pixrect.width + 2;
 	request_height= pixrect.height + 2;
+
+	outline_color = UIConfigurationBase::instance().color ("generic button: outline");
 
 	clear ();
 }
@@ -561,7 +567,7 @@ FastMeter::vertical_expose (cairo_t* cr, cairo_rectangle_t* area)
 	GdkRectangle background;
 	GdkRectangle eventarea;
 
-	cairo_set_source_rgb (cr, 0, 0, 0); // black
+	Gtkmm2ext::set_source_rgba (cr, outline_color);
 	rounded_rectangle (cr, 0, 0, pixwidth + 2, pixheight + 2, 2);
 	cairo_stroke (cr);
 
@@ -634,7 +640,7 @@ FastMeter::horizontal_expose (cairo_t* cr, cairo_rectangle_t* area)
 	GdkRectangle background;
 	GdkRectangle eventarea;
 
-	cairo_set_source_rgb (cr, 0, 0, 0); // black
+	Gtkmm2ext::set_source_rgba (cr, outline_color);
 	rounded_rectangle (cr, 0, 0, pixwidth + 2, pixheight + 2, 2);
 	cairo_stroke (cr);
 

--- a/libs/widgets/widgets/ardour_button.h
+++ b/libs/widgets/widgets/ardour_button.h
@@ -195,6 +195,9 @@ class LIBWIDGETS_API ArdourButton : public CairoWidget , public Gtkmm2ext::Activ
 	uint32_t led_custom_color;
 	bool     use_custom_led_color;
 
+	uint32_t outline_color;
+
+
 	cairo_pattern_t* convex_pattern;
 	cairo_pattern_t* concave_pattern;
 	cairo_pattern_t* led_inset_pattern;

--- a/libs/widgets/widgets/ardour_fader.h
+++ b/libs/widgets/widgets/ardour_fader.h
@@ -110,6 +110,8 @@ private:
 	Gtkmm2ext::Color explicit_fg;
 	bool have_explicit_fg;
 
+	uint32_t outline_color;
+
 	void create_patterns();
 	void adjustment_changed ();
 	void set_adjustment_from_event (GdkEventButton *);

--- a/libs/widgets/widgets/fastmeter.h
+++ b/libs/widgets/widgets/fastmeter.h
@@ -96,6 +96,8 @@ private:
 	float current_user_level;
 	bool highlight;
 
+	uint32_t outline_color;
+
 	void vertical_expose (cairo_t*, cairo_rectangle_t*);
 	void vertical_size_request (GtkRequisition*);
 	void vertical_size_allocate (Gtk::Allocation&);


### PR DESCRIPTION
I'm back with a few minor ui tweaks! This time I avoided structural changes for real

- removed track header inner shadow in TAV (less fuzzy) 
- themable outline color for buttons, meters & faders
- properly aligned horizontal separator between track headers in TAV (a separator after the last track is still missing though)
- more visible horizontal separator between track headers in TAV (using darker color variant instead of ligher)
- cleaner processor list layout (1px inner stroke removed, more consistent inline display radius and spacing)
- slightly padded tooltips & consistent outline color

That's pretty much it :)