### PR TITLE
osc: Send /select/plugin plugin_id feedback

### DIFF
--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -2888,7 +2888,7 @@ OSC::_sel_plugin (int id, lo_address addr)
 			sur->plugin_id = 0;
 			sur->plug_page = 1;
 			if (sur->sel_obs) {
-				sur->sel_obs->set_plugin_id(-1, 1);
+				sur->sel_obs->set_plugin_id(0, 1);
 			}
 			return 0;
 		} else if (id < 1) {
@@ -2924,7 +2924,7 @@ OSC::_sel_plugin (int id, lo_address addr)
 		sur->plug_page = 1;
 
 		if (sur->sel_obs) {
-			sur->sel_obs->set_plugin_id(sur->plugins[sur->plugin_id - 1], sur->plug_page);
+			sur->sel_obs->set_plugin_id(sur->plugin_id, sur->plug_page);
 		}
 		return 0;
 	}

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -486,6 +486,8 @@ OSCSelectObserver::plugin_init()
 		plugin_end ();
 		return;
 	}
+	_osc.float_message (X_("/select/plugin"), selected_piid, addr);
+
 	std::shared_ptr<ARDOUR::Plugin> pip = pi->plugin();
 	// we have a plugin we can ask if it is activated
 	proc->ActiveChanged.connect (plugin_connections, MISSING_INVALIDATOR, boost::bind (&OSCSelectObserver::plug_enable, this, X_("/select/plugin/activate"), proc), OSC::instance());
@@ -558,6 +560,7 @@ void
 OSCSelectObserver::plugin_end ()
 {
 	plugin_connections.drop_connections ();
+	_osc.float_message (X_("/select/plugin"), 0, addr);
 	_osc.float_message (X_("/select/plugin/activate"), 0, addr);
 	_osc.text_message (X_("/select/plugin/name"), " ", addr);
 	for (uint32_t i = 1; i <= plug_size; i++) {

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -77,9 +77,9 @@ OSCSelectObserver::OSCSelectObserver (OSC& o, ARDOUR::Session& s, ArdourSurface:
 	plug_size = plug_page_size;
 	plug_page = sur->plug_page;
 	if (sur->plugins.size () > 0) {
-		plug_id = sur->plugins[sur->plugin_id - 1];
+		selected_piid = sur->plugin_id;
 	} else {
-		plug_id = -1;
+		selected_piid = 0;
 	}
 	_group_sharing[15] = 1;
 	refresh_strip (sur->select, sur->nsends, gainmode, true);
@@ -441,7 +441,7 @@ OSCSelectObserver::send_end ()
 void
 OSCSelectObserver::set_plugin_id (int id, uint32_t page)
 {
-	plug_id = id;
+	selected_piid = id;
 	plug_page = page;
 	renew_plugin ();
 }
@@ -469,7 +469,7 @@ OSCSelectObserver::renew_plugin () {
 void
 OSCSelectObserver::plugin_init()
 {
-	if (plug_id < 0) {
+	if (!selected_piid) {
 		plugin_end ();
 		return;
 	}
@@ -480,7 +480,7 @@ OSCSelectObserver::plugin_init()
 	}
 
 	// we have a plugin number now get the processor
-	std::shared_ptr<Processor> proc = r->nth_plugin (plug_id);
+	std::shared_ptr<Processor> proc = r->nth_plugin (sur->plugins[selected_piid - 1]);
 	std::shared_ptr<PluginInsert> pi;
 	if (!(pi = std::dynamic_pointer_cast<PluginInsert>(proc))) {
 		plugin_end ();

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -89,7 +89,7 @@ class OSCSelectObserver
 	uint32_t nplug_params;
 	uint32_t plug_page_size;
 	uint32_t plug_page;
-	int plug_id;
+	uint32_t selected_piid;
 	uint32_t plug_size;
 	std::vector<int> plug_params;
 	int eq_bands;


### PR DESCRIPTION
Whenever the active plugin changes (because the plugin changes or the selected strip changes), the name, some other properties and parameter values for the newly selected plugin is sent as feedback.  However, there was no clear indication of which plugin was selected exactly.

Applications or surfaces that need to know the active plugin could track the currently selected plugin by remembering the most recently selected index, but unexpected plugin changes (e.g. when switching to a strip with fewer plugins) and the asynchronous nature of OSC messages make this more complicated than it should be.

By sending the active plugin id as feedback, clients do not have to guess.

When no plugin is selected (e.g. on startup or when no strip is selected) or the currently selected index is not a plugin (but a some other kind of processor), a value of -1 is sent.

This uses the `/select/plugin` message, which is also used to change the selected plugin. There is a slight discrepancy: the control messages accepts a delta on the selected plugin, while the feedback sends an absolute value.