### PR TITLE
clang-format source preparations

### DIFF
--- a/gtk2_ardour/ghostregion.h
+++ b/gtk2_ardour/ghostregion.h
@@ -28,6 +28,7 @@
 #include <vector>
 #include <boost/unordered_map.hpp>
 
+#include "evoral/Note.h"
 #include "pbd/signals.h"
 
 #include "gtkmm2ext/colors.h"

--- a/gtk2_ardour/insert_remove_time_dialog.h
+++ b/gtk2_ardour/insert_remove_time_dialog.h
@@ -20,6 +20,7 @@
 #include "public_editor.h"
 #include "editing.h"
 #include "audio_clock.h"
+#include <gtkmm/comboboxtext.h>
 
 class InsertRemoveTimeDialog : public ArdourDialog
 {

--- a/gtk2_ardour/note_base.cc
+++ b/gtk2_ardour/note_base.cc
@@ -29,9 +29,13 @@
 
 #include "note_base.h"
 #include "public_editor.h"
-#include "editing_syms.h"
 #include "keyboard.h"
 #include "midi_region_view.h"
+
+/* clang-format off */
+// Include last, when GRIDTYPE has been defined by editing.h via midi_region_view.h
+#include "editing_syms.h"
+/* clang-format on */
 
 using namespace std;
 using namespace Gtkmm2ext;

--- a/gtk2_ardour/playlist_selection.h
+++ b/gtk2_ardour/playlist_selection.h
@@ -20,12 +20,10 @@
 #ifndef __ardour_gtk_playlist_selection_h__
 #define __ardour_gtk_playlist_selection_h__
 
+#include "ardour/playlist.h"
+
 #include <list>
 #include <memory>
-
-namespace ARDOUR {
-	class Playlist;
-}
 
 struct PlaylistSelection : std::list<std::shared_ptr<ARDOUR::Playlist> > {
 public:

--- a/gtk2_ardour/port_group.h
+++ b/gtk2_ardour/port_group.h
@@ -31,12 +31,12 @@
 #include <gtkmm/widget.h>
 #include <gtkmm/checkbutton.h>
 
+#include "ardour/bundle.h"
 #include "ardour/data_type.h"
 #include "ardour/types.h"
 
 namespace ARDOUR {
 	class Session;
-	class Bundle;
 	class Processor;
 	class IO;
 }

--- a/gtk2_ardour/port_matrix_grid.h
+++ b/gtk2_ardour/port_matrix_grid.h
@@ -31,10 +31,6 @@
 class PortMatrix;
 class PortMatrixBody;
 
-namespace ARDOUR {
-	class Bundle;
-}
-
 /**  The grid part of the port matrix */
 class PortMatrixGrid : public PortMatrixComponent
 {

--- a/gtk2_ardour/sys_ex.h
+++ b/gtk2_ardour/sys_ex.h
@@ -20,11 +20,8 @@
 #ifndef __SYSEX_H__
 #define __SYSEX_H__
 
+#include "canvas/flag.h"
 #include "midi_region_view.h"
-
-namespace ArdourCanvas {
-	class Flag;
-}
 
 class SysEx
 {

--- a/libs/ardour/ardour/minimp3.h
+++ b/libs/ardour/ardour/minimp3.h
@@ -1,5 +1,8 @@
 #ifndef MINIMP3_H
 #define MINIMP3_H
+
+/* clang-format off */
+
 /*
     https://github.com/lieff/minimp3
     To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.

--- a/libs/ardour/ardour/operations.h
+++ b/libs/ardour/ardour/operations.h
@@ -18,6 +18,7 @@
  */
 
 #include "ardour/libardour_visibility.h"
+#include "pbd/properties.h"
 
 /** These are GQuarks for a subset of UI operations.  We use these
  *  so that the undo system can be queried to find out what operations

--- a/libs/ardour/ardour/route_group_member.h
+++ b/libs/ardour/ardour/route_group_member.h
@@ -21,6 +21,7 @@
 #ifndef __libardour_route_group_member_h__
 #define __libardour_route_group_member_h__
 
+#include "ardour/libardour_visibility.h"
 #include "pbd/controllable.h"
 #include "pbd/signals.h"
 

--- a/libs/ardour/ardour/session_configuration.h
+++ b/libs/ardour/ardour/session_configuration.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <string>
 
+#include "ardour/types.h"
 #include "pbd/configuration.h"
 
 namespace ARDOUR {

--- a/libs/ardour/ardour/session_configuration.h
+++ b/libs/ardour/ardour/session_configuration.h
@@ -44,6 +44,7 @@ public:
 
 	/* define accessor methods */
 
+	/* clang-format off */
 #undef  CONFIG_VARIABLE
 #undef  CONFIG_VARIABLE_SPECIAL
 #define CONFIG_VARIABLE(Type,var,name,value) \
@@ -55,11 +56,13 @@ public:
 #include "ardour/session_configuration_vars.h"
 #undef  CONFIG_VARIABLE
 #undef  CONFIG_VARIABLE_SPECIAL
+	/* clang-format on */
 
   private:
 
 	/* declare variables */
 
+	/* clang-format off */
 #undef  CONFIG_VARIABLE
 #undef  CONFIG_VARIABLE_SPECIAL
 #define CONFIG_VARIABLE(Type,var,name,value) PBD::ConfigVariable<Type> var;
@@ -67,6 +70,7 @@ public:
 #include "ardour/session_configuration_vars.h"
 #undef  CONFIG_VARIABLE
 #undef  CONFIG_VARIABLE_SPECIAL
+	/* clang-format on */
 
 	int foo;
 

--- a/libs/ardour/session_configuration.cc
+++ b/libs/ardour/session_configuration.cc
@@ -41,6 +41,8 @@
 using namespace ARDOUR;
 using namespace PBD;
 
+/* clang-format off */
+
 SessionConfiguration::SessionConfiguration ()
 	:
 /* construct variables */
@@ -151,6 +153,7 @@ SessionConfiguration::map_parameters (boost::function<void (std::string)>& funct
 #undef  CONFIG_VARIABLE_SPECIAL
 }
 
+/* clang-format on */
 
 bool
 SessionConfiguration::load_state ()

--- a/libs/ardour/triggerbox.cc
+++ b/libs/ardour/triggerbox.cc
@@ -4178,6 +4178,7 @@ TriggerBox::run (BufferSet& bufs, samplepos_t start_sample, samplepos_t end_samp
 					all_triggers[_active_scene]->bang ();
 				} else {
 					stop_all_quantized ();  //empty slot, this should work as a Stop for the running clips
+
 					//TODO:  can we set a flag so the UI reports that we are stopping?
 				}
 			}

--- a/libs/ardour/vst_plugin.cc
+++ b/libs/ardour/vst_plugin.cc
@@ -193,6 +193,7 @@ VSTPlugin::set_parameter (uint32_t which, float newval, sampleoffset_t when)
 		} else {
 			cerr << "effSetBypass failed rv=" << rv << endl; // XXX DEBUG
 #ifdef ALLOW_VST_BYPASS_TO_FAIL // yet unused, see also vst_plugin.cc
+
 			// emit signal.. hard un/bypass from here?!
 #endif
 		}

--- a/libs/gtkmm2ext/gtkmm2ext/persistent_tooltip.h
+++ b/libs/gtkmm2ext/gtkmm2ext/persistent_tooltip.h
@@ -22,6 +22,7 @@
 
 #include <sigc++/trackable.h>
 
+#include <gtkmm.h>
 #include "gtkmm2ext/visibility.h"
 
 namespace Gtkmm2ext {

--- a/libs/surfaces/us2400/control_group.h
+++ b/libs/surfaces/us2400/control_group.h
@@ -19,6 +19,7 @@
 #ifndef __ardour_us2400_control_protocol_control_group_h__
 #define __ardour_us2400_control_protocol_control_group_h__
 
+#include <string>
 #include <vector>
 
 namespace ArdourSurface {


### PR DESCRIPTION
These changes makes it possible to build after applying clang-format to most source files. And also a bit of cosmetics.

Those who runs clang-format casually might also need these changes at some point.

These changes allow me to work on top of a local full reformat, making sure my diffs are consistent even if the upstream repo isn't.
