### PR TITLE
Fix compilation on Fedora 40 with GCC 14

### DIFF
--- a/libs/aaf/utils.c
+++ b/libs/aaf/utils.c
@@ -18,6 +18,9 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+/* stdlib.h should define realpath */
+#define _GNU_SOURCE
+
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/libs/tk/ytk/gtkrc.c
+++ b/libs/tk/ytk/gtkrc.c
@@ -24,6 +24,9 @@
  * GTK+ at ftp://ftp.gtk.org/pub/gtk/. 
  */
 
+/* sys/stat.h should define lstat */
+#define _GNU_SOURCE
+
 #include "config.h"
 
 #include <locale.h>


### PR DESCRIPTION
More strict correctness of C include files cause some failures, with the core of the problem explained as comments next to the solutions/workarounds.

It seems like the best solutions are careful
    #define _GNU_SOURCE
or
    #define _XOPEN_SOURCE 500
similar to what the code base already has in some places.