### PR TITLE
fix various typos throughout codebase

### DIFF
--- a/libs/ardour/export_handler.cc
+++ b/libs/ardour/export_handler.cc
@@ -311,7 +311,7 @@ ExportHandler::handle_duplicate_format_extensions()
 			/* stem-export has multiple files in the same timestamp, but a different channel_config for each.
 			 * However channel_config is only set in ExportGraphBuilder::Encoder::init_writer()
 			 * so we cannot yet use   it->second.filename->get_path(it->second.format).
-			 * We have to explicily check uniqueness of "channel-config + extension" here:
+			 * We have to explicitly check uniqueness of "channel-config + extension" here:
 			 */
 			counts[pfx + it->second.channel_config->name() + it->second.format->extension()]++;
 		} else {

--- a/libs/ardour/luabindings.cc
+++ b/libs/ardour/luabindings.cc
@@ -204,7 +204,7 @@ luabridge::getIdentityKey ()
 /* ...and this is the ugly part of it.
  *
  * We need to forward declare classes from gtk2_ardour
- * AND explicily list classes which are used by gtk2_ardour's bindings.
+ * AND explicitly list classes which are used by gtk2_ardour's bindings.
  *
  * This is required because some of the GUI classes use objects from libardour
  * as function parameters or return values and the .exe would re-create

--- a/libs/tk/ytk/gtkmenuitem.c
+++ b/libs/tk/ytk/gtkmenuitem.c
@@ -849,7 +849,7 @@ gtk_menu_item_select (GtkMenuItem *menu_item)
 
   gtk_item_select (GTK_ITEM (menu_item));
 
-  /* Enable themeing of the parent menu item depending on whether
+  /* Enable theming of the parent menu item depending on whether
    * something is selected in its submenu
    */
   if (GTK_IS_MENU (GTK_WIDGET (menu_item)->parent))
@@ -868,7 +868,7 @@ gtk_menu_item_deselect (GtkMenuItem *menu_item)
 
   gtk_item_deselect (GTK_ITEM (menu_item));
 
-  /* Enable themeing of the parent menu item depending on whether
+  /* Enable theming of the parent menu item depending on whether
    * something is selected in its submenu
    */
   if (GTK_IS_MENU (GTK_WIDGET (menu_item)->parent))
@@ -1541,7 +1541,7 @@ gtk_menu_item_real_popup_submenu (GtkWidget *widget,
                       0);
     }
 
-  /* Enable themeing of the parent menu item depending on whether
+  /* Enable theming of the parent menu item depending on whether
    * its submenu is shown or not.
    */
   gtk_widget_queue_draw (widget);

--- a/libs/tk/ytk/gtktreeview.c
+++ b/libs/tk/ytk/gtktreeview.c
@@ -833,7 +833,7 @@ gtk_tree_view_class_init (GtkTreeViewClass *class)
   /**
    * GtkTreeView:row-ending-details:
    *
-   * Enable extended row background themeing
+   * Enable extended row background theming
    *
    * Deprecated: 2.22: This style property will be removed in GTK+ 3
    */

--- a/tools/gccabicheck/README
+++ b/tools/gccabicheck/README
@@ -5,7 +5,7 @@ This is a simple tool to test a system for g++5's glibmm at runtime.
 
 GCC5.1 introduced a new ABI for the C++ standard library.
 The old 3.4 .. 5.0 ABI is not compatible. By default gcc provides a
-dual ABI, so testing libstc++ itself is not sufficient.
+dual ABI, so testing libstdc++ itself is not sufficient.
 
 
 Some GNU/Linux distributions systems switched to the new ABI already

--- a/tools/run-readtest.sh
+++ b/tools/run-readtest.sh
@@ -30,7 +30,7 @@ done
 if [ -d $dir -a -f $dir/testfile_1 ] ; then
     # dir exists and has a testfile within it - reuse to avoid
     # recreating files
-    echo "# Re-using files in $dir"
+    echo "# Reusing files in $dir"
     needfiles=
 else
     dir=$dir/readtest_$$

--- a/tools/run-threadreadtest.sh
+++ b/tools/run-threadreadtest.sh
@@ -30,7 +30,7 @@ done
 if [ -d $dir -a -f $dir/testfile_1 ] ; then
     # dir exists and has a testfile within it - reuse to avoid
     # recreating files
-    echo "# Re-using files in $dir"
+    echo "# Reusing files in $dir"
     needfiles=
 else
     dir=$dir/readtest_$$

--- a/tools/sanity_check/main.cpp
+++ b/tools/sanity_check/main.cpp
@@ -231,7 +231,7 @@ ParseSwitches(
 						if (++i < argc) {
 							string	op = argv[i];
 							if (op[0] == '-') {
-								// reqiured option for this switch is missing
+								// required option for this switch is missing
 								--i;
 								OK = false;
 								break;
@@ -240,7 +240,7 @@ ParseSwitches(
 							break;
 						}
 						else {
-							// reqiured option for this switch is missing
+							// required option for this switch is missing
 							--i;
 							OK = false;
 							break;

--- a/tools/x-win/package.sh
+++ b/tools/x-win/package.sh
@@ -247,7 +247,7 @@ cp gtk2_ardour/icons/ArdourBug.ico $DESTDIR/share/
 # replace default cursor with square version (sans hotspot file)
 cp gtk2_ardour/icons/cursor_square/* $DESTDIR/share/${LOWERCASE_DIRNAME}/icons/
 
-# clean build-dir after depoyment
+# clean build-dir after deployment
 echo " === bundle completed, cleaning up"
 ./waf uninstall
 find $DESTDIR -name "*.dll.a" -print0 | xargs -0 -r rm

--- a/wscript
+++ b/wscript
@@ -1508,7 +1508,7 @@ const char* const ardour_config_info = "\\n\\
     write_config_text('Futex Semaphore',       conf.is_defined('USE_FUTEX_SEMAPHORE'))
     write_config_text('Freedesktop files',     opts.freedesktop)
     write_config_text('G_ENABLE_DEBUG',        opts.gdebug or conf.env['DEBUG'])
-    write_config_text('I/O Priorty Set',       conf.is_defined('HAVE_IOPRIO'))
+    write_config_text('I/O Priority Set',      conf.is_defined('HAVE_IOPRIO'))
     write_config_text('Libjack linking',       conf.env['libjack_link'])
     write_config_text('Libjack metadata',      conf.is_defined ('HAVE_JACK_METADATA'))
     write_config_text('Lua Binding Doc',       conf.is_defined('LUABINDINGDOC'))


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,*.po,./.git,*.tosc,./waf,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch" -L acount,addin,ane,ba,buss,busses,caf,capela,devine,disconnectin,discreet,doubleclick,envolution,filetest,fo,ghandi,homs,hsi,layed,maschine,mis,nd,ontop,pass-thru,removeable,retrn,ro,scrollin,sectionin,seh,siz,sord,sur,te,trough,ue,wth`