### PR TITLE
Change default archive audio format to FLAC 24bit

### DIFF
--- a/gtk2_ardour/session_archive_dialog.cc
+++ b/gtk2_ardour/session_archive_dialog.cc
@@ -46,7 +46,7 @@ SessionArchiveDialog::SessionArchiveDialog ()
 	encode_selector.append (_("None"));
 	encode_selector.append (_("FLAC 16bit"));
 	encode_selector.append (_("FLAC 24bit"));
-	encode_selector.set_active_text (_("FLAC 16bit")); // TODO remember
+	encode_selector.set_active_text (_("FLAC 24bit")); // TODO remember
 
 	compression_selector.append (_("None"));
 	compression_selector.append (_("Fast"));

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -610,7 +610,7 @@ public:
 	};
 
 	int archive_session (const std::string&, const std::string&,
-	                     ArchiveEncode compress_audio = FLAC_16BIT,
+	                     ArchiveEncode compress_audio = FLAC_24BIT,
 	                     PBD::FileArchive::CompressionLevel compression_level = PBD::FileArchive::CompressGood,
 	                     bool only_used_sources = false,
 	                     PBD::Progress* p = 0);


### PR DESCRIPTION
Hi, so I think this is a better default because it does not lose as much dynamic range in case one accidentally just pressed "OK" in the archive dialog without double checking the options every damn time (currently always resets to FLAC 16bit)

Although this is not perfect yet in another case:
The archive feature currently reencodes ALL audio files of a project. So if one set the project format to FLAC 16bit but makes an archive in FLAC 24bit, the archive can become larger than the original project directory

So to improve on that, Ardour should check files before encoding and only encode those where it makes sense. It should skip re-encoding into the same format or if the original file has the same codec but lower bit-depth

This can be implemented in another PR. I tried but failed for now. So if anyone else wants to work on that (or help me out), feel free to do so