### PR TITLE
Add text control type for LuaDialog. 

### DIFF
--- a/gtk2_ardour/luadialog.cc
+++ b/gtk2_ardour/luadialog.cc
@@ -591,6 +591,35 @@ protected:
 	Gtk::FileChooserWidget _fc;
 };
 
+class LuaDialogText : public LuaDialogWidget
+{
+public:
+	LuaDialogText (std::string const& key, std::string const& title, std::string const& dflt)
+		: LuaDialogWidget (key, title)
+	{
+		_text_view.set_wrap_mode (Gtk::WRAP_WORD);
+		_text_view.get_buffer()->set_text (dflt);
+
+		_scrolled_window.set_policy(Gtk::POLICY_AUTOMATIC, Gtk::POLICY_AUTOMATIC);
+
+        _scrolled_window.add(_text_view);
+	}
+
+	Gtk::Widget* widget ()
+	{
+		return &_scrolled_window;
+	}
+
+	void assign (luabridge::LuaRef* rv) const
+	{
+		(*rv)[_key] = std::string (_text_view.get_buffer()->get_text());
+	}
+
+protected:
+	Gtk::TextView _text_view;
+	Gtk::ScrolledWindow _scrolled_window;
+};
+
 /* *****************************************************************************
  * Lua Parameter Dialog
  */
@@ -659,6 +688,12 @@ Dialog::Dialog (std::string const& title, luabridge::LuaRef lr)
 				dflt = i.value ()["default"].cast<std::string> ();
 			}
 			w = new LuaDialogEntry (key, title, dflt);
+		} else if (type == "text") {
+			std::string dflt;
+			if (i.value ()["default"].isString ()) {
+				dflt = i.value ()["default"].cast<std::string> ();
+			}
+			w = new LuaDialogText (key, title, dflt);
 		} else if (type == "radio") {
 			std::string dflt;
 			if (!i.value ()["values"].isTable ()) {

--- a/share/scripts/track_organizer.lua
+++ b/share/scripts/track_organizer.lua
@@ -56,7 +56,7 @@ function factory () return function ()
            type = "dropdown", key = t:name() .. ' g',  col = 1, colspan = 1, title = "", values = pl, default = interrogate(t)
        }) --group
        table.insert(dialog_options, {
-           type = "entry",    key = t:name() .. ' cm', col = 2, colspan = 1, default = t:comment(), title = ""
+           type = "text",    key = t:name() .. ' cm', col = 2, colspan = 1, default = t:comment(), title = ""
        }) --comment
        table.insert(dialog_options, {
            type = "dropdown", key = t:name() .. ' c',  col = 3, colspan = 1, title = "", values = rbow, default = find_color(t)


### PR DESCRIPTION
Type "text" is based on scrollable Gtk::TextView. 

Example use:

`            local dialog_options = {
                {type = "text", key = "progression", title = "Progression", default = "Am|Dm|E7"}
            }
`

Update track_organizer lua script to use new control type.