### PR TITLE
mixer: use ardour widgets instead of gtk natives for plugin list

### DIFF
--- a/gtk2_ardour/mixer_ui.cc
+++ b/gtk2_ardour/mixer_ui.cc
@@ -112,6 +112,13 @@ using namespace std;
 using PBD::atoi;
 using PBD::Unwinder;
 
+static const gchar *_plugin_list_mode_strings[] = {
+	N_("Favorite Plugins"),
+	N_("Recent Plugins"),
+	N_("Top-10 Plugins"),
+	0
+};
+
 Mixer_UI* Mixer_UI::_instance = 0;
 
 Mixer_UI*
@@ -126,7 +133,7 @@ Mixer_UI::instance ()
 
 Mixer_UI::Mixer_UI ()
 	: Tabbable (_content, _("Mixer"), X_("mixer"))
-	, plugin_search_clear_button (Stock::CLEAR)
+	, plugin_search_clear_button (X_("Clear"))
 	, _mixer_scene_release (0)
 	, no_track_list_redisplay (false)
 	, in_group_row_change (false)
@@ -146,6 +153,9 @@ Mixer_UI::Mixer_UI ()
 	, _strip_selection_change_without_scroll (false)
 	, _selection (*this, *this)
 {
+
+	plugin_list_mode_strings = I18N (_plugin_list_mode_strings);
+
 	load_bindings ();
 	register_actions ();
 	Glib::RefPtr<ToggleAction> fb_act = ActionManager::get_toggle_action ("Mixer", "ToggleFoldbackStrip");
@@ -268,14 +278,14 @@ Mixer_UI::Mixer_UI ()
 	favorite_plugins_model->signal_row_has_child_toggled().connect (sigc::mem_fun (*this, &Mixer_UI::sync_treeview_favorite_ui_state));
 	favorite_plugins_model->signal_row_deleted().connect (sigc::mem_fun (*this, &Mixer_UI::favorite_plugins_deleted));
 
-	favorite_plugins_mode_combo.append (_("Favorite Plugins"));
-	favorite_plugins_mode_combo.append (_("Recent Plugins"));
-	favorite_plugins_mode_combo.append (_("Top-10 Plugins"));
-	favorite_plugins_mode_combo.set_active_text (_("Favorite Plugins"));
-	favorite_plugins_mode_combo.signal_changed().connect (sigc::mem_fun (*this, &Mixer_UI::plugin_list_mode_changed));
+	favorite_plugins_mode_combo.AddMenuElem (Menu_Helpers::MenuElem (_("Favorite Plugins"), sigc::bind(sigc::mem_fun(*this, &Mixer_UI::set_plugin_list_mode), PLM_Favorite)));
+	favorite_plugins_mode_combo.AddMenuElem (Menu_Helpers::MenuElem (_("Recent Plugins"), sigc::bind(sigc::mem_fun(*this, &Mixer_UI::set_plugin_list_mode), PLM_Recent)));
+	favorite_plugins_mode_combo.AddMenuElem (Menu_Helpers::MenuElem (_("Top-10 Plugins"), sigc::bind(sigc::mem_fun(*this, &Mixer_UI::set_plugin_list_mode), PLM_TopHits)));
+	favorite_plugins_mode_combo.set_size_request(-1, 24);
+	set_plugin_list_mode(PLM_Favorite);
 
 	plugin_search_entry.signal_changed().connect (sigc::mem_fun (*this, &Mixer_UI::plugin_search_entry_changed));
-	plugin_search_clear_button.signal_clicked().connect (sigc::mem_fun (*this, &Mixer_UI::plugin_search_clear_button_clicked));
+	plugin_search_clear_button.signal_clicked.connect (sigc::mem_fun (*this, &Mixer_UI::plugin_search_clear_button_clicked));
 
 	favorite_plugins_scroller.add (favorite_plugins_display);
 	favorite_plugins_scroller.set_policy (Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
@@ -3122,22 +3132,10 @@ Mixer_UI::monitor_section_detached ()
 	act->set_sensitive (false);
 }
 
-Mixer_UI::PluginListMode
-Mixer_UI::plugin_list_mode () const
-{
-	if (favorite_plugins_mode_combo.get_active_text() == _("Top-10 Plugins")) {
-		return PLM_TopHits;
-	} else if (favorite_plugins_mode_combo.get_active_text() == _("Recent Plugins")) {
-		return PLM_Recent;
-	} else {
-		return PLM_Favorite;
-	}
-}
-
 void
 Mixer_UI::store_current_favorite_order ()
 {
-	if (plugin_list_mode () != PLM_Favorite || !plugin_search_entry.get_text ().empty()) {
+	if (plugin_list_mode != PLM_Favorite || !plugin_search_entry.get_text ().empty()) {
 		return;
 	}
 
@@ -3163,9 +3161,16 @@ Mixer_UI::save_favorite_ui_state (const TreeModel::iterator& iter, const TreeMod
 }
 
 void
-Mixer_UI::plugin_list_mode_changed ()
+Mixer_UI::set_plugin_list_mode (PluginListMode plm)
 {
-	if (plugin_list_mode () == PLM_Favorite) {
+	plugin_list_mode = plm;
+	
+	string str = plugin_list_mode_strings[(int)plm];
+	if (str != favorite_plugins_mode_combo.get_text ()) {
+		favorite_plugins_mode_combo.set_text (str);
+	}
+
+	if (plugin_list_mode == PLM_Favorite) {
 		PBD::Unwinder<bool> uw (ignore_plugin_refill, true);
 		favorite_plugins_search_hbox.show ();
 		plugin_search_entry.set_text ("");
@@ -3178,7 +3183,7 @@ Mixer_UI::plugin_list_mode_changed ()
 void
 Mixer_UI::plugin_search_entry_changed ()
 {
-	if (plugin_list_mode () == PLM_Favorite) {
+	if (plugin_list_mode == PLM_Favorite) {
 		refill_favorite_plugins ();
 	}
 }
@@ -3193,7 +3198,7 @@ void
 Mixer_UI::refiller (PluginInfoList& result, const PluginInfoList& plugs)
 {
 	PluginManager& manager (PluginManager::instance());
-	PluginListMode plm = plugin_list_mode ();
+	PluginListMode plm = plugin_list_mode;
 
 	std::string searchstr = plugin_search_entry.get_text ();
 	setup_search_string (searchstr);
@@ -3264,7 +3269,7 @@ Mixer_UI::refill_favorite_plugins ()
 	refiller (plugs, mgr.lv2_plugin_info ());
 	refiller (plugs, mgr.lua_plugin_info ());
 
-	switch (plugin_list_mode ()) {
+	switch (plugin_list_mode) {
 		default:
 			/* use favorites as-is */
 			break;
@@ -3295,12 +3300,12 @@ Mixer_UI::maybe_refill_favorite_plugins (PluginListMode plm)
 {
 	switch (plm) {
 		case PLM_Favorite:
-			if (plugin_list_mode () == PLM_Favorite) {
+			if (plugin_list_mode == PLM_Favorite) {
 				refill_favorite_plugins();
 			}
 			break;
 		default:
-			if (plugin_list_mode () != PLM_Favorite) {
+			if (plugin_list_mode != PLM_Favorite) {
 				refill_favorite_plugins();
 			}
 			break;
@@ -3330,7 +3335,7 @@ void
 Mixer_UI::sync_treeview_from_favorite_order ()
 {
 	PBD::Unwinder<bool> uw (ignore_plugin_reorder, true);
-	switch (plugin_list_mode ()) {
+	switch (plugin_list_mode) {
 		case PLM_Favorite:
 			{
 				PluginUIOrderSorter cmp (favorite_ui_order);
@@ -3594,14 +3599,14 @@ Mixer_UI::plugin_drag_motion (const Glib::RefPtr<Gdk::DragContext>& ctx, int x, 
 	}
 
 	if (target == "GTK_TREE_MODEL_ROW") {
-		if (plugin_list_mode () == PLM_Favorite && plugin_search_entry.get_text ().empty()) {
+		if (plugin_list_mode == PLM_Favorite && plugin_search_entry.get_text ().empty()) {
 			/* re-order rows */
 			ctx->drag_status (Gdk::ACTION_MOVE, time);
 			return true;
 		}
 	} else if (target == "x-ardour/plugin.preset") {
 		ctx->drag_status (Gdk::ACTION_COPY, time);
-		//favorite_plugins_mode_combo.set_active_text (_("Favorite Plugins"));
+		//favorite_plugins_mode_combo.set_text (_("Favorite Plugins"));
 		return true;
 	}
 

--- a/gtk2_ardour/mixer_ui.h
+++ b/gtk2_ardour/mixer_ui.h
@@ -54,6 +54,7 @@
 
 #include "widgets/pane.h"
 #include "widgets/tabbable.h"
+#include "widgets/ardour_dropdown.h"
 
 #include "axis_provider.h"
 #include "enums.h"
@@ -194,9 +195,9 @@ private:
 	Gtk::Frame            favorite_plugins_frame;
 	Gtk::VBox             favorite_plugins_vbox;
 	Gtk::HBox             favorite_plugins_search_hbox;
-	Gtk::ComboBoxText     favorite_plugins_mode_combo;
+	ArdourWidgets::ArdourDropdown favorite_plugins_mode_combo;
 	Gtk::Entry            plugin_search_entry;
-	Gtk::Button           plugin_search_clear_button;
+	ArdourWidgets::ArdourButton plugin_search_clear_button;
 	ArdourWidgets::VPane  rhs_pane1;
 	ArdourWidgets::VPane  rhs_pane2;
 	ArdourWidgets::HPane  inner_pane;
@@ -443,13 +444,15 @@ private:
 		PLM_Recent,
 		PLM_TopHits
 	};
+	enum PluginListMode plugin_list_mode;
+	void set_plugin_list_mode (PluginListMode plm);
+	std::vector<std::string> plugin_list_mode_strings;
 
 	void refiller (ARDOUR::PluginInfoList& result, const ARDOUR::PluginInfoList& plugs);
 	void refill_favorite_plugins ();
 	void maybe_refill_favorite_plugins (PluginListMode);
 	void store_current_favorite_order();
-	enum PluginListMode plugin_list_mode () const;
-	void plugin_list_mode_changed ();
+
 	void plugin_search_entry_changed ();
 	void plugin_search_clear_button_clicked ();
 	void favorite_plugins_deleted (const Gtk::TreeModel::Path&);

--- a/gtk2_ardour/mixer_ui.h
+++ b/gtk2_ardour/mixer_ui.h
@@ -442,7 +442,8 @@ private:
 	enum PluginListMode {
 		PLM_Favorite,
 		PLM_Recent,
-		PLM_TopHits
+		PLM_TopHits,
+		PLM_All
 	};
 	enum PluginListMode plugin_list_mode;
 	void set_plugin_list_mode (PluginListMode plm);


### PR DESCRIPTION
The native dropdown and the "clear" button felt somewhat out of place, this brings some more unity in that regard.

The second commit is an experiment that might be worth considering: having all plugins available in the list with the search option could be a time saver, don't you think ?