### PR TITLE
add control names to General MIDI drums

### DIFF
--- a/share/patchfiles/MIDI.midnam
+++ b/share/patchfiles/MIDI.midnam
@@ -102,6 +102,7 @@
         <AvailableChannel Channel="10" Available="true"/>
       </AvailableForChannels>
       <UsesNoteNameList Name="General MIDI Drums"/>
+      <UsesControlNameList Name="Controls"/>
       <PatchBank Name="Patches" ROM="false">
         <MIDICommands>
           <ControlChange Control="120" Value="120"/>


### PR DESCRIPTION
Supersedes #875.

In MIDI tracks using General MIDI, CC automation for channel 10 cannot be added manually (see screenshot below). Currently, the only workaround is to record incoming CC into the track, then use "Show existing automation".

![Screenshot_20240229_115648](https://github.com/Ardour/ardour/assets/20989763/0579c3f1-e130-4bd2-b7d1-4a75c008518c)

This pull request adds the Generic MIDI control name list to "General MIDI Drums" in MIDI.midnam, fixing the above issue.