### PR TITLE
Fix undefined symbol when built with VST3 disabled.

### DIFF
--- a/libs/ardour/session.cc
+++ b/libs/ardour/session.cc
@@ -136,7 +136,10 @@
 #include "ardour/utils.h"
 #include "ardour/vca_manager.h"
 #include "ardour/vca.h"
+
+#ifdef VST3_SUPPORT
 #include "ardour/vst3_plugin.h"
+#endif // VST3_SUPPORT
 
 #include "midi++/port.h"
 #include "midi++/mmc.h"
@@ -881,10 +884,12 @@ Session::destroy ()
 
 	_transport_fsm->stop ();
 
+#ifdef VST3_SUPPORT
 	/* close VST3 Modules */
 	for (auto const& nfo : PluginManager::instance().vst3_plugin_info()) {
 		std::dynamic_pointer_cast<VST3PluginInfo> (nfo)->m.reset ();
 	}
+#endif // VST3_SUPPORT
 
 	DEBUG_TRACE (DEBUG::Destruction, "Session::destroy() done\n");
 


### PR DESCRIPTION
Commit cd5369c added some cleanup code to `libs/ardour/session.cc`, which drags in the type info symbol of VST3PluginInfo. When built with `--no-vst3`, the resulting binary dies at startup:

```
ld-elf.so.1: /usr/local/lib/ardour8/libardour.so.3: Undefined symbol
"_ZTIN6ARDOUR14VST3PluginInfoE"
```

Make that code compile conditional on VST3_SUPPORT. Occurs on FreeBSD 14.0-RELEASE, clang 16.0.6, amd64.

Making the include statement conditional is not strictly necessary to fix the undefined symbol, but may prevent similar problems in the future.

Original bug report: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=277938