### PR TITLE
fix short_version (upper/lower) case priority

### DIFF
--- a/libs/pbd/convert.cc
+++ b/libs/pbd/convert.cc
@@ -119,19 +119,19 @@ short_version (string orig, string::size_type target_length)
 		orig.replace (pos, 1, "");
 	}
 
-	/* remove upper-case vowels, starting at end */
+	/* remove lower-case consonants, starting at end */
 
 	while (orig.length() > target_length) {
-		if ((pos = orig.find_last_of (_("AEIOU"))) == string::npos) {
+		if ((pos = orig.find_last_of (_("bcdfghjklmnpqrtvwxyz"))) == string::npos) {
 			break;
 		}
 		orig.replace (pos, 1, "");
 	}
 
-	/* remove lower-case consonants, starting at end */
+	/* remove upper-case vowels, starting at end */
 
 	while (orig.length() > target_length) {
-		if ((pos = orig.find_last_of (_("bcdfghjklmnpqrtvwxyz"))) == string::npos) {
+		if ((pos = orig.find_last_of (_("AEIOU"))) == string::npos) {
 			break;
 		}
 		orig.replace (pos, 1, "");


### PR DESCRIPTION
Replaces #971.

`short_version` is used in narrow strips to limit the number of letters of strip names or plugin names. Reading its code, something jumped out at me and explain why many times there is nearly no link between the original name and the short name.

This function removes characters until the desired limit is reached.
Originally, It removes characters in this order :
* white spaces and punctuation
* lower-case vowels
* upper-case vowels
* lower-case consonants
* upper-case consonants

In this PR, it removes characters in this order:
* white spaces and punctuation
* lower-case vowels
* lower-case consonants
* upper-case vowels
* upper-case consonants

Upper case has priority over lower case ! It explain why
`ACE Reasonable Synth` gave in 5 characters `CRsnS` (no link with original, instead of  `ACRsS`, not perfect but better). It allows to use CamelCase and have at least the first letter of each word.

Note that "Y" is considered as a consonant, "S" is never removed, I did not change that.