### PR TITLE
ytk: Fix function pointer casting compiler error with clang

### DIFF
--- a/libs/tk/ytk/gtkscale.c
+++ b/libs/tk/ytk/gtkscale.c
@@ -1471,7 +1471,7 @@ gtk_scale_add_mark (GtkScale        *scale,
   mark->position = position;
  
   priv->marks = g_slist_insert_sorted_with_data (priv->marks, mark,
-                                                 (GCompareFunc) compare_marks,
+                                                 (GCompareDataFunc) compare_marks,
                                                  GINT_TO_POINTER (
                                                    gtk_range_get_inverted (GTK_RANGE (scale)) 
                                                    ));


### PR DESCRIPTION

    This fixes the following compiler error.
    
    ../libs/tk/ytk/gtkscale.c:1474:50: error: incompatible function pointer types passing
    'GCompareFunc' (aka 'int (*)(const void *, const void *)') to parameter of type
    'GCompareDataFunc' (aka 'int (*)(const void *, const void *, void *)') [-Wincompatible-function-pointer-types]
        (GCompareFunc) compare_marks,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/glib-2.0/glib/gslist.h:76:26: note: passing argument to parameter 'func' here
        GCompareDataFunc  func,
        ^
