### PR TITLE
ardour.desktop.in add NSM related keys

### DIFF
--- a/gtk2_ardour/ardour.desktop.in
+++ b/gtk2_ardour/ardour.desktop.in
@@ -8,3 +8,5 @@ MimeType=application/x-ardour;
 Type=Application
 Categories=AudioVideo;Audio;AudioEditing;X-Recorders;X-Multitrack;X-Jack;
 StartupWMClass=Ardour
+X-NSM-Capable=true
+X-NSM-Exec=@ARDOUR_EXEC@


### PR DESCRIPTION
This adds NSM related desktop file keys, for tools to discover applications with NSM support. 

X-NSM-Capable, is used to detect if the application has NSM support. The value should ideally become false if ardour is build without NSM support. I didn't find a example so far how to do this, but how ardour is using *.desktop.in might be that example ... 

The value of  X-NSM-Exec, should be the executable name of ardour when using it in NSM. The value shouldn't contain a path (so not /usr/bin/ardour) and no command line arguments. So the X-NSM-Exec value added here, needs some eyeballs as I'm not sure what @ARDOUR_EXEC@ will give us here. 

If  the X-NSM-Exec value is always the same as the Exec value, setting X-NSM-Capable should be sufficient and the X-NSM-Exec entry is not needed , but I think it's wise to add X-NSM-Exec. 

