### PR TITLE
Leftovers from #914

### DIFF
--- a/libs/ardour/ardour/chan_mapping.h
+++ b/libs/ardour/ardour/chan_mapping.h
@@ -106,12 +106,24 @@ public:
 #if defined(_MSC_VER) /* && (_MSC_VER < 1900)
 	                   * Regarding the note (below) it was initially
 	                   * thought that this got fixed in VS2015 - but
-	                   * in fact it's still faulty (JE - Feb 2021) */
+	                   * in fact it's still faulty (JE - Feb 2021).
+	                   * 2024-09-03 update: Faulty compile up to
+	                   * VS2022 17.4. From there it compiles but does
+	                   * not link with the exception of the arm64
+	                   * platform. This quirk is actually a bug that
+	                   * Microsoft seems to have failed to
+	                   * acknowledge as such for years judging from
+	                   * web search results about MSVC's std::map,
+					   * and have not even fixed correctly when they
+					   * tried.
+	                   */
 	/* Use the older (heap based) mapping for early versions of MSVC.
-	 * In fact it might be safer to use this for all MSVC builds - as
-	 * our StackAllocator class depends on 'boost::aligned_storage'
-	 * which is known to be troublesome with Visual C++ :-
-	 * https://www.boost.org/doc/libs/1_65_0/libs/type_traits/doc/html/boost_typetraits/reference/aligned_storage.html
+	 * In fact it might be safer to use this for all MSVC builds. It
+	 * was thought that this was related to issues with
+	 * boost::aligned_storage, but actually it seems to be that there
+	 * are bugs in the std::map implementation of MSVC that are being
+	 * triggered, messing with the copy constructor of
+	 * PBD::StackAllocator.
 	 */
 	typedef std::map<uint32_t, uint32_t>    TypeMapping;
 	typedef std::map<DataType, TypeMapping> Mappings;

--- a/libs/evoral/ControlSet.cc
+++ b/libs/evoral/ControlSet.cc
@@ -26,6 +26,7 @@
 #include "evoral/Event.h"
 
 using namespace std;
+using namespace std::placeholders;
 
 namespace Evoral {
 

--- a/libs/pbd/receiver.cc
+++ b/libs/pbd/receiver.cc
@@ -42,9 +42,8 @@ void
 Receiver::listen_to (Transmitter &transmitter)
 
 {
-	/* odd syntax here because boost's placeholders (_1, _2) are in an
-	   anonymous namespace which causes ambiguity with sigc++ (and will also
-	   do so with std::placeholder in the C++11 future
+	/* odd syntax here because std's placeholders (_1, _2) are in an
+	   anonymous namespace which causes ambiguity with sigc++
 	*/
 	transmitter.sender().connect_same_thread (connections, std::bind (&Receiver::receive, this, std::placeholders::_1, std::placeholders::_2));
 

--- a/libs/surfaces/osc/osc_cue_observer.cc
+++ b/libs/surfaces/osc/osc_cue_observer.cc
@@ -17,8 +17,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "boost/lambda/lambda.hpp"
-
 #include "pbd/control_math.h"
 
 #include "ardour/track.h"

--- a/libs/surfaces/osc/osc_global_observer.cc
+++ b/libs/surfaces/osc/osc_global_observer.cc
@@ -17,8 +17,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "boost/lambda/lambda.hpp"
-
 #include "pbd/control_math.h"
 
 #include "ardour/amp.h"

--- a/libs/surfaces/osc/osc_route_observer.cc
+++ b/libs/surfaces/osc/osc_route_observer.cc
@@ -19,8 +19,6 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#include "boost/lambda/lambda.hpp"
-
 #include "pbd/control_math.h"
 #include <glibmm.h>
 

--- a/libs/surfaces/osc/osc_select_observer.cc
+++ b/libs/surfaces/osc/osc_select_observer.cc
@@ -19,8 +19,6 @@
  */
 
 #include <vector>
-#include "boost/lambda/lambda.hpp"
-
 #include "pbd/control_math.h"
 
 #include "ardour/session.h"

--- a/tools/signal-test/signal-test.cc
+++ b/tools/signal-test/signal-test.cc
@@ -23,7 +23,7 @@ class Rx1
 public:
 	Rx1 (Tx& sender)
 	{
-		sender.sig1.connect_same_thread (_connection, boost::bind (&Rx1::cb, this, _1));
+		sender.sig1.connect_same_thread (_connection, std::bind (&Rx1::cb, this, _1));
 	}
 
 private:
@@ -87,7 +87,7 @@ class Rx2 : public PBD::ScopedConnectionList
 public:
 	Rx2 (Tx& sender)
 	{
-		sender.sig1.connect (*this, &_ir, boost::bind (&Rx2::cb, this, _1), &event_loop);
+		sender.sig1.connect (*this, &_ir, std::bind (&Rx2::cb, this, _1), &event_loop);
 	}
 
 private:

--- a/wscript
+++ b/wscript
@@ -562,7 +562,6 @@ int main() { return 0; }''',
             cxx_flags.append('-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION')
         else:
             cxx_flags.append('-DBOOST_NO_AUTO_PTR')
-            cxx_flags.append('-DBOOST_BIND_GLOBAL_PLACEHOLDERS')
 
     if (is_clang and platform == "darwin"):
         # Silence warnings about the non-existing osx clang compiler flags
@@ -747,7 +746,7 @@ int main() { return 0; }''',
 
     # need ISOC9X for llabs()
     compiler_flags.extend(
-        ('-DBOOST_SYSTEM_NO_DEPRECATED', '-DBOOST_BIND_GLOBAL_PLACEHOLDERS', '-D_ISOC9X_SOURCE',
+        ('-DBOOST_SYSTEM_NO_DEPRECATED', '-D_ISOC9X_SOURCE',
          '-D_LARGEFILE64_SOURCE', '-D_FILE_OFFSET_BITS=64'))
     cxx_flags.extend(
         ('-D__STDC_LIMIT_MACROS', '-D__STDC_FORMAT_MACROS',


### PR DESCRIPTION
Some stuff was left from #914. Most of the commits in this new PR do not keep all the original modifications. Feel free to rearrange the commits as you see fit. I guess the one that uses std::stringstream will need to be reworked.