### PR TITLE
Two fixes to OSCSelectObserver: apply feedback config and fix send/plugin paging

### DIFF
--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -1881,8 +1881,6 @@ OSC::set_surface (uint32_t b_size, uint32_t strips, uint32_t fb, uint32_t gm, ui
 	} else {
 		s->usegroup = PBD::Controllable::NoGroup;
 	}
-	s->send_page_size = se_size;
-	s->plug_page_size = pi_size;
 	if (s->temp_mode) {
 		s->temp_mode = TempOff;
 	}

--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -1872,6 +1872,9 @@ OSC::set_surface (uint32_t b_size, uint32_t strips, uint32_t fb, uint32_t gm, ui
 	s->bank_size = b_size;
 	s->strip_types = strips;
 	s->feedback = fb;
+	if (s->sel_obs) {
+		s->sel_obs->set_feedback(fb);
+	}
 	s->gainmode = gm;
 	if (s->strip_types[10]) {
 		s->usegroup = PBD::Controllable::UseGroup;
@@ -1952,6 +1955,9 @@ OSC::set_surface_feedback (uint32_t fb, lo_message msg)
 	}
 	OSCSurface *s = get_surface(get_address (msg), true);
 	s->feedback = fb;
+	if (s->sel_obs) {
+		s->sel_obs->set_feedback(fb);
+	}
 
 	strip_feedback (s, true);
 	global_feedback (s);

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -68,8 +68,7 @@ OSCSelectObserver::OSCSelectObserver (OSC& o, ARDOUR::Session& s, ArdourSurface:
 	session = &s;
 	addr = lo_address_new_from_url 	(sur->remote_url.c_str());
 	gainmode = sur->gainmode;
-	feedback = sur->feedback;
-	in_line = feedback[2];
+	set_feedback(sur->feedback);
 	send_page_size = sur->send_page_size;
 	send_size = send_page_size;
 	send_page = sur->send_page;
@@ -91,6 +90,15 @@ OSCSelectObserver::~OSCSelectObserver ()
 	_init = true;
 	no_strip ();
 	lo_address_free (addr);
+}
+
+void
+OSCSelectObserver::set_feedback (std::bitset<32> fb)
+{
+	feedback = fb;
+	in_line = fb[2];
+	// No explicit refresh, callers should take care of that to
+	// prevent duplicate refreshing
 }
 
 void

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -54,6 +54,7 @@ class OSCSelectObserver
 	void set_plugin_id (int id, uint32_t page);
 	void set_plugin_page (uint32_t page);
 	void set_plugin_size (uint32_t size);
+	void set_feedback (std::bitset<32> fb);
 
   private:
 	std::shared_ptr<ARDOUR::Stripable> _strip;


### PR DESCRIPTION
These are two small fixes to the OSC selected strip code that I ran into while testing for another (to be submitted) PR. Since these are small and unrelated fixes, it seemed good to submit these separately. See commit messages for details.