### PR TITLE
Make Stripable::Sorter::operator() const

### DIFF
--- a/libs/ardour/ardour/stripable.h
+++ b/libs/ardour/ardour/stripable.h
@@ -95,7 +95,7 @@ class LIBARDOUR_API Stripable : public SessionObject,
 
 	struct LIBARDOUR_API Sorter
 	{
-		bool _mixer_order; // master is last
+		const bool _mixer_order; // master is last
 		Sorter (bool mixer_order = false) : _mixer_order (mixer_order) {}
 		bool operator() (std::shared_ptr<ARDOUR::Stripable> a, std::shared_ptr<ARDOUR::Stripable> b) const;
 	};

--- a/libs/ardour/ardour/stripable.h
+++ b/libs/ardour/ardour/stripable.h
@@ -97,7 +97,7 @@ class LIBARDOUR_API Stripable : public SessionObject,
 	{
 		bool _mixer_order; // master is last
 		Sorter (bool mixer_order = false) : _mixer_order (mixer_order) {}
-		bool operator() (std::shared_ptr<ARDOUR::Stripable> a, std::shared_ptr<ARDOUR::Stripable> b);
+		bool operator() (std::shared_ptr<ARDOUR::Stripable> a, std::shared_ptr<ARDOUR::Stripable> b) const;
 	};
 
 	/* gui's call this for their own purposes. */

--- a/libs/ardour/stripable.cc
+++ b/libs/ardour/stripable.cc
@@ -129,7 +129,7 @@ Stripable::is_selected() const
 }
 
 bool
-Stripable::Sorter::operator() (std::shared_ptr<ARDOUR::Stripable> a, std::shared_ptr<ARDOUR::Stripable> b)
+Stripable::Sorter::operator() (std::shared_ptr<ARDOUR::Stripable> a, std::shared_ptr<ARDOUR::Stripable> b) const
 {
 	const PresentationInfo::Flag a_flag = a->presentation_info().flags ();
 	const PresentationInfo::Flag b_flag = b->presentation_info().flags ();


### PR DESCRIPTION
This is required by C++17.  I also made, by the way, `Stripable::Sorter::_mixer_order` const, just cause it makes sense.