### PR TITLE
Define _GNU_SOURCE in hidapi build

### DIFF
--- a/libs/hidapi/wscript
+++ b/libs/hidapi/wscript
@@ -21,6 +21,7 @@ def configure(conf):
             autowaf.check_pkg(conf, 'libudev', uselib_store='UDEV', mandatory=False)
             if conf.is_defined('HAVE_UDEV'):
                 conf.define ('HAVE_HIDAPI', 1)
+            conf.define('_GNU_SOURCE', 1)
         else:
             print ("hidapi is not yet available for the given system")
 


### PR DESCRIPTION
I tried compiling Ardour 8.7 on openSUSE Tumbleweed but the build failed due to problems with resolution of functions like `wcsdup`, `strtok_r`, etc. It seems that even if the correct headers are included, those functions won't be included unless `_GNU_SOURCE` is defined (the explanation is in `wchar.h`). 

I added the definition of `_GNU_SOURCE` to the `wscript` in the case of Linux builds so that the code will be compiled correctly.