### PR TITLE
Update adwaita_dark-ardour.colors

### DIFF
--- a/gtk2_ardour/themes/adwaita_dark-ardour.colors
+++ b/gtk2_ardour/themes/adwaita_dark-ardour.colors
@@ -326,7 +326,7 @@
     <ColorAlias name="pluginui toggle: fill" alias="widget:bg"/>
     <ColorAlias name="pluginui toggle: fill active" alias="widget:blue"/>
     <ColorAlias name="preference highlight" alias="alert:yellow"/>
-    <ColorAlias name="processor automation line" alias="theme:bg1"/>
+    <ColorAlias name="processor automation line" alias="alert:green"/>
     <ColorAlias name="processor auxfeedback: fill" alias="theme:contrasting alt"/>
     <ColorAlias name="processor auxfeedback: led active" alias="alert:green"/>
     <ColorAlias name="processor control button: fill" alias="neutral:background"/>


### PR DESCRIPTION
Hello Paul, Robin! May be these PR(s) are not correct...
 I've found some new item "processor automation line" and it makes pale gray color of the automation line in all custom themes. So I've made the "processor automation line"-item the same like an old "automation line"-item (for all custom themes).