### PR TITLE
Fix typos in gtk2_ardour

### DIFF
--- a/gtk2_ardour/ardour_ui_ed.cc
+++ b/gtk2_ardour/ardour_ui_ed.cc
@@ -602,11 +602,11 @@ ARDOUR_UI::install_dependent_actions ()
 	                                      sigc::bind (sigc::mem_fun(*editor, &PublicEditor::jump_forward_to_mark_flagged), Location::Flags(Location::IsRangeMarker | Location::IsSessionRange), Location::Flags (0), Location::Flags (0)));
 	ActionManager::session_sensitive_actions.push_back (act);
 
-	act = ActionManager::register_action (common_actions, "jump-backward-to-section-mark", _("Jump to Previous Arrangment Mark"),
+	act = ActionManager::register_action (common_actions, "jump-backward-to-section-mark", _("Jump to Previous Arrangement Mark"),
 	                                      sigc::bind (sigc::mem_fun(*editor, &PublicEditor::jump_backward_to_mark_flagged), Location::Flags (0), Location::Flags (0), Location::Flags (Location::IsMark | Location::IsSection)));
 	ActionManager::session_sensitive_actions.push_back (act);
 
-	act = ActionManager::register_action (common_actions, "jump-forward-to-section-mark", _("Jump to Next Arrangment Mark"),
+	act = ActionManager::register_action (common_actions, "jump-forward-to-section-mark", _("Jump to Next Arrangement Mark"),
 	                                      sigc::bind (sigc::mem_fun(*editor, &PublicEditor::jump_forward_to_mark_flagged), Location::Flags (0), Location::Flags (0), Location::Flags(Location::IsMark | Location::IsSection)));
 	ActionManager::session_sensitive_actions.push_back (act);
 

--- a/gtk2_ardour/pianoroll_midi_view.cc
+++ b/gtk2_ardour/pianoroll_midi_view.cc
@@ -71,7 +71,7 @@ PianorollMidiView::PianorollMidiView (std::shared_ptr<ARDOUR::MidiTrack> mt,
 
 	/* The event rect is a sibling of canvas items that share @param
 	 * parent. Consequently, it does not get events that they do not handle
-	 * (because event propagation is up the item child->parent heirarchy,
+	 * (because event propagation is up the item child->parent hierarchy,
 	 * not sideways.
 	 *
 	 * This means that if, for example, the start boundary rect doesn't


### PR DESCRIPTION
Found via codespell. Includes two user-facing typo fixes. 