### PR TITLE
Use a dedicated mutex for the fix in 5925ee0 to solve a deadlock at exit using pipewire

### DIFF
--- a/libs/ardour/ardour/audioengine.h
+++ b/libs/ardour/ardour/audioengine.h
@@ -266,6 +266,7 @@ class LIBARDOUR_API AudioEngine : public PortManager, public SessionHandlePtr
 
 	static AudioEngine*       _instance;
 
+	Glib::Threads::Mutex       _buffer_lock;
 	Glib::Threads::Mutex       _process_lock;
 	Glib::Threads::Mutex       _latency_lock;
 	Glib::Threads::RecMutex    _state_lock;

--- a/libs/ardour/audioengine.cc
+++ b/libs/ardour/audioengine.cc
@@ -212,7 +212,7 @@ AudioEngine::sample_rate_change (pframes_t nframes)
 int
 AudioEngine::buffer_size_change (pframes_t bufsiz)
 {
-	Glib::Threads::Mutex::Lock pl (_process_lock);
+	Glib::Threads::Mutex::Lock pl (_buffer_lock);
 	set_port_buffer_sizes (bufsiz);
 
 	if (_session) {
@@ -235,6 +235,7 @@ int
 AudioEngine::process_callback (pframes_t nframes)
 {
 	TimerRAII tr (dsp_stats[ProcessCallback]);
+	Glib::Threads::Mutex::Lock bm (_buffer_lock);
 	Glib::Threads::Mutex::Lock tm (_process_lock, Glib::Threads::TRY_LOCK);
 	Port::set_varispeed_ratio (1.0);
 


### PR DESCRIPTION
In the same spirit as #888, this PR fixes another deadlock when using pipewire-jack, this time at exit. 

Using the same mutex in `AudioEngine::buffer_size_change` and `AudioEngine::stop` causes a deadlock at exit due to a lock inversion. While `stop()` holds the `_process_lock` mutex the buffer size callback is called while holding a mutex inside pipewire than stop needs to acquire, leading to a deadlock.

An apparent solution is to use a dedicated mutex for the purpose for which the lock in `buffer_size_change` was introduced: mutual exclusion between this function and the processing loop.

Despite the simplicity, I'm not fully confident about not having introduced a race condition with this change. I thought of other solutions and tried to look at pipewire's code to figure out why the callback is called in such a strange moment (without much success). This solution is the simplest that seemed correct that I could find.