### PR TITLE
no resolve for MidiPort::realtime_locate at loop end

### DIFF
--- a/libs/ardour/midi_port.cc
+++ b/libs/ardour/midi_port.cc
@@ -375,9 +375,9 @@ MidiPort::transport_stopped ()
 }
 
 void
-MidiPort::realtime_locate (bool)
+MidiPort::realtime_locate (bool for_loop_end)
 {
-	_resolve_required = true;
+	_resolve_required = !for_loop_end;
 }
 
 void


### PR DESCRIPTION
fixes midi notes being cut short at loop start due to `resolve_notes` call after `realtime_relocate` from loop end.

tested and verified working with hardware on 8.12.