### PR TITLE
add control names to general MIDI drums

### DIFF
--- a/share/patchfiles/MIDI.midnam
+++ b/share/patchfiles/MIDI.midnam
@@ -101,6 +101,7 @@
       <AvailableForChannels>
         <AvailableChannel Channel="10" Available="true"/>
       </AvailableForChannels>
+      <UsesControlNameList Name="Controls"/>
       <UsesNoteNameList Name="General MIDI Drums"/>
       <PatchBank Name="Patches" ROM="false">
         <MIDICommands>


### PR DESCRIPTION
In MIDI tracks using General MIDI, CC automation for channel 10 cannot be added manually (see screenshot below). Currently, the only workaround is to record incoming CC into the track, then use "Show existing automation".

![Screenshot_20240229_115648](https://github.com/Ardour/ardour/assets/20989763/aef10f0d-bee0-4746-b21d-d66fe914e646)

This pull request adds the Generic MIDI control name list to "General MIDI Drums" in `MIDI.midnam`, fixing the above issue.