### PR TITLE
Don’t install test programs

### DIFF
--- a/libs/ardour/wscript
+++ b/libs/ardour/wscript
@@ -727,8 +727,7 @@ def create_ardour_test_program(bld, includes, name, target, sources):
     testobj.use          = [ 'testcommon' ]
     testobj.name         = name
     testobj.target       = target
-    # not sure about install path
-    testobj.install_path = bld.env['LIBDIR']
+    testobj.install_path = ''
     testobj.defines      = [
         'PACKAGE="libardour' + bld.env['MAJOR'] + 'test"',
         'DATA_DIR="' + os.path.normpath(bld.env['DATADIR']) + '"',

--- a/libs/pbd/wscript
+++ b/libs/pbd/wscript
@@ -209,3 +209,4 @@ def build(bld):
         testobj.defines      = [ 'PACKAGE="' + I18N_PACKAGE + '"' ]
         if sys.platform != 'darwin' and bld.env['build_target'] != 'mingw':
             testobj.lib      = ['rt', 'dl']
+        testobj.install_path = ''


### PR DESCRIPTION
Installing from a snapshot tarball (`waf dist`) dropped `run-tests` into `/usr/bin`. This should fix it.