### PR TITLE
Remove MSVC quirk handling of StackAllocator

### DIFF
--- a/libs/ardour/ardour/chan_mapping.h
+++ b/libs/ardour/ardour/chan_mapping.h
@@ -104,22 +104,8 @@ public:
 	 */
 	bool     is_subset (const ChanMapping& superset) const;
 
-#if defined(_MSC_VER) /* && (_MSC_VER < 1900)
-	                   * Regarding the note (below) it was initially
-	                   * thought that this got fixed in VS2015 - but
-	                   * in fact it's still faulty (JE - Feb 2021) */
-	/* Use the older (heap based) mapping for early versions of MSVC.
-	 * In fact it might be safer to use this for all MSVC builds - as
-	 * our StackAllocator class depends on 'boost::aligned_storage'
-	 * which is known to be troublesome with Visual C++ :-
-	 * https://www.boost.org/doc/libs/1_65_0/libs/type_traits/doc/html/boost_typetraits/reference/aligned_storage.html
-	 */
-	typedef std::map<uint32_t, uint32_t>    TypeMapping;
-	typedef std::map<DataType, TypeMapping> Mappings;
-#else
 	typedef std::map<uint32_t, uint32_t, std::less<uint32_t>, PBD::StackAllocator<std::pair<const uint32_t, uint32_t>, 16> > TypeMapping;
 	typedef std::map<DataType, TypeMapping, std::less<DataType>, PBD::StackAllocator<std::pair<const DataType, TypeMapping>, 2> > Mappings;
-#endif
 
 	Mappings        mappings()       { return _mappings; }
 	const Mappings& mappings() const { return _mappings; }

--- a/libs/ardour/ardour/plugin_insert.h
+++ b/libs/ardour/ardour/plugin_insert.h
@@ -323,20 +323,7 @@ private:
 	Match _match;
 
 	/* ordered map [plugin instance ID] => ARDOUR::ChanMapping */
-#if defined(_MSC_VER) /* && (_MSC_VER < 1900)
-	                   * Regarding the note (below) it was initially
-	                   * thought that this got fixed in VS2015 - but
-	                   * in fact it's still faulty (JE - Feb 2021) */
-	/* Use the older (heap based) mapping for early versions of MSVC.
-	 * In fact it might be safer to use this for all MSVC builds - as
-	 * our StackAllocator class depends on 'boost::aligned_storage'
-	 * which is known to be troublesome with Visual C++ :-
-	 * https://www.boost.org/doc/libs/1_65_0/libs/type_traits/doc/html/boost_typetraits/reference/aligned_storage.html
-	 */
-	typedef std::map <uint32_t, ARDOUR::ChanMapping> PinMappings;
-#else
 	typedef std::map <uint32_t, ARDOUR::ChanMapping, std::less<uint32_t>, PBD::StackAllocator<std::pair<const uint32_t, ARDOUR::ChanMapping>, 4> > PinMappings;
-#endif
 
 	PinMappings _in_map;
 	PinMappings _out_map;

--- a/libs/pbd/pbd/stack_allocator.h
+++ b/libs/pbd/pbd/stack_allocator.h
@@ -19,7 +19,6 @@
 #ifndef PBD_STACK_ALLOCATOR_H
 #define PBD_STACK_ALLOCATOR_H
 
-#include <boost/type_traits/aligned_storage.hpp>
 #include <limits>
 
 #include "pbd/libpbd_visibility.h"
@@ -61,22 +60,22 @@ public:
 	};
 
 	StackAllocator ()
-		: _ptr ((pointer)&_buf)
+		: _ptr ((pointer)_buf)
 	{ }
 
 	StackAllocator (const StackAllocator&)
-		: _ptr ((pointer)&_buf)
+		: _ptr ((pointer)_buf)
 	{ }
 
 	template <typename U, size_t other_capacity>
 	StackAllocator (const StackAllocator<U, other_capacity>&)
-		: _ptr ((pointer)&_buf)
+		: _ptr ((pointer)_buf)
 	{ }
 
 	/* inspired by http://howardhinnant.github.io/stack_alloc.h */
 	pointer allocate (size_type n, void* hint = 0)
 	{
-		if ((pointer)&_buf + stack_capacity >= _ptr + n) {
+		if ((pointer)_buf + stack_capacity >= _ptr + n) {
 			DEBUG_STACK_ALLOC ("Allocate %ld item(s) of size %zu on the stack\n", n, sizeof (T));
 			pointer rv = _ptr;
 			_ptr += n;
@@ -108,12 +107,12 @@ public:
 
 	bool operator== (StackAllocator const& a) const
 	{
-		return &_buf == &a._buf;
+		return _buf == a._buf;
 	}
 
 	bool operator!= (StackAllocator const& a) const
 	{
-		return &_buf != &a._buf;
+		return _buf != a._buf;
 	}
 
 	template <class U>
@@ -147,12 +146,10 @@ private:
 
 	bool pointer_in_buffer (pointer const p)
 	{
-		return ((pointer const)&_buf <= p && p < (pointer const)&_buf + stack_capacity);
+		return ((pointer const)_buf <= p && p < (pointer const)_buf + stack_capacity);
 	}
 
-	typedef typename boost::aligned_storage<sizeof (T) * stack_capacity, 16>::type align_t;
-
-	align_t _buf;
+	alignas(16) value_type _buf[stack_capacity];
 	pointer _ptr;
 };
 

--- a/libs/pbd/pbd/stack_allocator.h
+++ b/libs/pbd/pbd/stack_allocator.h
@@ -72,6 +72,11 @@ public:
 		: _ptr ((pointer)_buf)
 	{ }
 
+	StackAllocator& operator= (const StackAllocator&)
+	{
+		return *this;
+	}
+
 	/* inspired by http://howardhinnant.github.io/stack_alloc.h */
 	pointer allocate (size_type n, void* hint = 0)
 	{
@@ -142,8 +147,6 @@ public:
 #endif
 
 private:
-	StackAllocator& operator= (const StackAllocator&);
-
 	bool pointer_in_buffer (pointer const p)
 	{
 		return ((pointer const)_buf <= p && p < (pointer const)_buf + stack_capacity);


### PR DESCRIPTION
By avoiding the use of `boost::align_storage`, and following the notes, this quirk should not be triggered anymore. But I want @johne53 to confirm.