### PR TITLE
Fix typo in ardour.keys.in causing spacebar to not work

### DIFF
--- a/gtk2_ardour/ardour.keys.in
+++ b/gtk2_ardour/ardour.keys.in
@@ -117,7 +117,7 @@ This mode provides many different operations on both regions and control points,
 @eep|Editor/edit-cursor-to-previous-region-sync|                   apostrophe|EP to prev region sync
 @eep|Editor/edit-cursor-to-next-region-sync|                        semicolon|EP to next region sync
 
-@trans|Transport/SpacebarAction                                         space|toggle roll
+@trans|Transport/SpacebarAction|                                        space|toggle roll
 @trans|Transport/PlaySelection|                            <@SECONDARY@>space|play edit range
 @edit|Editor/play-from-edit-point-and-return|    <@PRIMARY@><@TERTIARY@>space|play from EP \& return
 @trans|Transport/ToggleRollMaybe|               <@PRIMARY@><@SECONDARY@>space|stop (keep loop/range play)


### PR DESCRIPTION
### Description

This PR addresses a typo introduced in 6f45a9f9ac6028d82828d9c38a03961206e6bef8 causing spacebar to not work at all in dev builds.