### PR TITLE
Add a hint about quotes in post-export.

### DIFF
--- a/gtk2_ardour/export_format_dialog.cc
+++ b/gtk2_ardour/export_format_dialog.cc
@@ -70,7 +70,7 @@ ExportFormatDialog::ExportFormatDialog (FormatPtr format, bool new_dialog)
 	, silence_end_checkbox (_("Add silence at end:"))
 	, silence_end_clock ("silence_end", true, "", true, false, true)
 
-	, command_label (_("Command to run post-export\n(%f=file path, %d=directory, %b=basename, see tooltip for more):"), Gtk::ALIGN_START)
+	, command_label (_("Command to run post-export\n(%f=file path, %d=directory, %b=basename; see tooltip for more,\ndon't add quotes around arguments):"), Gtk::ALIGN_START)
 
 	, format_table (3, 4)
 	, compatibility_label (_("Compatibility"), Gtk::ALIGN_START)


### PR DESCRIPTION
When I saw the post-export hint, I thought I needed to quote the arguments. It took me a while to debug what was going wrong: I used quotes in my post-export command, and Ardour was doing a similar thing as well.

Usually, either you provide a string which will be interpolated by the shell, in which case you need to add quotes, or you build an array of strings, and in this case you don't need to add quotes - but you build an array and not write a command template. Ardour's approach is a departure from this mode, so let's save future people time trying to figure this detail out.
