### PR TITLE
osc: Allow enabling parameter value feedback for all plugins

### DIFF
--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -2849,9 +2849,20 @@ OSC::sel_plug_page (int page, lo_message msg)
 	int new_page = 0;
 	OSCSurface *s = get_surface(get_address (msg));
 	if (page > 0) {
-		new_page = s->plug_page + s->plug_page_size;
-		if ((uint32_t) new_page > s->plugin_input_params[s->plugin_id].size ()) {
-			new_page = s->plug_page;
+		// Do not change page when there are no more parameters
+		// in the next page
+		new_page = s->plug_page;
+		if (s->feedback[17]) {
+			for (auto const& params: s->plugin_input_params) {
+				if ((uint32_t) new_page <= params.size ()) {
+					new_page = s->plug_page + s->plug_page_size;
+					break;
+				}
+			}
+		} else {
+			if ((uint32_t) new_page <= s->plugin_input_params[s->plugin_id].size ()) {
+				new_page = s->plug_page + s->plug_page_size;
+			}
 		}
 	} else {
 		new_page = s->plug_page - s->plug_page_size;

--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -1881,8 +1881,6 @@ OSC::set_surface (uint32_t b_size, uint32_t strips, uint32_t fb, uint32_t gm, ui
 	} else {
 		s->usegroup = PBD::Controllable::NoGroup;
 	}
-	s->send_page_size = se_size;
-	s->plug_page_size = pi_size;
 	if (s->temp_mode) {
 		s->temp_mode = TempOff;
 	}

--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -2888,7 +2888,7 @@ OSC::_sel_plugin (int id, lo_address addr)
 			sur->plugin_id = 0;
 			sur->plug_page = 1;
 			if (sur->sel_obs) {
-				sur->sel_obs->set_plugin_id(-1, 1);
+				sur->sel_obs->set_plugin_id(0, 1);
 			}
 			return 0;
 		} else if (id < 1) {
@@ -2924,7 +2924,7 @@ OSC::_sel_plugin (int id, lo_address addr)
 		sur->plug_page = 1;
 
 		if (sur->sel_obs) {
-			sur->sel_obs->set_plugin_id(sur->plugins[sur->plugin_id - 1], sur->plug_page);
+			sur->sel_obs->set_plugin_id(sur->plugin_id, sur->plug_page);
 		}
 		return 0;
 	}

--- a/libs/surfaces/osc/osc.cc
+++ b/libs/surfaces/osc/osc.cc
@@ -1872,6 +1872,9 @@ OSC::set_surface (uint32_t b_size, uint32_t strips, uint32_t fb, uint32_t gm, ui
 	s->bank_size = b_size;
 	s->strip_types = strips;
 	s->feedback = fb;
+	if (s->sel_obs) {
+		s->sel_obs->set_feedback(fb);
+	}
 	s->gainmode = gm;
 	if (s->strip_types[10]) {
 		s->usegroup = PBD::Controllable::UseGroup;
@@ -1952,6 +1955,9 @@ OSC::set_surface_feedback (uint32_t fb, lo_message msg)
 	}
 	OSCSurface *s = get_surface(get_address (msg), true);
 	s->feedback = fb;
+	if (s->sel_obs) {
+		s->sel_obs->set_feedback(fb);
+	}
 
 	strip_feedback (s, true);
 	global_feedback (s);

--- a/libs/surfaces/osc/osc.h
+++ b/libs/surfaces/osc/osc.h
@@ -158,7 +158,7 @@ class OSC : public ARDOUR::ControlProtocol, public AbstractUI<OSCUIRequest>
 		int plug_page;				// current plugin page
 		uint32_t plug_page_size;	// plugin page size (number of controls)
 		int plugin_id;			// id of current plugin
-		std::vector<int> plug_params; // vector to store ports that are controls
+		std::vector<std::vector<int>> plugin_input_params; // vector with indices of input parameters for each plugin in plugins
 		std::vector<int> plugins;	// stores allowable plugins with index (work around MB strip PIs)
 		int send_page;				// current send page
 		uint32_t send_page_size;	// send page size in channels

--- a/libs/surfaces/osc/osc_gui.cc
+++ b/libs/surfaces/osc/osc_gui.cc
@@ -407,6 +407,12 @@ OSC_GUI::OSC_GUI (OSC& p)
 	fbtable->attach (scene_status, 1, 2, fn, fn+1, AttachOptions(FILL|EXPAND), AttachOptions(0), 0, 0);
 	++fn;
 
+	label = manage (new Gtk::Label(_("Report values for all plugins:")));
+	label->set_alignment(1, .5);
+	fbtable->attach (*label, 0, 1, fn, fn+1, AttachOptions(FILL|EXPAND), AttachOptions(0));
+	fbtable->attach (all_plugins, 1, 2, fn, fn+1, AttachOptions(FILL|EXPAND), AttachOptions(0), 0, 0);
+	++fn;
+
 	fbtable->show_all ();
 	append_page (*fbtable, _("Default Feedback"));
 	// set strips and feedback from loaded default values
@@ -440,6 +446,7 @@ OSC_GUI::OSC_GUI (OSC& p)
 	use_osc10.signal_clicked().connect (sigc::mem_fun (*this, &OSC_GUI::set_bitsets));
 	trigger_status.signal_clicked().connect (sigc::mem_fun (*this, &OSC_GUI::set_bitsets));
 	scene_status.signal_clicked().connect (sigc::mem_fun (*this, &OSC_GUI::set_bitsets));
+	all_plugins.signal_clicked().connect (sigc::mem_fun (*this, &OSC_GUI::set_bitsets));
 	preset_busy = false;
 
 }
@@ -696,6 +703,7 @@ OSC_GUI::reshow_values ()
 	use_osc10.set_active(def_feedback & 16384);
 	trigger_status.set_active(def_feedback & 32768);
 	scene_status.set_active(def_feedback & 65536);
+	all_plugins.set_active(def_feedback & 131072);
 
 	calculate_strip_types ();
 	calculate_feedback ();
@@ -755,6 +763,9 @@ OSC_GUI::calculate_feedback ()
 	}
 	if (scene_status.get_active()) {
 		fbvalue += 65536;
+	}
+	if (all_plugins.get_active()) {
+		fbvalue += 131072;
 	}
 
 	current_feedback.set_text(string_compose("%1", fbvalue));

--- a/libs/surfaces/osc/osc_gui.h
+++ b/libs/surfaces/osc/osc_gui.h
@@ -115,6 +115,7 @@ private:
 	Gtk::CheckButton use_osc10;
 	Gtk::CheckButton trigger_status;
 	Gtk::CheckButton scene_status;
+	Gtk::CheckButton all_plugins;
 	int fbvalue;
 	void set_bitsets ();
 

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -577,7 +577,6 @@ OSCSelectObserver::plugin_end ()
 		_osc.text_message_with_id (X_("/select/plugin/parameter/name"), i, " ", in_line, addr);
 	}
 	plug_size = 0;
-	nplug_params = 0;
 }
 
 void

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -486,6 +486,8 @@ OSCSelectObserver::plugin_init()
 		plugin_end ();
 		return;
 	}
+	_osc.float_message (X_("/select/plugin"), selected_piid, addr);
+
 	std::shared_ptr<ARDOUR::Plugin> pip = pi->plugin();
 	// we have a plugin we can ask if it is activated
 	proc->ActiveChanged.connect (plugin_connections, MISSING_INVALIDATOR, boost::bind (&OSCSelectObserver::plug_enable, this, X_("/select/plugin/activate"), proc), OSC::instance());
@@ -558,6 +560,7 @@ void
 OSCSelectObserver::plugin_end ()
 {
 	plugin_connections.drop_connections ();
+	_osc.float_message (X_("/select/plugin"), 0, addr);
 	_osc.float_message (X_("/select/plugin/activate"), 0, addr);
 	_osc.text_message (X_("/select/plugin/name"), " ", addr);
 	for (uint32_t i = 1; i <= plug_size; i++) {

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -516,14 +516,22 @@ OSCSelectObserver::plugin_init()
 	}
 	nplug_params = plug_params.size ();
 
-	// default of 0 page size means show all
-	plug_size = nplug_params;
-	if (plug_page_size) {
-		plug_size = plug_page_size;
-	}
 	_osc.text_message (X_("/select/plugin/name"), pip->name(), addr);
-	uint32_t page_start = plug_page - 1;
-	uint32_t page_end = page_start + plug_size;
+	uint32_t page_start, page_end;
+	if (plug_page_size) {
+		page_start = plug_page - 1;
+		page_end = page_start + plug_page_size;
+		plug_size = plug_page_size;
+	} else {
+		// plug_page_size=0 means to disable paging
+		page_start = 0;
+		// If we have fewer params than the last time, increase
+		// page_end to clear the values of the extra parameters
+		page_end = std::max(nplug_params, plug_size);
+		// But remember only the actual parameters, no need to
+		// keep clearing the same parameters over and over again.
+		plug_size = nplug_params;
+	}
 
 	int pid = 1;
 	for ( uint32_t ppi = page_start;  ppi < page_end; ++ppi, ++pid) {

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -77,9 +77,9 @@ OSCSelectObserver::OSCSelectObserver (OSC& o, ARDOUR::Session& s, ArdourSurface:
 	plug_size = plug_page_size;
 	plug_page = sur->plug_page;
 	if (sur->plugins.size () > 0) {
-		plug_id = sur->plugins[sur->plugin_id - 1];
+		selected_piid = sur->plugin_id;
 	} else {
-		plug_id = -1;
+		selected_piid = 0;
 	}
 	_group_sharing[15] = 1;
 	refresh_strip (sur->select, sur->nsends, gainmode, true);
@@ -441,7 +441,7 @@ OSCSelectObserver::send_end ()
 void
 OSCSelectObserver::set_plugin_id (int id, uint32_t page)
 {
-	plug_id = id;
+	selected_piid = id;
 	plug_page = page;
 	renew_plugin ();
 }
@@ -469,7 +469,7 @@ OSCSelectObserver::renew_plugin () {
 void
 OSCSelectObserver::plugin_init()
 {
-	if (plug_id < 0) {
+	if (!selected_piid) {
 		plugin_end ();
 		return;
 	}
@@ -480,7 +480,7 @@ OSCSelectObserver::plugin_init()
 	}
 
 	// we have a plugin number now get the processor
-	std::shared_ptr<Processor> proc = r->nth_plugin (plug_id);
+	std::shared_ptr<Processor> proc = r->nth_plugin (sur->plugins[selected_piid - 1]);
 	std::shared_ptr<PluginInsert> pi;
 	if (!(pi = std::dynamic_pointer_cast<PluginInsert>(proc))) {
 		plugin_end ();

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -533,11 +533,11 @@ OSCSelectObserver::plugin_init()
 		plug_size = nplug_params;
 	}
 
-	int pid = 1;
-	for ( uint32_t ppi = page_start;  ppi < page_end; ++ppi, ++pid) {
+	int paid = 1;
+	for ( uint32_t ppi = page_start;  ppi < page_end; ++ppi, ++paid) {
 		if (ppi >= nplug_params) {
-			_osc.text_message_with_id (X_("/select/plugin/parameter/name"), pid, " ", in_line, addr);
-			_osc.float_message_with_id (X_("/select/plugin/parameter"), pid, 0, in_line, addr);
+			_osc.text_message_with_id (X_("/select/plugin/parameter/name"), paid, " ", in_line, addr);
+			_osc.float_message_with_id (X_("/select/plugin/parameter"), paid, 0, in_line, addr);
 			continue;
 		}
 
@@ -547,7 +547,7 @@ OSCSelectObserver::plugin_init()
 		}
 		ParameterDescriptor pd;
 		pip->get_parameter_descriptor(controlid, pd);
-		_osc.text_message_with_id (X_("/select/plugin/parameter/name"), pid, pd.label, in_line, addr);
+		_osc.text_message_with_id (X_("/select/plugin/parameter/name"), paid, pd.label, in_line, addr);
 		if ( pip->parameter_is_input(controlid)) {
 			std::shared_ptr<AutomationControl> c = pi->automation_control(Evoral::Parameter(PluginAutomation, 0, controlid));
 			if (c) {
@@ -555,8 +555,8 @@ OSCSelectObserver::plugin_init()
 				if (pd.integer_step && pd.upper == 1) {
 					swtch = true;
 				}
-				c->Changed.connect (plugin_connections, MISSING_INVALIDATOR, boost::bind (&OSCSelectObserver::plugin_parameter_changed, this, pid, swtch, c), OSC::instance());
-				plugin_parameter_changed (pid, swtch, c);
+				c->Changed.connect (plugin_connections, MISSING_INVALIDATOR, boost::bind (&OSCSelectObserver::plugin_parameter_changed, this, paid, swtch, c), OSC::instance());
+				plugin_parameter_changed (paid, swtch, c);
 			}
 		}
 	}

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -487,8 +487,13 @@ OSCSelectObserver::plugin_init()
 		return;
 	}
 
+	plugin_feedback(r, selected_piid);
+}
+
+void
+OSCSelectObserver::plugin_feedback(std::shared_ptr<Route> r, int piid) {
 	// we have a plugin number now get the processor
-	std::shared_ptr<Processor> proc = r->nth_plugin (sur->plugins[selected_piid - 1]);
+	std::shared_ptr<Processor> proc = r->nth_plugin (sur->plugins[piid - 1]);
 	std::shared_ptr<PluginInsert> pi;
 	if (!(pi = std::dynamic_pointer_cast<PluginInsert>(proc))) {
 		plugin_end ();

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -68,8 +68,7 @@ OSCSelectObserver::OSCSelectObserver (OSC& o, ARDOUR::Session& s, ArdourSurface:
 	session = &s;
 	addr = lo_address_new_from_url 	(sur->remote_url.c_str());
 	gainmode = sur->gainmode;
-	feedback = sur->feedback;
-	in_line = feedback[2];
+	set_feedback(sur->feedback);
 	send_page_size = sur->send_page_size;
 	send_size = send_page_size;
 	send_page = sur->send_page;
@@ -91,6 +90,15 @@ OSCSelectObserver::~OSCSelectObserver ()
 	_init = true;
 	no_strip ();
 	lo_address_free (addr);
+}
+
+void
+OSCSelectObserver::set_feedback (std::bitset<32> fb)
+{
+	feedback = fb;
+	in_line = fb[2];
+	// No explicit refresh, callers should take care of that to
+	// prevent duplicate refreshing
 }
 
 void

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -503,7 +503,7 @@ OSCSelectObserver::plugin_init()
 
 	bool ok = false;
 	// put only input controls into a vector
-	plug_params.clear ();
+	std::vector<int> plug_params;
 	uint32_t nplug_params  = pip->parameter_count();
 	for ( uint32_t ppi = 0;  ppi < nplug_params; ++ppi) {
 		uint32_t controlid = pip->nth_parameter(ppi, ok);

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -87,7 +87,6 @@ class OSCSelectObserver
 	uint32_t send_size;
 	uint32_t send_page;
 
-	uint32_t nplug_params;
 	uint32_t plug_page_size;
 	uint32_t plug_page;
 	uint32_t selected_piid;

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -89,7 +89,7 @@ class OSCSelectObserver
 	uint32_t nplug_params;
 	uint32_t plug_page_size;
 	uint32_t plug_page;
-	int plug_id;
+	uint32_t selected_piid;
 	uint32_t plug_size;
 	std::vector<int> plug_params;
 	int eq_bands;

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -72,6 +72,7 @@ class OSCSelectObserver
 	uint32_t gainmode;
 	std::bitset<32> feedback;
 	bool in_line;
+	bool all_plugins;
 	ArdourSurface::OSC::OSCSurface* sur;
 	std::vector<int> send_timeout;
 	uint32_t gain_timeout;
@@ -90,7 +91,7 @@ class OSCSelectObserver
 	uint32_t plug_page_size;
 	uint32_t plug_page;
 	uint32_t selected_piid;
-	uint32_t plug_size;
+	std::vector<uint32_t> params_sent;
 	int eq_bands;
 	uint32_t _expand;
 	std::bitset<16> _group_sharing;
@@ -117,9 +118,11 @@ class OSCSelectObserver
 	void send_init (void);
 	void send_end (void);
 	void plugin_init (void);
-	void plugin_feedback (std::shared_ptr<ARDOUR::Route> r, int piid );
+	void plugin_feedback(std::shared_ptr<ARDOUR::Route> r, uint32_t piid, uint32_t msg_pid);
+	void plugin_feedback_clear (uint32_t piid);
+	void plugin_parameter_message (std::string path, uint32_t piid, uint32_t paid, std::string value_str, float value_float, int value_int);
 	void plugin_end (void);
-	void plugin_parameter_changed (int pid, bool swtch, std::shared_ptr<PBD::Controllable> controllable);
+	void plugin_parameter_changed (uint32_t piid, uint32_t paid, bool swtch, std::shared_ptr<PBD::Controllable> controllable);
 	void send_gain (uint32_t id, std::shared_ptr<PBD::Controllable> controllable);
 	void send_enable (std::string path, uint32_t id, std::shared_ptr<ARDOUR::Processor> proc);
 	void plug_enable (std::string path, std::shared_ptr<ARDOUR::Processor> proc);

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -117,6 +117,7 @@ class OSCSelectObserver
 	void send_init (void);
 	void send_end (void);
 	void plugin_init (void);
+	void plugin_feedback (std::shared_ptr<ARDOUR::Route> r, int piid );
 	void plugin_end (void);
 	void plugin_parameter_changed (int pid, bool swtch, std::shared_ptr<PBD::Controllable> controllable);
 	void send_gain (uint32_t id, std::shared_ptr<PBD::Controllable> controllable);

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -54,6 +54,7 @@ class OSCSelectObserver
 	void set_plugin_id (int id, uint32_t page);
 	void set_plugin_page (uint32_t page);
 	void set_plugin_size (uint32_t size);
+	void set_feedback (std::bitset<32> fb);
 
   private:
 	std::shared_ptr<ARDOUR::Stripable> _strip;

--- a/libs/surfaces/osc/osc_select_observer.h
+++ b/libs/surfaces/osc/osc_select_observer.h
@@ -91,7 +91,6 @@ class OSCSelectObserver
 	uint32_t plug_page;
 	uint32_t selected_piid;
 	uint32_t plug_size;
-	std::vector<int> plug_params;
 	int eq_bands;
 	uint32_t _expand;
 	std::bitset<16> _group_sharing;


### PR DESCRIPTION
Currently, feedback is only sent about parameter for a single, selected plugin. By setting this new "all_plugins" bit in the `/set_surface` message (or preferences), behaviour is changed to provide feedback for all plugins in the currently selected strip.

If enabled, this bit changes the format of the `/select/plugin/*` messages by adding an extra (first) argument containing the plugin id (piid).  This matches the format that is accepted by the `/select/plugin/parameter` message already (which allows the piid to be specified or omitted).

The main change is in the last commit, the commits leading up to that are small refactorings to simplify reviewing the big change. The first five commits are the same is #897 and #900, so should probably be ignored here and reviewed in those PRs (I'll rebase once those are merged).

I'll also update the documentation, once https://github.com/Ardour/manual/pull/266 is merged.