### PR TITLE
fix typos in gtk2_ardour directory

### DIFF
--- a/gtk2_ardour/add_video_dialog.cc
+++ b/gtk2_ardour/add_video_dialog.cc
@@ -220,7 +220,7 @@ AddVideoDialog::AddVideoDialog (Session* s)
 	//ok_button->set_sensitive(false);
 	set_action_ok(false);
 
-	/* connect signals after eveything has been initialized */
+	/* connect signals after everything has been initialized */
 	chooser.signal_selection_changed().connect (mem_fun (*this, &AddVideoDialog::file_selection_changed));
 	chooser.signal_file_activated().connect (mem_fun (*this, &AddVideoDialog::file_activated));
 	//chooser.signal_update_preview().connect(sigc::mem_fun(*this, &AddVideoDialog::update_preview));

--- a/gtk2_ardour/ardour.keys.in
+++ b/gtk2_ardour/ardour.keys.in
@@ -15,7 +15,7 @@
 ;                "owner" field is otherwise ignored.
 ;
 ;                If the group name starts with "-", the binding will not appear
-;                on the cheetsheet.
+;                on the cheatsheet.
 ;
 ; @group|action|binding|description -> defines an action+binding with description, as a member of a binding group
 ;                                       if group starts with '-' it will not be printed in the cheatsheet.

--- a/gtk2_ardour/ardour_http.cc
+++ b/gtk2_ardour/ardour_http.cc
@@ -213,7 +213,7 @@ HttpGet::get (const char* url, bool with_error_logging)
 
 	if (!persist) {
 		::free (mem.data);
-	} // otherwise caller is expected to have free()d or re-used it.
+	} // otherwise caller is expected to have free()d or reused it.
 
 	error_buffer[0] = 0;
 	mem.data = NULL;

--- a/gtk2_ardour/ardour_ui.h
+++ b/gtk2_ardour/ardour_ui.h
@@ -647,7 +647,7 @@ private:
 	bool process_snapshot_session_prompter (ArdourWidgets::Prompter& prompter, bool switch_to_it);
 	void snapshot_session (bool switch_to_it);
 
-	void quick_snapshot_session (bool switch_to_it);  //does not promtp for name, just makes a timestamped file
+	void quick_snapshot_session (bool switch_to_it);  //does not prompt for name, just makes a timestamped file
 
 	SaveAsDialog* save_as_dialog;
 

--- a/gtk2_ardour/ardour_ui_aaf.cc
+++ b/gtk2_ardour/ardour_ui_aaf.cc
@@ -404,7 +404,7 @@ set_session_timecode (AAF_Iface* aafi, Session* s)
 	s->config.set_timecode_format (ardourtc);
 }
 
-/* Create and open Sesssion from AAF
+/* Create and open Session from AAF
  * return > 0 if file is not a [valid] AAF
  * return < 0 if session creation failed.
  * return 0 on success. path and snapshot are set.

--- a/gtk2_ardour/ardour_ui_dialogs.cc
+++ b/gtk2_ardour/ardour_ui_dialogs.cc
@@ -906,7 +906,7 @@ ARDOUR_UI::new_midi_tracer_window ()
 		t->show_all ();
 		_midi_tracer_windows.push_back (t);
 	} else {
-		/* re-use the hidden one */
+		/* reuse the hidden one */
 		(*i)->show_all ();
 	}
 }

--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -1256,7 +1256,7 @@ RegionMotionDrag::motion (GdkEvent* event, bool first_move)
 		 * Hidden tracks at the bottom of the TAV need to be skipped.
 		 *
 		 * This also handles the case if the mouse entered the DZ
-		 * in a large step (exessive delta), either due to fast-movement,
+		 * in a large step (excessive delta), either due to fast-movement,
 		 * autoscroll, laggy UI. _ddropzone copensates for that (see "move into dz" above)
 		 */
 		if (delta_time_axis_view < 0 && (int)_ddropzone - delta_time_axis_view >= (int)_pdropzone) {
@@ -2855,7 +2855,7 @@ TrimDrag::motion (GdkEvent* event, bool first_move)
 		non_overlap_trim = true;
 	}
 
-	/* contstrain trim to fade length */
+	/* constrain trim to fade length */
 	if (_preserve_fade_anchor) {
 		/* fades are audio and always use AudioTime domain */
 
@@ -3336,7 +3336,7 @@ TempoMarkerDrag::motion (GdkEvent* event, bool first_move)
 	} else if (_movable) {
 		timepos_t pos = adjusted_current_time (event);
 
-		/* This relies on the tempo map to round up the beat postiion
+		/* This relies on the tempo map to round up the beat position
 		 * and see if that differs from the current position (tempo
 		 * markers only allowed on beat)
 		 */
@@ -3984,7 +3984,7 @@ CursorDrag::start_grab (GdkEvent* event, Gdk::Cursor* c)
 		}
 	}
 
-	/* during fake-locate, the mouse position is delievered to the (red) playhead line, so we have to momentarily sensitize it */
+	/* during fake-locate, the mouse position is delivered to the (red) playhead line, so we have to momentarily sensitize it */
 	editing_context.playhead_cursor ()->set_sensitive (true);
 
 	fake_locate (where.earlier (snap_delta (event->button.state)).samples ());

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -1617,7 +1617,7 @@ Editor::button_release_handler (ArdourCanvas::Item* item, GdkEvent* event, ItemT
 			switch (item_type) {
 			case RegionItem:
 			{
-				/* since we have FreehandLineDrag we can only get here after a drag, when no movement has happend.
+				/* since we have FreehandLineDrag we can only get here after a drag, when no movement has happened.
 				 * Except when a drag was aborted by pressing Esc.
 				 */
 				if (!were_dragging) {

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -1635,7 +1635,7 @@ Editor::scroll_down_one_track (bool skip_child_views)
 				if (dev.first) {
 					/* some automation lane is currently at the top */
 					if (ci == kids.rbegin()) {
-						/* first (bottom-most) autmation lane is at the top.
+						/* first (bottom-most) automation lane is at the top.
 						 * -> move to next track
 						 */
 						nkid = kids.rend();
@@ -1707,7 +1707,7 @@ Editor::scroll_up_one_track (bool skip_child_views)
 				if (dev.first) {
 					/* some automation lane is currently at the top */
 					if (ci == kids.begin()) {
-						/* first (top-most) autmation lane is at the top.
+						/* first (top-most) automation lane is at the top.
 						 * jump directly to this track's top
 						 */
 						ensure_time_axis_view_is_visible (**t, true);

--- a/gtk2_ardour/export_report.cc
+++ b/gtk2_ardour/export_report.cc
@@ -597,7 +597,7 @@ ExportReport::init (const AnalysisResults & ar, bool with_file)
 
 		if (channels > 0 && file_length > 0 && sample_rate > 0)
 		{
-			/* Time Axis  -- re-use waveform width */
+			/* Time Axis  -- reuse waveform width */
 			const size_t width = p->width;
 			Cairo::RefPtr<Cairo::ImageSurface> ytme = ArdourGraphs::time_axis (get_pango_context (), width, m_l, start_off, file_length, sample_rate);
 

--- a/gtk2_ardour/midi_view.cc
+++ b/gtk2_ardour/midi_view.cc
@@ -1664,7 +1664,7 @@ MidiView::start_playing_midi_chord (vector<std::shared_ptr<NoteType> > notes)
 
 	player->play ();
 
-	/* player is deleted after a timeout when its ::off() method is invokved */
+	/* player is deleted after a timeout when its ::off() method is invoked */
 }
 
 bool

--- a/gtk2_ardour/midi_view.h
+++ b/gtk2_ardour/midi_view.h
@@ -255,7 +255,7 @@ class MidiView : public virtual sigc::trackable, public LineMerger
 	 * @return true iff the note is within the (time) extent of the region.
 	 */
 	virtual bool note_in_region_range(const std::shared_ptr<NoteType> note, bool& visible) const;
-	/* Test if a note is withing this region's time range. Return true if so */
+	/* Test if a note is within this region's time range. Return true if so */
 	virtual bool note_in_region_time_range(const std::shared_ptr<NoteType> note) const;
 
 	/** Get the region position in pixels relative to session. */

--- a/gtk2_ardour/opts.cc
+++ b/gtk2_ardour/opts.cc
@@ -180,7 +180,7 @@ ARDOUR_COMMAND_LINE::parse_opts (int argc, char *argv[])
 				exit (EXIT_SUCCESS);
 			}
 #else
-			cerr << "This is not a debug build - igoring '-D " << optarg << "'" << endl;
+			cerr << "This is not a debug build - ignoring '-D " << optarg << "'" << endl;
 #endif /* NDEBUG */
 			break;
 

--- a/gtk2_ardour/pianoroll_midi_view.cc
+++ b/gtk2_ardour/pianoroll_midi_view.cc
@@ -505,7 +505,7 @@ MergeableLine*
 PianorollMidiView::make_merger ()
 {
 	if (active_automation && active_automation->line) {
-		std::cerr << "Mergable will use active automation @ " << active_automation << std::endl;
+		std::cerr << "Mergeable will use active automation @ " << active_automation << std::endl;
 
 		return new MergeableLine (active_automation->line, active_automation->control,
 		                          [](Temporal::timepos_t const& t) { return t; },

--- a/gtk2_ardour/plugin_display.cc
+++ b/gtk2_ardour/plugin_display.cc
@@ -89,7 +89,7 @@ PluginDisplay::render_inline (cairo_t* cr, uint32_t width)
 	}
 
 	/* allocate a local image-surface,
-	 * We cannot re-use the data via cairo_image_surface_create_for_data(),
+	 * We cannot reuse the data via cairo_image_surface_create_for_data(),
 	 * since pixman keeps a reference to it.
 	 * we'd need to hand over the data and ha cairo_surface_destroy to free it.
 	 * it might be possible to work around via cairo_surface_set_user_data().

--- a/gtk2_ardour/plugin_pin_dialog.cc
+++ b/gtk2_ardour/plugin_pin_dialog.cc
@@ -651,7 +651,7 @@ PluginPinWidget::add_port_to_table (std::shared_ptr<Port> p, uint32_t r, bool ca
 					continue;
 				}
 				/* if processor goes away, we're notified by the port disconnect,
-				 * there should be no need to explicily connect to proc->DropReferences
+				 * there should be no need to explicitly connect to proc->DropReferences
 				 */
 				set<Evoral::Parameter> p = proc->what_can_be_automated ();
 				for (set<Evoral::Parameter>::iterator i = p.begin (); i != p.end (); ++i) {

--- a/gtk2_ardour/preference-metadata
+++ b/gtk2_ardour/preference-metadata
@@ -52,9 +52,9 @@
 [clock-display-limit]
   clock display limit length maximum duration
 [color-file]
- theme colors appearance style themeing
+ theme colors appearance style theming
 [color-regions-using-track-color]
- theme colors appearance style themeing
+ theme colors appearance style theming
 [default-bindings]
  shortcuts keys keybindings bindings
 [default-lower-midi-note]

--- a/gtk2_ardour/route_time_axis.cc
+++ b/gtk2_ardour/route_time_axis.cc
@@ -1593,7 +1593,7 @@ RouteTimeAxisView::ensure_pan_views (bool show)
 		}
 	}
 
-	/* remove ATAV of no longer relevant pan ctrls (e.g. witdh, height); */
+	/* remove ATAV of no longer relevant pan ctrls (e.g. width, height); */
 	bool removed_one;
 	do {
 		removed_one = false;

--- a/gtk2_ardour/step_editor.h
+++ b/gtk2_ardour/step_editor.h
@@ -48,7 +48,7 @@ class StepEntry;
  * changes.
  *
  * The StepEntry is a singleton, used over and over each time the user wants to
- * step edit; the StepEditor is owned by a MidiTimeAxisView and re-used for any
+ * step edit; the StepEditor is owned by a MidiTimeAxisView and reused for any
  * step editing in the MidiTrack for which the MidiTimeAxisView is a view.
  */
 

--- a/gtk2_ardour/step_entry.h
+++ b/gtk2_ardour/step_entry.h
@@ -44,7 +44,7 @@ class StepEditor;
  * accomplish that.
  *
  * The StepEntry is a singleton, used over and over each time the user wants to
- * step edit; the StepEditor is owned by a MidiTimeAxisView and re-used for any
+ * step edit; the StepEditor is owned by a MidiTimeAxisView and reused for any
  * step editing in the MidiTrack for which the MidiTimeAxisView is a view.
  */
 


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,*.po,./.git,*.tosc,./waf,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch" -L acount,addin,ane,ba,buss,busses,caf,capela,devine,disconnectin,discreet,doubleclick,envolution,filetest,fo,ghandi,homs,hsi,layed,maschine,mis,nd,ontop,pass-thru,removeable,retrn,ro,scrollin,sectionin,seh,siz,sord,sur,te,trough,ue,wth`