### PR TITLE
Ignore connection optional ports in LV2 plugins

### DIFF
--- a/libs/ardour/ardour/lv2_plugin.h
+++ b/libs/ardour/ardour/lv2_plugin.h
@@ -256,7 +256,8 @@ class LIBARDOUR_API LV2Plugin : public ARDOUR::Plugin, public ARDOUR::Workee
 		PORT_AUTOCTRL = 1 << 9,  ///< Event port supports auto:AutomationControl
 		PORT_CTRLED   = 1 << 10, ///< Port prop auto:AutomationControlled (can be self controlled)
 		PORT_CTRLER   = 1 << 11, ///< Port prop auto:AutomationController (can be self set)
-		PORT_NOAUTO   = 1 << 12  ///< Port don't allow to automate
+		PORT_NOAUTO   = 1 << 12, ///< Port don't allow to automate
+		PORT_OTHOPT   = 1 << 13  ///< Port of unknown data type with prop connectionOptional
 	} PortFlag;
 
 	typedef unsigned PortFlags;

--- a/libs/ardour/lv2_plugin.cc
+++ b/libs/ardour/lv2_plugin.cc
@@ -189,7 +189,7 @@ public:
 	LilvNode* lv2_ControlPort;
 	LilvNode* lv2_InputPort;
 	LilvNode* lv2_OutputPort;
-	LilvNode* lv2_CvPort;
+	LilvNode* lv2_connectionOptional;
 	LilvNode* lv2_designation;
 	LilvNode* lv2_enumeration;
 	LilvNode* lv2_freewheeling;
@@ -841,7 +841,7 @@ LV2Plugin::init(const void* c_plugin, samplecnt_t rate)
 			lilv_nodes_free(min_size_v);
 			lilv_nodes_free(buffer_types);
 			lilv_nodes_free(atom_supports);
-		} else if (!lilv_port_is_a(_impl->plugin, port, _world.lv2_CvPort)) {
+		} else if (!lilv_port_has_property(_impl->plugin, port, _world.lv2_connectionOptional)) {
 			error << string_compose(
 				"LV2: \"%1\" port %2 has no known data type",
 				lilv_node_as_string(_impl->name), i) << endmsg;
@@ -3498,59 +3498,59 @@ LV2World::LV2World()
 	: world(lilv_world_new())
 	, _bundle_checked(false)
 {
-	atom_AtomPort      = lilv_new_uri(world, LV2_ATOM__AtomPort);
-	atom_Chunk         = lilv_new_uri(world, LV2_ATOM__Chunk);
-	atom_Sequence      = lilv_new_uri(world, LV2_ATOM__Sequence);
-	atom_bufferType    = lilv_new_uri(world, LV2_ATOM__bufferType);
-	atom_supports      = lilv_new_uri(world, LV2_ATOM__supports);
-	atom_eventTransfer = lilv_new_uri(world, LV2_ATOM__eventTransfer);
-	ev_EventPort       = lilv_new_uri(world, LILV_URI_EVENT_PORT);
-	ext_logarithmic    = lilv_new_uri(world, LV2_PORT_PROPS__logarithmic);
-	ext_notOnGUI       = lilv_new_uri(world, LV2_PORT_PROPS__notOnGUI);
-	ext_expensive      = lilv_new_uri(world, LV2_PORT_PROPS__expensive);
-	ext_causesArtifacts= lilv_new_uri(world, LV2_PORT_PROPS__causesArtifacts);
-	ext_notAutomatic   = lilv_new_uri(world, LV2_PORT_PROPS__notAutomatic);
-	ext_rangeSteps     = lilv_new_uri(world, LV2_PORT_PROPS__rangeSteps);
-	ext_displayPriority= lilv_new_uri(world, LV2_PORT_PROPS__displayPriority);
-	groups_group       = lilv_new_uri(world, LV2_PORT_GROUPS__group);
-	groups_element     = lilv_new_uri(world, LV2_PORT_GROUPS__element);
-	lv2_AudioPort      = lilv_new_uri(world, LILV_URI_AUDIO_PORT);
-	lv2_ControlPort    = lilv_new_uri(world, LILV_URI_CONTROL_PORT);
-	lv2_InputPort      = lilv_new_uri(world, LILV_URI_INPUT_PORT);
-	lv2_OutputPort     = lilv_new_uri(world, LILV_URI_OUTPUT_PORT);
-	lv2_CvPort         = lilv_new_uri(world, LILV_URI_CV_PORT);
-	lv2_inPlaceBroken  = lilv_new_uri(world, LV2_CORE__inPlaceBroken);
-	lv2_isSideChain    = lilv_new_uri(world, LV2_CORE_PREFIX "isSideChain");
-	lv2_index          = lilv_new_uri(world, LV2_CORE__index);
-	lv2_integer        = lilv_new_uri(world, LV2_CORE__integer);
-	lv2_default        = lilv_new_uri(world, LV2_CORE__default);
-	lv2_minimum        = lilv_new_uri(world, LV2_CORE__minimum);
-	lv2_maximum        = lilv_new_uri(world, LV2_CORE__maximum);
-	lv2_reportsLatency = lilv_new_uri(world, LV2_CORE__reportsLatency);
-	lv2_sampleRate     = lilv_new_uri(world, LV2_CORE__sampleRate);
-	lv2_toggled        = lilv_new_uri(world, LV2_CORE__toggled);
-	lv2_designation    = lilv_new_uri(world, LV2_CORE__designation);
-	lv2_enumeration    = lilv_new_uri(world, LV2_CORE__enumeration);
-	lv2_freewheeling   = lilv_new_uri(world, LV2_CORE__freeWheeling);
-	midi_MidiEvent     = lilv_new_uri(world, LILV_URI_MIDI_EVENT);
-	rdfs_comment       = lilv_new_uri(world, LILV_NS_RDFS "comment");
-	rdfs_label         = lilv_new_uri(world, LILV_NS_RDFS "label");
-	rdfs_range         = lilv_new_uri(world, LILV_NS_RDFS "range");
-	rsz_minimumSize    = lilv_new_uri(world, LV2_RESIZE_PORT__minimumSize);
-	time_Position      = lilv_new_uri(world, LV2_TIME__Position);
-	time_beatsPerMin   = lilv_new_uri(world, LV2_TIME__beatsPerMinute);
-	ui_GtkUI           = lilv_new_uri(world, LV2_UI__GtkUI);
-	ui_X11UI           = lilv_new_uri(world, LV2_UI__X11UI);
-	ui_external        = lilv_new_uri(world, "http://lv2plug.in/ns/extensions/ui#external");
-	ui_externalkx      = lilv_new_uri(world, "http://kxstudio.sf.net/ns/lv2ext/external-ui#Widget");
-	units_unit         = lilv_new_uri(world, LV2_UNITS__unit);
-	units_render       = lilv_new_uri(world, LV2_UNITS__render);
-	units_hz           = lilv_new_uri(world, LV2_UNITS__hz);
-	units_midiNote     = lilv_new_uri(world, LV2_UNITS__midiNote);
-	units_db           = lilv_new_uri(world, LV2_UNITS__db);
-	patch_writable     = lilv_new_uri(world, LV2_PATCH__writable);
-	patch_Message      = lilv_new_uri(world, LV2_PATCH__Message);
-	opts_requiredOptions = lilv_new_uri(world, LV2_OPTIONS__requiredOption);
+	atom_AtomPort          = lilv_new_uri(world, LV2_ATOM__AtomPort);
+	atom_Chunk             = lilv_new_uri(world, LV2_ATOM__Chunk);
+	atom_Sequence          = lilv_new_uri(world, LV2_ATOM__Sequence);
+	atom_bufferType        = lilv_new_uri(world, LV2_ATOM__bufferType);
+	atom_supports          = lilv_new_uri(world, LV2_ATOM__supports);
+	atom_eventTransfer     = lilv_new_uri(world, LV2_ATOM__eventTransfer);
+	ev_EventPort           = lilv_new_uri(world, LILV_URI_EVENT_PORT);
+	ext_logarithmic        = lilv_new_uri(world, LV2_PORT_PROPS__logarithmic);
+	ext_notOnGUI           = lilv_new_uri(world, LV2_PORT_PROPS__notOnGUI);
+	ext_expensive          = lilv_new_uri(world, LV2_PORT_PROPS__expensive);
+	ext_causesArtifacts    = lilv_new_uri(world, LV2_PORT_PROPS__causesArtifacts);
+	ext_notAutomatic       = lilv_new_uri(world, LV2_PORT_PROPS__notAutomatic);
+	ext_rangeSteps         = lilv_new_uri(world, LV2_PORT_PROPS__rangeSteps);
+	ext_displayPriority    = lilv_new_uri(world, LV2_PORT_PROPS__displayPriority);
+	groups_group           = lilv_new_uri(world, LV2_PORT_GROUPS__group);
+	groups_element         = lilv_new_uri(world, LV2_PORT_GROUPS__element);
+	lv2_AudioPort          = lilv_new_uri(world, LILV_URI_AUDIO_PORT);
+	lv2_ControlPort        = lilv_new_uri(world, LILV_URI_CONTROL_PORT);
+	lv2_InputPort          = lilv_new_uri(world, LILV_URI_INPUT_PORT);
+	lv2_OutputPort         = lilv_new_uri(world, LILV_URI_OUTPUT_PORT);
+	lv2_connectionOptional = lilv_new_uri(world, LV2_CORE__connectionOptional);
+	lv2_inPlaceBroken      = lilv_new_uri(world, LV2_CORE__inPlaceBroken);
+	lv2_isSideChain        = lilv_new_uri(world, LV2_CORE_PREFIX "isSideChain");
+	lv2_index              = lilv_new_uri(world, LV2_CORE__index);
+	lv2_integer            = lilv_new_uri(world, LV2_CORE__integer);
+	lv2_default            = lilv_new_uri(world, LV2_CORE__default);
+	lv2_minimum            = lilv_new_uri(world, LV2_CORE__minimum);
+	lv2_maximum            = lilv_new_uri(world, LV2_CORE__maximum);
+	lv2_reportsLatency     = lilv_new_uri(world, LV2_CORE__reportsLatency);
+	lv2_sampleRate         = lilv_new_uri(world, LV2_CORE__sampleRate);
+	lv2_toggled            = lilv_new_uri(world, LV2_CORE__toggled);
+	lv2_designation        = lilv_new_uri(world, LV2_CORE__designation);
+	lv2_enumeration        = lilv_new_uri(world, LV2_CORE__enumeration);
+	lv2_freewheeling       = lilv_new_uri(world, LV2_CORE__freeWheeling);
+	midi_MidiEvent         = lilv_new_uri(world, LILV_URI_MIDI_EVENT);
+	rdfs_comment           = lilv_new_uri(world, LILV_NS_RDFS "comment");
+	rdfs_label             = lilv_new_uri(world, LILV_NS_RDFS "label");
+	rdfs_range             = lilv_new_uri(world, LILV_NS_RDFS "range");
+	rsz_minimumSize        = lilv_new_uri(world, LV2_RESIZE_PORT__minimumSize);
+	time_Position          = lilv_new_uri(world, LV2_TIME__Position);
+	time_beatsPerMin       = lilv_new_uri(world, LV2_TIME__beatsPerMinute);
+	ui_GtkUI               = lilv_new_uri(world, LV2_UI__GtkUI);
+	ui_X11UI               = lilv_new_uri(world, LV2_UI__X11UI);
+	ui_external            = lilv_new_uri(world, "http://lv2plug.in/ns/extensions/ui#external");
+	ui_externalkx          = lilv_new_uri(world, "http://kxstudio.sf.net/ns/lv2ext/external-ui#Widget");
+	units_unit             = lilv_new_uri(world, LV2_UNITS__unit);
+	units_render           = lilv_new_uri(world, LV2_UNITS__render);
+	units_hz               = lilv_new_uri(world, LV2_UNITS__hz);
+	units_midiNote         = lilv_new_uri(world, LV2_UNITS__midiNote);
+	units_db               = lilv_new_uri(world, LV2_UNITS__db);
+	patch_writable         = lilv_new_uri(world, LV2_PATCH__writable);
+	patch_Message          = lilv_new_uri(world, LV2_PATCH__Message);
+	opts_requiredOptions   = lilv_new_uri(world, LV2_OPTIONS__requiredOption);
 #ifdef LV2_EXTENDED
 	lv2_noSampleAccurateCtrl    = lilv_new_uri(world, "http://ardour.org/lv2/ext#noSampleAccurateControls"); // deprecated 2016-09-18
 	routing_connectAllOutputs   = lilv_new_uri(world, LV2_ROUTING__connectAllOutputs);
@@ -3621,7 +3621,7 @@ LV2World::~LV2World()
 	lilv_node_free(lv2_integer);
 	lilv_node_free(lv2_isSideChain);
 	lilv_node_free(lv2_inPlaceBroken);
-	lilv_node_free(lv2_CvPort);
+	lilv_node_free(lv2_connectionOptional);
 	lilv_node_free(lv2_OutputPort);
 	lilv_node_free(lv2_InputPort);
 	lilv_node_free(lv2_ControlPort);
@@ -3977,12 +3977,7 @@ LV2PluginInfo::discover (boost::function <void (std::string const&, PluginScanLo
 					count_ctrl_out++;
 				}
 			}
-			else if (lilv_port_is_a(p, port, world.lv2_CvPort)) {
-				LilvNode* name = lilv_port_get_name(p, port);
-				cb (uri, PluginScanLogEntry::OK, string_compose (_("Port %1 ('%2') has CV data type. It is not usable in Ardour."), i, lilv_node_as_string (name)), false);
-				lilv_node_free(name);
-			}
-			else if (!lilv_port_is_a(p, port, world.lv2_AudioPort)) {
+			else if (!lilv_port_is_a(p, port, world.lv2_AudioPort) && !lilv_port_has_property(p, port, world.lv2_connectionOptional)) {
 				err = 1;
 				LilvNode* name = lilv_port_get_name(p, port);
 				cb (uri, PluginScanLogEntry::Error, string_compose (_("Port %1 ('%2') has no known data type"), i, lilv_node_as_string (name)), false);


### PR DESCRIPTION
This PR allows Ardour to load LV2 plugins that have CV ports. Until now, these plugins were completely ignored. However, there are plugins that work perfectly without using their CV input/output ports, like [Cardinal's main variant](https://github.com/DISTRHO/Cardinal#main).
This PR makes Ardour aware of existing LV2 CV ports without using them.