### PR TITLE
Improve Simple Chinese translation in `gtk2_ardour/po/zh.po`.

### DIFF
--- a/gtk2_ardour/po/zh.po
+++ b/gtk2_ardour/po/zh.po
@@ -793,7 +793,7 @@ msgstr "普通"
 #: rc_option_editor.cc:3099 rc_option_editor.cc:3102 rc_option_editor.cc:3104
 #: rc_option_editor.cc:3112 rc_option_editor.cc:3113
 msgid "MIDI"
-msgstr "MIDI（乐器数字接口 Musical Instrument Digital Interface ）"
+msgstr ""
 
 #: add_route_dialog.cc:554
 msgid "Manual Configuration"
@@ -979,6 +979,10 @@ msgstr "独奏"
 msgid "Feedback"
 msgstr "反馈"
 
+#: ardour_ui.cc:319 dsp_stats_window.cc:29
+msgid "Performance Meters"
+msgstr "性能仪表"
+
 #: ardour_ui.cc:329 speaker_dialog.cc:37
 msgid "Speaker Configuration"
 msgstr "扬声器配置"
@@ -1046,6 +1050,10 @@ msgstr "播送控制"
 #: ardour_ui.cc:345 rc_option_editor.cc:3082
 msgid "Virtual Keyboard"
 msgstr "虚拟键盘"
+
+#: ardour_ui.cc:327
+msgid "Library Downloader"
+msgstr "库下载器"
 
 #: ardour_ui.cc:346
 msgid "Audio Connections"
@@ -1955,7 +1963,7 @@ msgstr "样本格式"
 
 #: ardour_ui_ed.cc:167 rc_option_editor.cc:3556 rc_option_editor.cc:3557
 msgid "Control Surfaces"
-msgstr "控制面"
+msgstr "控制面板"
 
 #: ardour_ui_ed.cc:168 rc_option_editor.cc:3563 rc_option_editor.cc:3564
 #: rc_option_editor.cc:3570 rc_option_editor.cc:3579 rc_option_editor.cc:3590
@@ -1991,6 +1999,10 @@ msgstr "新建…"
 #: ardour_ui_ed.cc:178
 msgid "Open..."
 msgstr "打开…"
+
+#: ardour_ui_ed.cc:179 recorder_ui.cc:81
+msgid "Recorder"
+msgstr "录音器"
 
 #: ardour_ui_ed.cc:179
 msgid "Recent..."
@@ -2423,6 +2435,10 @@ msgstr "导入"
 msgid "Stem export..."
 msgstr "主体导出…"
 
+#: ardour_ui_ed.cc:634
+msgid "Quick Audio Export..."
+msgstr "快速导出音频…"
+
 #: ardour_ui_ed.cc:580
 msgid "Export to Audio File(s)..."
 msgstr "导出为音频文件…"
@@ -2542,6 +2558,10 @@ msgstr "附加"
 #: ardour_ui_ed.cc:686
 msgid "Show Mixer"
 msgstr "显示混音器"
+
+#: ardour_ui_ed.cc:760
+msgid "Show Recorder"
+msgstr "显示录音器"
 
 #: ardour_ui_ed.cc:687
 msgid "Show Editor"
@@ -3739,6 +3759,10 @@ msgstr "视频时间线"
 msgid "mode"
 msgstr "模式"
 
+#: editor.cc:434 editor_actions.cc:578
+msgid "Time Signature"
+msgstr "拍号"
+
 #: editor.cc:667
 msgid "Tracks & Busses"
 msgstr "音轨 & 总线"
@@ -3800,6 +3824,18 @@ msgstr "撤销激活"
 #: editor.cc:1504 editor.cc:1529
 msgid "Activate"
 msgstr "激活"
+
+#: editor.cc:1507 editor_actions.cc:359
+msgid "Cut/Paste Range Section to Edit Point"
+msgstr "剪切/粘贴范围区域到编辑点"
+
+#: editor.cc:1506 editor_actions.cc:358
+msgid "Copy/Paste Range Section to Edit Point"
+msgstr "复制/粘贴范围区域到编辑点"
+
+#: editor.cc:1509 editor_actions.cc:363 editor_actions.cc:364
+msgid "Delete Range Section"
+msgstr "删除范围区域"
 
 #: editor.cc:1614 editor.cc:1622 editor_ops.cc:4037
 msgid "Freeze"
@@ -4338,6 +4374,14 @@ msgstr "复制播放列表"
 msgid "clear playlists"
 msgstr "清除播放列表"
 
+#: editor.cc:4871
+msgid "Copy Playlist for ALL Tracks"
+msgstr "为所有音轨复制播放列表"
+
+#: editor.cc:4871
+msgid "New Playlist for All Tracks"
+msgstr "为所有音轨新建播放列表"
+
 #: editor.cc:5205
 msgid "Please wait while %1 loads visual data."
 msgstr "请等候 %1 载入可见数据。"
@@ -4420,6 +4464,10 @@ msgstr "增益"
 #: editor_actions.cc:143 editor_actions.cc:616
 msgid "Ranges"
 msgstr "范围"
+
+#: editor_actions.cc:143
+msgid "Editor Views"
+msgstr "编辑器视图"
 
 #: editor_actions.cc:144 editor_actions.cc:1551 session_option_editor.cc:144
 #: session_option_editor.cc:146 session_option_editor.cc:153
@@ -4862,6 +4910,14 @@ msgstr "设置自动切换从指针处入/出"
 #: editor_actions.cc:365 editor_actions.cc:1557
 msgid "Multi-Duplicate..."
 msgstr "多个副本…"
+
+#: editor_actions.cc:370
+msgid "Group Selected Regions"
+msgstr "分组选定区域"
+
+#: editor_actions.cc:371
+msgid "Ungroup Selected Regions"
+msgstr "取消分组选定区域"
 
 #: editor_actions.cc:374
 msgid "Undo Selection Change"
@@ -6489,7 +6545,7 @@ msgstr "移除区域"
 
 #: editor_ops.cc:4569
 msgid "recover regions"
-msgstr "移除区域"
+msgstr "恢复区域"
 
 #: editor_ops.cc:5111
 msgid "duplicate range selection"
@@ -7268,9 +7324,21 @@ msgstr "音高替换"
 msgid "timefx cannot be started - thread creation error"
 msgstr "间特效无法启动——线程创建错误"
 
+#: engine_dialog.cc:85
+msgid "Advanced Settings"
+msgstr "高级设置"
+
+#: engine_dialog.cc:86
+msgid "Hardware Monitoring"
+msgstr "硬件监控"
+
 #: engine_dialog.cc:97
 msgid "Device Control Panel"
 msgstr "设备控制面板"
+
+#: engine_dialog.cc:107
+msgid "Setup & Calibration"
+msgstr "设置和校准"
 
 #: engine_dialog.cc:98
 msgid "Midi Device Setup"
@@ -7293,19 +7361,19 @@ msgid "Measure"
 msgstr "测量"
 
 #: engine_dialog.cc:104
-msgid "Use results"
+msgid "Use Results"
 msgstr "使用结果"
 
 #: engine_dialog.cc:105
-msgid "Back to settings ... (ignore results)"
-msgstr "回到设置…（忽略结果）"
+msgid "Back to Settings (Ignore Results)"
+msgstr "回到设置（忽略结果）"
 
 #: engine_dialog.cc:106
 msgid "Calibrate Audio"
 msgstr "校正音频"
 
 #: engine_dialog.cc:110
-msgid "Back to settings"
+msgid "Back to Settings"
 msgstr "回到设置"
 
 #: engine_dialog.cc:132
@@ -7387,11 +7455,11 @@ msgstr "设备："
 
 #: engine_dialog.cc:603 engine_dialog.cc:720 export_report.cc:165
 #: export_report.cc:339 sfdb_ui.cc:183 sfdb_ui.cc:412 sfdb_ui.cc:417
-msgid "Sample rate:"
+msgid "Sample Rate:"
 msgstr "采样率："
 
 #: engine_dialog.cc:608 engine_dialog.cc:727
-msgid "Buffer size:"
+msgid "Buffer Size:"
 msgstr "缓冲区大小："
 
 #: engine_dialog.cc:617
@@ -7407,7 +7475,7 @@ msgid "Output channels:"
 msgstr "输出声道："
 
 #: engine_dialog.cc:666
-msgid "Hardware input latency:"
+msgid "Hardware Input Latency:"
 msgstr "硬件输入延迟："
 
 #: engine_dialog.cc:669 engine_dialog.cc:682
@@ -7415,7 +7483,7 @@ msgid "samples"
 msgstr "样本"
 
 #: engine_dialog.cc:679
-msgid "Hardware output latency:"
+msgid "Hardware Output Latency:"
 msgstr "硬件输出延迟："
 
 #: engine_dialog.cc:690
@@ -7449,11 +7517,11 @@ msgstr ""
 
 #: engine_dialog.cc:932
 msgid "Engine|Stop"
-msgstr "停"
+msgstr "停止"
 
 #: engine_dialog.cc:936
 msgid "Engine|Start"
-msgstr "启"
+msgstr "启动"
 
 #: engine_dialog.cc:1022
 msgid "MIDI Devices"
@@ -11475,6 +11543,10 @@ msgstr "配置插件 '%1'"
 msgid "Output Configuration"
 msgstr "输出配置"
 
+#: ardour_ui.cc:316 io_plugin_window.cc:55
+msgid "I/O Plugins"
+msgstr "I/O 插件"
+
 #: plugin_selector.cc:70
 msgid "Plugin Manager"
 msgstr "插件管理"
@@ -11491,6 +11563,10 @@ msgstr "创建者"
 #: transport_masters_dialog.cc:734
 msgid "Type"
 msgstr "类型"
+
+#: plugin_selector.cc:74
+msgid "Plugin Selector"
+msgstr "插件选择器"
 
 #: plugin_selector.cc:103
 msgid "Audio I/O"
@@ -11593,6 +11669,10 @@ msgstr ""
 #: plugin_selector.cc:965
 msgid "Favorites"
 msgstr "收藏夹"
+
+#: plugin_selector.cc:962
+msgid "Plugin Selector..."
+msgstr "插件选择器…"
 
 #: plugin_selector.cc:967
 msgid "Plugin Manager..."
@@ -12156,6 +12236,10 @@ msgstr "移除监听发送端…"
 msgid "Send Options"
 msgstr "发送端选项"
 
+#: processor_box.cc:4182
+msgid "Presets"
+msgstr "预设"
+
 #: processor_box.cc:3917
 msgid "Clear (all)"
 msgstr "清除（所有）"
@@ -12692,6 +12776,10 @@ msgstr "%1 首选项"
 msgid "General"
 msgstr "通用"
 
+#: rc_option_editor.cc:2379
+msgid "Show Audio/MIDI Setup Window"
+msgstr "显示 音频/MIDI 设置窗口"
+
 #: rc_option_editor.cc:2304
 msgid "DSP CPU Utilization"
 msgstr "DSP（数字信号处理器）CPU使用率"
@@ -12716,6 +12804,10 @@ msgstr[0] "%1 处理器"
 #: rc_option_editor.cc:2320
 msgid "This setting will only take effect when %1 is restarted."
 msgstr "该设置将仅仅在 %1 重新启动时起作用。"
+
+#: rc_option_editor.cc:4837
+msgid "Power Management, CPU DMA latency"
+msgstr "电源管理, CPU DMA 延迟"
 
 #: rc_option_editor.cc:2326
 msgid "Memory Usage"
@@ -12824,8 +12916,8 @@ msgid "Maximum number of recent sessions"
 msgstr "当前会话的最大数量"
 
 #: rc_option_editor.cc:2465 rc_option_editor.cc:2476
-msgid "General/Translation"
-msgstr "通用 /翻译"
+msgid "Appearance/Translation"
+msgstr "外观/翻译"
 
 #: rc_option_editor.cc:2465
 msgid "Internationalization"
@@ -13245,6 +13337,14 @@ msgstr "自动化物理输出"
 msgid "automatically to master bus"
 msgstr "自动化主控总线"
 
+#: rc_option_editor.cc:2972 rc_option_editor.cc:2976
+msgid "Appearance/Size and Scale"
+msgstr "外观/大小和缩放"
+
+#: rc_option_editor.cc:2972
+msgid "User Interface Size and Scale"
+msgstr "用户界面大小和缩放"
+
 #: rc_option_editor.cc:2972
 msgid "Use 'Strict-I/O' for new tracks or busses"
 msgstr "为新的音轨或总线使用“精确-输入/输出”"
@@ -13288,6 +13388,15 @@ msgstr "在重新启动音频引擎之前，更改可能不会生效。"
 #: rc_option_editor.cc:3046
 msgid "Enable automatic analysis of audio"
 msgstr "启用音频自动分析"
+
+#: rc_option_editor.cc:4811 rc_option_editor.cc:4829 rc_option_editor.cc:4880
+#: rc_option_editor.cc:4886 rc_option_editor.cc:4888 rc_option_editor.cc:4935
+#: rc_option_editor.cc:4938 rc_option_editor.cc:4940 rc_option_editor.cc:4960
+#: rc_option_editor.cc:4972 rc_option_editor.cc:4977 rc_option_editor.cc:4989
+#: rc_option_editor.cc:4991 rc_option_editor.cc:4993 rc_option_editor.cc:5002
+#: rc_option_editor.cc:5011 rc_option_editor.cc:5025
+msgid "Performance"
+msgstr "性能"
 
 #: rc_option_editor.cc:3054
 msgid "Replicate missing region channels"
@@ -13340,6 +13449,10 @@ msgstr "MIDI 端口选项"
 #: rc_option_editor.cc:3107
 msgid "MIDI input follows MIDI track selection"
 msgstr "MIDI 输入跟随 MIDI 音轨已选择部分"
+
+#: rc_option_editor.cc:3623 rc_option_editor.cc:3624
+msgid "MIDI/MIDI Port Config"
+msgstr "MIDI/MIDI端口配置"
 
 #: rc_option_editor.cc:3123
 msgid "Enable metronome only while recording"
@@ -13503,6 +13616,14 @@ msgstr "导出后将响度分析另存为图像文件"
 #: rc_option_editor.cc:3292
 msgid "Save Mixer screenshot after export"
 msgstr "导出后保存混音器屏幕截图"
+
+#: rc_option_editor.cc:2474
+msgid "New Version Check"
+msgstr "检查新版本"
+
+#: rc_option_editor.cc:2477
+msgid "Check for announcements at application start"
+msgstr "在应用程序启动时检查公告"
 
 #: rc_option_editor.cc:3303
 msgid "Stop at the end of the session"
@@ -13904,6 +14025,12 @@ msgstr ""
 msgid "Plugins/VST"
 msgstr "插件/VST（虚拟工作室技术）"
 
+#: rc_option_editor.cc:4063 rc_option_editor.cc:4064 rc_option_editor.cc:4078
+#: rc_option_editor.cc:4092 rc_option_editor.cc:4096 rc_option_editor.cc:4097
+#: rc_option_editor.cc:4111
+msgid "Plugins/GUI"
+msgstr "插件/GUI"
+
 #: rc_option_editor.cc:3621
 msgid "VST"
 msgstr "VST 虚拟工作室技术（Virtual Studio Technology）"
@@ -14055,6 +14182,22 @@ msgstr "插件图形用户界面"
 msgid "Automatically open the plugin GUI when adding a new plugin"
 msgstr "添加新的插件时自动打开插件图形用户界面"
 
+#: rc_option_editor.cc:4074
+msgid "Show only one plugin window at a time"
+msgstr "一次只显示一个插件窗口"
+
+#: rc_option_editor.cc:4088
+msgid "only hides the window"
+msgstr "仅隐藏窗口"
+
+#: rc_option_editor.cc:4089
+msgid "destroys the GUI instance, releasing resources"
+msgstr "销毁 GUI 实例，释放资源"
+
+#: rc_option_editor.cc:4090
+msgid "only destroys VST2/3 UIs, hides others"
+msgstr "仅关闭 VST2/3 UI，隐藏其他窗口"
+
 #: rc_option_editor.cc:3807
 msgid "Show Plugin Inline Display on Mixerstrip by default"
 msgstr "在混音器工具栏上默认显示插件内联显示"
@@ -14083,6 +14226,10 @@ msgid ""
 "before adding a multichannel plugin."
 msgstr ""
 "<b>当启用时</b>显示一个对话框以便于在添加一个复合声道插件前选择乐器声道配置。"
+
+#: rc_option_editor.cc:4084
+msgid "Closing a Plugin GUI Window"
+msgstr "关闭插件 GUI 窗口时"
 
 #: rc_option_editor.cc:3841
 msgid "Statistics"
@@ -14164,6 +14311,14 @@ msgstr "闪亮录制预备按钮"
 msgid "Blink Alert Indicators"
 msgstr "闪亮警报指示器"
 
+#: rc_option_editor.cc:2621 rc_option_editor.cc:2634
+msgid "Appearance/Recorder"
+msgstr "外观/录音器"
+
+#: rc_option_editor.cc:2621 rc_option_editor.cc:2625
+msgid "Input Meter Layout"
+msgstr "输入仪表布局"
+
 #: rc_option_editor.cc:3947 rc_option_editor.cc:3948 rc_option_editor.cc:3956
 #: rc_option_editor.cc:3964 rc_option_editor.cc:3984 rc_option_editor.cc:3995
 #: rc_option_editor.cc:3997 rc_option_editor.cc:4000 rc_option_editor.cc:4009
@@ -14186,6 +14341,10 @@ msgstr "区域颜色跟随音轨颜色"
 #: rc_option_editor.cc:3967
 msgid "Show Region Names"
 msgstr "显示区域名称"
+
+#: rc_option_editor.cc:2665
+msgid "Show Selection Marker"
+msgstr "显示选择标记"
 
 #: rc_option_editor.cc:3975
 msgid "Track name ellipsize mode"
@@ -14325,6 +14484,10 @@ msgstr "主播送工具栏条目"
 #: rc_option_editor.cc:4154
 msgid "Display Record/Punch Options"
 msgstr "显示录制/切换选项"
+
+#: rc_option_editor.cc:2904
+msgid "Display Latency Compensation"
+msgstr "显示延迟补偿"
 
 #: rc_option_editor.cc:4162
 msgid "Display Monitoring Options"
@@ -14469,6 +14632,10 @@ msgid ""
 "When detaching the monitoring section, mark it as \"Utility\" window to stay "
 "in front."
 msgstr "分离监控中的部分时，让它作为“工具”窗口保留在前面。"
+
+#: rc_option_editor.cc:3091
+msgid "Allow to resize Engine Dialog"
+msgstr "允许调整引擎对话框的大小"
 
 #: rc_option_editor.cc:4349
 msgid "Video Server"
@@ -16228,6 +16395,10 @@ msgid ""
 msgstr ""
 "音频/MIDI 引擎意外停止运行。\n"
 "您的音频/MIDI 设备设置可能有问题。"
+
+#: startup_fsm.cc:458
+msgid "Starting Audio/MIDI Engine"
+msgstr "正在启动 音频/MIDI 引擎"
 
 #: startup_fsm.cc:557
 msgid "Cannot get existing session information from %1"


### PR DESCRIPTION
Fix mistakes:
```
移除区域 -> 恢复区域
```
*The last contributor may copy the template but forgot to modify it.*

New translations:
```
Recorder -> 录音器
Quick Audio Export... -> 快速导出音频…
Show Recorder -> 显示录音器
Time Signature -> 拍号
Editor Views -> 编辑器视图
Performance Meters -> 性能仪表
Cut/Paste Range Section to Edit Point -> 剪切/粘贴范围区域到编辑点
Copy/Paste Range Section to Edit Point -> 复制/粘贴范围区域到编辑点
Group Selected Regions -> 分组选定区域
Ungroup Selected Regions -> 取消分组选定区域
MIDI/MIDI Port Config -> MIDI/MIDI端口配置
Show only one plugin window at a time -> 一次只显示一个插件窗口
only hides the window -> 仅隐藏窗口
destroys the GUI instance, releasing resources -> 销毁 GUI 实例，释放资源
only destroys VST2/3 UIs, hides others -> 仅关闭 VST2/3 UI，隐藏其他窗口
Closing a Plugin GUI Window -> 关闭插件 GUI 窗口时
Appearance/Recorder -> 外观/录音器
Input Meter Layout -> 输入仪表布局
Plugin Selector -> 插件选择器
Show Audio/MIDI Setup Window -> 显示 音频/MIDI 设置窗口
Power Management, CPU DMA latency -> 电源管理, CPU DMA 延迟
New Version Check -> 检查新版本
Check for announcements at application start -> 在应用程序启动时检查公告
Show Selection Marker -> 显示选择标记
Allow to resize Engine Dialog -> 允许调整引擎对话框的大小
Starting Audio/MIDI Engine -> 正在启动 音频/MIDI 引擎
```

Improved expressions:
```
控制面 -> 控制面板
启 -> 启动
停 -> 停止
```