### PR TITLE
set explicit StartupWMClass for better Linux desktop UX

### DIFF
--- a/gtk2_ardour/ardour.desktop.in
+++ b/gtk2_ardour/ardour.desktop.in
@@ -7,3 +7,4 @@ Terminal=false
 MimeType=application/x-ardour;
 Type=Application
 Categories=AudioVideo;Audio;AudioEditing;X-Recorders;X-Multitrack;X-Jack;
+StartupWMClass=Ardour


### PR DESCRIPTION
At least on GNOME (tested Wayland + X11) this fixes classifying open Ardour windows and consequently assigning the correct icon etc.