### PR TITLE
Store VST 3 kAfterTouch events and VST 2 VstMidiEvents with the correct size

### DIFF
--- a/libs/ardour/session_vst.cc
+++ b/libs/ardour/session_vst.cc
@@ -27,6 +27,8 @@
 #endif
 #include <cstdio>
 
+#include "evoral/midi_util.h"
+
 #include "ardour/audioengine.h"
 #include "ardour/debug.h"
 #include "ardour/session.h"
@@ -301,7 +303,12 @@ intptr_t Session::vst_callback (
 			for (int n = 0 ; n < v->numEvents; ++n) {
 				VstMidiEvent *vme = (VstMidiEvent*) (v->events[n]->dump);
 				if (vme->type == kVstMidiType) {
-					plug->midi_buffer()->push_back(vme->deltaSamples, Evoral::MIDI_EVENT, 3, (uint8_t*)vme->midiData);
+					plug->midi_buffer()->push_back(
+						vme->deltaSamples,
+						Evoral::MIDI_EVENT,
+						Evoral::midi_event_size((uint8_t)vme->midiData[0]),
+						(uint8_t*)vme->midiData
+					);
 				}
 			}
 		}

--- a/libs/ardour/vst3_plugin.cc
+++ b/libs/ardour/vst3_plugin.cc
@@ -647,36 +647,44 @@ VST3PI::vst3_to_midi_buffers (BufferSet& bufs, ChanMapping const& out_map)
 				data[2] = vst_to_midi (e.polyPressure.pressure);
 				mb.push_back (e.sampleOffset, Evoral::MIDI_EVENT, 3, data);
 				break;
-			case Vst::Event::kLegacyMIDICCOutEvent:
+			case Vst::Event::kLegacyMIDICCOutEvent: {
+				size_t size = 0;
+
 				switch (e.midiCCOut.controlNumber) {
 					case Vst::kCtrlPolyPressure:
+						size = 3;
 						data[0] = MIDI_CMD_NOTE_PRESSURE | e.midiCCOut.channel;
 						data[1] = e.midiCCOut.value;
 						data[2] = e.midiCCOut.value2;
 						break;
 					default: /* Control Change */
+						size = 3;
 						data[0] = MIDI_CMD_CONTROL | e.midiCCOut.channel;
 						data[1] = e.midiCCOut.controlNumber;
 						data[2] = e.midiCCOut.value;
 						break;
 					case Vst::kCtrlProgramChange:
+						size = 2;
 						data[0] = MIDI_CMD_PGM_CHANGE | e.midiCCOut.channel;
 						data[1] = e.midiCCOut.value;
 						data[2] = e.midiCCOut.value2;
 						break;
 					case Vst::kAfterTouch:
+						size = 2;
 						data[0] = MIDI_CMD_CHANNEL_PRESSURE | e.midiCCOut.channel;
 						data[1] = e.midiCCOut.value;
 						data[2] = e.midiCCOut.value2;
 						break;
 					case Vst::kPitchBend:
+						size = 3;
 						data[0] = MIDI_CMD_BENDER | e.midiCCOut.channel;
 						data[1] = e.midiCCOut.value;
 						data[2] = e.midiCCOut.value2;
 						break;
 				}
-				mb.push_back (e.sampleOffset, Evoral::MIDI_EVENT, e.midiCCOut.controlNumber == Vst::kCtrlProgramChange ? 2 : 3, data);
+				mb.push_back (e.sampleOffset, Evoral::MIDI_EVENT, size, data);
 				break;
+			}
 
 			case Vst::Event::kNoteExpressionValueEvent:
 			case Vst::Event::kNoteExpressionTextEvent:


### PR DESCRIPTION
...otherwise MidiBuffer::push_back() will drop them.