### PR TITLE
Grid/Snap: fix triplets/quintuplets, disable broken septuplets

### DIFF
--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -3079,6 +3079,9 @@ Editor::_snap_to_bbt (timepos_t const & presnap, Temporal::RoundMode direction, 
 			case GridTypeBeatDiv7:
 			case GridTypeBeatDiv14:
 			case GridTypeBeatDiv28:
+				// Septuplets suffer from drifting until libtemporal handles fractional ticks
+				// or if ticks_per_beat (ppqn) is raised to a point where the result
+				// of Temporal::ticks_per_beat / beat_div is always an integer
 				divisor = 3.5;
 				break;
 			case GridTypeBeat:
@@ -3616,15 +3619,17 @@ Editor::build_grid_type_menu ()
 	}
 	grid_type_selector.AddMenuElem (Menu_Helpers::MenuElem (_("Quintuplets"), *_quintuplet_menu));
 
-	/* septuplet grid */
-	Gtk::Menu *_septuplet_menu = manage (new Menu);
-	MenuList& septuplet_items (_septuplet_menu->items());
-	{
-		septuplet_items.push_back (MenuElem (grid_type_strings[(int)GridTypeBeatDiv7],  sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeBeatDiv7)));
-		septuplet_items.push_back (MenuElem (grid_type_strings[(int)GridTypeBeatDiv14], sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeBeatDiv14)));
-		septuplet_items.push_back (MenuElem (grid_type_strings[(int)GridTypeBeatDiv28], sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeBeatDiv28)));
-	}
-	grid_type_selector.AddMenuElem (Menu_Helpers::MenuElem (_("Septuplets"), *_septuplet_menu));
+	/* septuplet grid */	
+	// Septuplets suffer from drifting and can't be draw properly until libtemporal handles fractional ticks
+	// or if ticks_per_beat (ppqn) is raised to a point where the result
+	// of Temporal::ticks_per_beat / beat_div is always an integer	// Gtk::Menu *_septuplet_menu = manage (new Menu);
+	// MenuList& septuplet_items (_septuplet_menu->items());
+	// {
+	// 	septuplet_items.push_back (MenuElem (grid_type_strings[(int)GridTypeBeatDiv7],  sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeBeatDiv7)));
+	// 	septuplet_items.push_back (MenuElem (grid_type_strings[(int)GridTypeBeatDiv14], sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeBeatDiv14)));
+	// 	septuplet_items.push_back (MenuElem (grid_type_strings[(int)GridTypeBeatDiv28], sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeBeatDiv28)));
+	// }
+	// grid_type_selector.AddMenuElem (Menu_Helpers::MenuElem (_("Septuplets"), *_septuplet_menu));
 
 	grid_type_selector.AddMenuElem(SeparatorElem());
 	grid_type_selector.AddMenuElem (MenuElem (grid_type_strings[(int)GridTypeTimecode], sigc::bind (sigc::mem_fun(*this, &Editor::grid_type_selection_done), (GridType) GridTypeTimecode)));

--- a/gtk2_ardour/editor.cc
+++ b/gtk2_ardour/editor.cc
@@ -3063,7 +3063,7 @@ Editor::_snap_to_bbt (timepos_t const & presnap, Temporal::RoundMode direction, 
 		 * for the snap, based on the grid setting.
 		 */
 
-		int divisor;
+		float divisor;
 		switch (_grid_type) {
 			case GridTypeBeatDiv3:
 			case GridTypeBeatDiv6:
@@ -3074,12 +3074,12 @@ Editor::_snap_to_bbt (timepos_t const & presnap, Temporal::RoundMode direction, 
 			case GridTypeBeatDiv5:
 			case GridTypeBeatDiv10:
 			case GridTypeBeatDiv20:
-				divisor = 5;
+				divisor = 2.5;
 				break;
 			case GridTypeBeatDiv7:
 			case GridTypeBeatDiv14:
 			case GridTypeBeatDiv28:
-				divisor = 7;
+				divisor = 3.5;
 				break;
 			case GridTypeBeat:
 				divisor = 1;

--- a/gtk2_ardour/editor_tempodisplay.cc
+++ b/gtk2_ardour/editor_tempodisplay.cc
@@ -358,7 +358,7 @@ Editor::compute_current_bbt_points (Temporal::TempoMapPoints& grid, samplepos_t 
 	const Beats lower_beat = (left < Beats() ? Beats() : left);
 	const samplecnt_t sr (_session->sample_rate());
 
-	int divisor;
+	float divisor;
 	switch (_grid_type) {
 		case GridTypeBeatDiv3:
 		case GridTypeBeatDiv6:
@@ -369,12 +369,12 @@ Editor::compute_current_bbt_points (Temporal::TempoMapPoints& grid, samplepos_t 
 		case GridTypeBeatDiv5:
 		case GridTypeBeatDiv10:
 		case GridTypeBeatDiv20:
-			divisor = 5;
+			divisor = 2.5;
 			break;
 		case GridTypeBeatDiv7:
 		case GridTypeBeatDiv14:
 		case GridTypeBeatDiv28:
-			divisor = 7;
+			divisor = 3.5;
 			break;
 		default:
 			divisor = 2;

--- a/gtk2_ardour/editor_tempodisplay.cc
+++ b/gtk2_ardour/editor_tempodisplay.cc
@@ -374,6 +374,9 @@ Editor::compute_current_bbt_points (Temporal::TempoMapPoints& grid, samplepos_t 
 		case GridTypeBeatDiv7:
 		case GridTypeBeatDiv14:
 		case GridTypeBeatDiv28:
+			// Septuplets can't be drawn until libtemporal handles fractional ticks
+			// or if ticks_per_beat (ppqn) is raised to a point where the result
+			// of Temporal::ticks_per_beat / beat_div is always an integer
 			divisor = 3.5;
 			break;
 		default:

--- a/gtk2_ardour/editor_tempodisplay.cc
+++ b/gtk2_ardour/editor_tempodisplay.cc
@@ -358,25 +358,48 @@ Editor::compute_current_bbt_points (Temporal::TempoMapPoints& grid, samplepos_t 
 	const Beats lower_beat = (left < Beats() ? Beats() : left);
 	const samplecnt_t sr (_session->sample_rate());
 
+	int divisor;
+	switch (_grid_type) {
+		case GridTypeBeatDiv3:
+		case GridTypeBeatDiv6:
+		case GridTypeBeatDiv12:
+		case GridTypeBeatDiv24:
+			divisor = 3;
+			break;
+		case GridTypeBeatDiv5:
+		case GridTypeBeatDiv10:
+		case GridTypeBeatDiv20:
+			divisor = 5;
+			break;
+		case GridTypeBeatDiv7:
+		case GridTypeBeatDiv14:
+		case GridTypeBeatDiv28:
+			divisor = 7;
+			break;
+		default:
+			divisor = 2;
+			break;
+	};
+
 	switch (bbt_ruler_scale) {
 
 	case bbt_show_quarters:
 		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 1);
 		break;
 	case bbt_show_eighths:
-		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 2);
+		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 1 * divisor);
 		break;
 	case bbt_show_sixteenths:
-		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 4);
+		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 2 * divisor);
 		break;
 	case bbt_show_thirtyseconds:
-		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 8);
+		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 4 * divisor);
 		break;
 	case bbt_show_sixtyfourths:
-		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 16);
+		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 8 * divisor);
 		break;
 	case bbt_show_onetwentyeighths:
-		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 32);
+		tmap->get_grid (grid, max (tmap->superclock_at (lower_beat), (superclock_t) 0), samples_to_superclock (rightmost, sr), 0, 16 * divisor);
 		break;
 
 	case bbt_show_1:


### PR DESCRIPTION
This PR addresses the regression described in this [ticket](https://tracker.ardour.org/view.php?id=9316).

- triplets are now drawn and snapped to correctly
- quintuplets are now drawn and snapped to correctly
- septuplets are still broken (see comments in last commit) and should be disabled until libtemporal is able to cope with these subdivisions