### PR TITLE
fix compiler flags in ytk and ydk on OSX (define DISABLE_VISIBILITY)

### DIFF
--- a/libs/tk/ydk/wscript
+++ b/libs/tk/ydk/wscript
@@ -188,6 +188,7 @@ def build(bld):
         obj.cflags   += ['-xobjective-c']
         obj.uselib   += ' OSX' # -framework Cocoa -framework CoreFoundation -framework ApplicationServices
         obj.includes += ['ydk/quartz', 'ydk/quartz/gdk', 'ydk/gdk/quartz']
+        obj.defines += ['DISABLE_VISIBILITY']
         obj.export_includes += ['ydk/gdk']
         obj.export_includes += ['ydk/quartz']
     elif bld.env['build_target'] == 'mingw':

--- a/libs/tk/ytk/wscript
+++ b/libs/tk/ytk/wscript
@@ -300,6 +300,7 @@ def build(bld):
         obj.source   = libytk_sources +  libytk_quartz_sources
         obj.cflags   += ['-xobjective-c']
         obj.uselib   += ' OSX' #  -framework Cocoa -framework CoreFoundation -framework ApplicationServices
+        obj.defines += ['DISABLE_VISIBILITY']
     elif bld.env['build_target'] == 'mingw':
         obj.source   = libytk_sources +  libytk_win32_sources
         obj.defines += [ 'INSIDE_GTK_WIN32', 'DLL_EXPORT', 'PIC' ]


### PR DESCRIPTION
Added DISABLE_VISIBILITY to compile patched GTK+ on OSX correctly.