### PR TITLE
fix typos in share/scripts directory

### DIFF
--- a/share/scripts/_amp2.lua
+++ b/share/scripts/_amp2.lua
@@ -34,8 +34,8 @@ end
 function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 	for c = 1,audio_ins do
 		-- ensure that processing does happen in-place
-		local ib = in_map:get(ARDOUR.DataType("audio"), c - 1); -- get id of mapped input buffer for given cannel
-		local ob = out_map:get(ARDOUR.DataType("audio"), c - 1); -- get id of mapped output buffer for given cannel
+		local ib = in_map:get(ARDOUR.DataType("audio"), c - 1); -- get id of mapped input buffer for given channel
+		local ob = out_map:get(ARDOUR.DataType("audio"), c - 1); -- get id of mapped output buffer for given channel
 		assert (ib ~= ARDOUR.ChanMapping.Invalid);
 		assert (ob ~= ARDOUR.ChanMapping.Invalid);
 

--- a/share/scripts/_amp_coefficient_ratio.lua
+++ b/share/scripts/_amp_coefficient_ratio.lua
@@ -40,7 +40,7 @@ function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 	local gain = ctrl[1] / ctrl[2]
 	ARDOUR.DSP.process_map (bufs, n_out, in_map, out_map, n_samples, offset)
 	for c = 1, n_audio do
-		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given cannel
+		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given channel
 		if (ob ~= ARDOUR.ChanMapping.Invalid) then
 			bufs:get_audio (ob):apply_gain (gain, n_samples);
 		end

--- a/share/scripts/a_mute.lua
+++ b/share/scripts/a_mute.lua
@@ -39,7 +39,7 @@ function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 
 	local g = cur_gain
 	for c = 1, n_audio do
-		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given cannel
+		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given channel
 		if (ob ~= ARDOUR.ChanMapping.Invalid) then
 			cur_gain = ARDOUR.Amp.apply_gain (bufs:get_audio(ob), sr, n_samples, g, target_gain, offset)
 		end

--- a/share/scripts/amp5.lua
+++ b/share/scripts/amp5.lua
@@ -47,7 +47,7 @@ function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 	cur_gain = target_gain -- use target gain if no channel is mapped.
 
 	for c = 1, n_audio do
-		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given cannel
+		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given channel
 		if (ob ~= ARDOUR.ChanMapping.Invalid) then
 			cur_gain = ARDOUR.Amp.apply_gain (bufs:get_audio(ob), sr, n_samples, current_gain, target_gain, offset)
 		end

--- a/share/scripts/barlow_arp.lua
+++ b/share/scripts/barlow_arp.lua
@@ -394,7 +394,7 @@ function dsp_run (_, _, n_samples)
    -- rolling state: It seems that we need to check the transport state (as
    -- given by Ardour's "transport finite state machine" = TFSM) here, even if
    -- the transport is not actually moving yet. Otherwise some input notes may
-   -- errorneously slip through before playback really starts.
+   -- erroneously slip through before playback really starts.
    local rolling = Session:transport_state_rolling ()
    -- whether the pattern must be recomputed, due to parameter changes or MIDI
    -- input
@@ -623,7 +623,7 @@ function dsp_run (_, _, n_samples)
 	 -- next beat is due immediately
 	 bt, ts = time.beat, time.sample
       elseif bf2 > bf1 and bf2 ~= b2 then
-	 -- next beat is due some time in this cycle (we're assuming contant
+	 -- next beat is due some time in this cycle (we're assuming constant
 	 -- tempo here, hence this number may be off in case the tempo is
 	 -- changing very quickly during the cycle -- so don't do that)
 	 local d = math.ceil((b2-bf2)/(b2-b1)*(s2-s1))

--- a/share/scripts/duplicate_to_grid.lua
+++ b/share/scripts/duplicate_to_grid.lua
@@ -24,7 +24,7 @@ function factory () return function ()
   local curPos = region:position()
   local curBeat = Editor:get_grid_type_as_beats(true, curPos)
   local nextPos = Temporal.timepos_t.from_ticks(curPos:ticks() + curBeat:to_ticks())
-  -- gap could be used to create mulitple duplicates at once
+  -- gap could be used to create multiple duplicates at once
   local gap = Temporal.timecnt_t.from_ticks(curBeat:to_ticks())
   playlist:duplicate(region, nextPos, gap, 1)
 

--- a/share/scripts/raptor_arp.lua
+++ b/share/scripts/raptor_arp.lua
@@ -1116,7 +1116,7 @@ function arpeggio:pulse()
       local wmin, wmax = self.wmin, self.wmax
       if w1 >= wmin and w1 <= wmax then
 	 local pmin, pmax = self.pmin, self.pmax
-	 -- Calculate the filter probablity. We allow for negative pmod values
+	 -- Calculate the filter probability. We allow for negative pmod values
 	 -- here, in which case stronger pulses tend to be filtered out first
 	 -- rather than weaker ones.
 	 local p = mod_value(pmin, pmax, self.pmod, w1)
@@ -1724,7 +1724,7 @@ function dsp_options ()
    -- right at the end of a loop. This sometimes causes hanging notes with
    -- automation when transport wraps around to the loop start. It's unclear
    -- whether the issue is in Ardour (caused by split cycles with automation)
-   -- or some unkown bug in the plugin. But the option makes it go away (which
+   -- or some unknown bug in the plugin. But the option makes it go away (which
    -- seems to indicate that the issue is on the Ardour side).
    return { time_info = true, regular_block_length = true }
 end
@@ -1878,7 +1878,7 @@ function dsp_run (_, _, n_samples)
    -- rolling state: It seems that we need to check the transport state (as
    -- given by Ardour's "transport finite state machine" = TFSM) here, even if
    -- the transport is not actually moving yet. Otherwise some input notes may
-   -- errorneously slip through before playback really starts.
+   -- erroneously slip through before playback really starts.
    local rolling = Session:transport_state_rolling ()
 
    -- detect param changes (subdiv is caught as a meter change below)
@@ -2034,7 +2034,7 @@ function dsp_run (_, _, n_samples)
 	 -- next beat is due immediately
 	 bt, ts = time.beat, time.sample
       elseif bf2 > bf1 and bf2 ~= b2 then
-	 -- next beat is due some time in this cycle (we're assuming contant
+	 -- next beat is due some time in this cycle (we're assuming constant
 	 -- tempo here, hence this number may be off in case the tempo is
 	 -- changing very quickly during the cycle -- so don't do that)
 	 local d = math.ceil((b2-bf2)/(b2-b1)*(s2-s1))

--- a/share/scripts/scope.lua
+++ b/share/scripts/scope.lua
@@ -59,8 +59,8 @@ function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 
 	for c = 1,audio_ins do
 		-- Note: lua starts counting at 1, ardour's ChanMapping::get() at 0
-		local ib = in_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped input buffer for given cannel
-		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given cannel
+		local ib = in_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped input buffer for given channel
+		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given channel
 		local chn_off = 4 + bufsiz * (c - 1)
 		if (ib ~= ARDOUR.ChanMapping.Invalid) then
 			if (write_ptr + n_samples < bufsiz) then
@@ -85,8 +85,8 @@ function dsp_runmap (bufs, in_map, out_map, n_samples, offset)
 	end
 	-- clear unconnected inplace buffers
 	for c = 1,audio_ins do
-		local ib = in_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped input buffer for given cannel
-		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given cannel
+		local ib = in_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped input buffer for given channel
+		local ob = out_map:get (ARDOUR.DataType ("audio"), c - 1); -- get id of mapped output buffer for given channel
 		if (ib == ARDOUR.ChanMapping.Invalid and ob ~= ARDOUR.ChanMapping.Invalid) then
 			bufs:get_audio (ob):silence (n_samples, offset)
 		end

--- a/share/scripts/select_regions_at_playhead.lua
+++ b/share/scripts/select_regions_at_playhead.lua
@@ -8,7 +8,7 @@ function factory (params) return function ()
 
 	local loc = Session:locations () -- all marker locations
 
-	-- get the playhead postion
+	-- get the playhead position
 	local playhead = Temporal.timepos_t (Session:transport_sample ())
 
 	local sl = ArdourUI.SelectionList () -- empty selection list

--- a/share/scripts/simple_arp.lua
+++ b/share/scripts/simple_arp.lua
@@ -147,7 +147,7 @@ function dsp_run (_, _, n_samples)
    -- rolling state: It seems that we need to check the transport state (as
    -- given by Ardour's "transport finite state machine" = TFSM) here, even if
    -- the transport is not actually moving yet. Otherwise some input notes may
-   -- errorneously slip through before playback really starts.
+   -- erroneously slip through before playback really starts.
    local rolling = Session:transport_state_rolling ()
    local changed = false
 
@@ -386,7 +386,7 @@ function dsp_run (_, _, n_samples)
 	 -- sudden jump in transport => next beat is due immediately
 	 bt, ts = time.beat, time.sample
       elseif bf2 > bf1 and bf2 ~= b2 then
-	 -- next beat is due some time in this cycle (we're assuming contant
+	 -- next beat is due some time in this cycle (we're assuming constant
 	 -- tempo here, hence this number may be off in case the tempo is
 	 -- changing very quickly during the cycle -- so don't do that)
 	 local d = math.ceil((b2-bf2)/(b2-b1)*(s2-s1))
@@ -449,7 +449,7 @@ function dsp_run (_, _, n_samples)
 	    -- first beat in a bar, 80 for the other non-fractional beats, 60
 	    -- for everything else (subdivision pulses). These values can be
 	    -- changed with the corresponding control. NOTE: There are much
-	    -- more sophisticted ways to do this, but we try to keep things
+	    -- more sophisticated ways to do this, but we try to keep things
 	    -- simple here.
 	    local v = vel3
 	    if p == 0 then

--- a/share/scripts/singen.lua
+++ b/share/scripts/singen.lua
@@ -10,7 +10,7 @@ ardour {
 function presets ()
 	return
 	{
-		-- one can speficy parmaters by name..
+		-- one can specify parameters by name..
 		{ name = "1k", params = { Frequency = 1000, Gain = -18 } },
 		{ name = "440", params = { Frequency = 440, Gain = -3 } },
 		-- ..or using zero-based indexing as number.

--- a/share/scripts/trigger_mixer_scene.lua
+++ b/share/scripts/trigger_mixer_scene.lua
@@ -3,7 +3,7 @@ ardour {
 	name        = "Mixer Scene Sequencer",
 	license     = "MIT",
 	author      = "John Devlin, Robin Gareus",
-	description = [[Recall a Mixer Scene when the playhead passes over a Marker named 'MS <nuber>' where <number> indicates the scene to recall.]]
+	description = [[Recall a Mixer Scene when the playhead passes over a Marker named 'MS <number>' where <number> indicates the scene to recall.]]
 }
 
 function factory ()


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,*.po,./.git,*.tosc,./waf,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch" -L acount,addin,ane,ba,buss,busses,caf,capela,devine,disconnectin,discreet,doubleclick,envolution,filetest,fo,ghandi,homs,hsi,layed,maschine,mis,nd,ontop,pass-thru,removeable,retrn,ro,scrollin,sectionin,seh,siz,sord,sur,te,trough,ue,wth`