### PR TITLE
Remove Sequence::overlaps and Sequence::overlaps_unlocked

### DIFF
--- a/libs/evoral/Sequence.cc
+++ b/libs/evoral/Sequence.cc
@@ -1170,45 +1170,6 @@ Sequence<Time>::contains_unlocked (const NotePtr& note) const
 }
 
 template<typename Time>
-bool
-Sequence<Time>::overlaps (const NotePtr& note, const NotePtr& without) const
-{
-	ReadLock lock (read_lock());
-	return overlaps_unlocked (note, without);
-}
-
-template<typename Time>
-bool
-Sequence<Time>::overlaps_unlocked (const NotePtr& note, const NotePtr& without) const
-{
-	Time sa = note->time();
-	Time ea  = note->end_time();
-
-	const Pitches& p (pitches (note->channel()));
-	NotePtr search_note(new Note<Time>(0, Time(), Time(), note->note()));
-
-	for (typename Pitches::const_iterator i = p.lower_bound (search_note);
-	     i != p.end() && (*i)->note() == note->note(); ++i) {
-
-		if (without && (**i) == *without) {
-			continue;
-		}
-
-		Time sb = (*i)->time();
-		Time eb = (*i)->end_time();
-
-		if (((sb > sa) && (eb <= ea)) ||
-		    ((eb >= sa) && (eb <= ea)) ||
-		    ((sb > sa) && (sb <= ea)) ||
-		    ((sa >= sb) && (sa <= eb) && (ea <= eb))) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
-template<typename Time>
 void
 Sequence<Time>::set_notes (const typename Sequence<Time>::Notes& n)
 {

--- a/libs/evoral/evoral/Sequence.h
+++ b/libs/evoral/evoral/Sequence.h
@@ -300,8 +300,6 @@ public:
 	bool edited() const      { return _edited; }
 	void set_edited(bool yn) { _edited = yn; }
 
-	bool overlaps (const NotePtr& ev,
-	               const NotePtr& ignore_this_note) const;
 	bool contains (const NotePtr& ev) const;
 
 	bool add_note_unlocked (const NotePtr note, void* arg = 0);
@@ -337,7 +335,6 @@ protected:
 private:
 	friend class const_iterator;
 
-	bool overlaps_unlocked (const NotePtr& ev, const NotePtr& ignore_this_note) const;
 	bool contains_unlocked (const NotePtr& ev) const;
 
 	void append_note_on_unlocked(const Event<Time>& event, Evoral::event_id_t);


### PR DESCRIPTION
While attempting to create a PR of an old fix I did a while ago (probably years ago) in `Sequence::overlaps_unlocked`, I discovered that neither `Sequence::overlaps_unlocked` nor `Sequence::overlaps` were used anywhere.  In other words they are dead code.

The question is: are they dead for good, or are they dead to be resuscitated in the foreseeable future?  I'll let you be the judge of that.  If they are to be resuscitated, then I'll cancel that PR and create a new one with my fix (which covers rare but existing corner cases).