### PR TITLE
"MIDI PC/CC" plugin script

### DIFF
--- a/gtk2_ardour/lua_proc_handlers.cc
+++ b/gtk2_ardour/lua_proc_handlers.cc
@@ -36,13 +36,23 @@
 
 using namespace ARDOUR;
 
-/* The Lua "prelude" loaded into every handler interpreter.  It supplies the
- * script-facing registry API (register_handler / unregister_handler /
- * clear_handlers) and the single C++-callable entry point __dispatch(id,val).
- * Keeping the registry in Lua keeps the C++ surface minimal (the design
- * report's explicit preference) and gives handlers a plain Lua table to
- * reason about.  pcall isolates a throwing handler so one bad callback can't
- * take down the GUI thread. */
+/* The Lua "prelude" loaded, on the GUI thread, into every handler
+ * interpreter.  It supplies the script-facing registry API (register_handler
+ * / unregister_handler / clear_handlers) and the single C++-callable entry
+ * point __dispatch(id,val).
+ *
+ * The handler interpreter does not exist until the DSP (RT) thread sends its
+ * first message.  That first self:dispatch() emits AccessLuaScript, which is
+ * marshalled to the GUI thread, where dispatch() -> get_or_create() builds the
+ * interpreter, loads this prelude, and runs the script's gui_init() (which
+ * should call register_handler to populate __rt_handlers).  That first
+ * message -- and every message after it -- is then delivered by calling
+ * __dispatch(id, val) in the interpreter, which looks up the handler
+ * registered for id and invokes it.
+ *
+ * Keeping the registry in Lua keeps the C++ surface minimal and gives handlers
+ * a plain Lua table to reason about.  pcall isolates a throwing handler so one
+ * bad callback can't take down the GUI thread. */
 static const char* handler_prelude =
 	"__rt_handlers = {}\n"
 	"function register_handler (id, fn) __rt_handlers[id] = fn end\n"
@@ -122,8 +132,8 @@ LuaProcHandlers::get_or_create (LuaProc* proc)
 		/* registry API + __dispatch entry point */
 		vm->lua->do_command (handler_prelude);
 
-		/* one-time GUI initialisation; this is where the script calls
-		 * register_handler(...) to populate __rt_handlers */
+		/* one-time GUI initialisation; this is where the script is
+		 * expected to call register_handler(...) to populate __rt_handlers */
 		luabridge::LuaRef gi = luabridge::getGlobal (L, "gui_init");
 		if (gi.isFunction ()) {
 			gi ();

--- a/gtk2_ardour/lua_proc_handlers.cc
+++ b/gtk2_ardour/lua_proc_handlers.cc
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026 Brent Baccala <cosine@freesoft.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <iostream>
+
+#include "pbd/error.h"
+
+#include "ardour/luaproc.h"
+
+#include "lua/luastate.h"
+#include "LuaBridge/LuaBridge.h"
+
+#include "gtkmm2ext/gui_thread.h"
+
+#include "public_editor.h"
+#include "luainstance.h"
+#include "lua_proc_handlers.h"
+#include "ui_config.h"
+
+#include "pbd/i18n.h"
+
+using namespace ARDOUR;
+
+/* The Lua "prelude" loaded into every handler interpreter.  It supplies the
+ * script-facing registry API (register_handler / unregister_handler /
+ * clear_handlers) and the single C++-callable entry point __dispatch(id,val).
+ * Keeping the registry in Lua keeps the C++ surface minimal (the design
+ * report's explicit preference) and gives handlers a plain Lua table to
+ * reason about.  pcall isolates a throwing handler so one bad callback can't
+ * take down the GUI thread. */
+static const char* handler_prelude =
+	"__rt_handlers = {}\n"
+	"function register_handler (id, fn) __rt_handlers[id] = fn end\n"
+	"function unregister_handler (id) __rt_handlers[id] = nil end\n"
+	"function clear_handlers () __rt_handlers = {} end\n"
+	"function __dispatch (id, val)\n"
+	"  local fn = __rt_handlers[id]\n"
+	"  if fn then\n"
+	"    local ok, err = pcall (fn, val)\n"
+	"    if not ok then print ('RT-dispatch handler ' .. tostring(id) .. ' error: ' .. tostring(err)) end\n"
+	"  end\n"
+	"end\n";
+
+LuaProcHandlers* LuaProcHandlers::_instance = 0;
+
+LuaProcHandlers*
+LuaProcHandlers::instance ()
+{
+	if (!_instance) {
+		_instance = new LuaProcHandlers ();
+	}
+	return _instance;
+}
+
+LuaProcHandlers::LuaProcHandlers ()
+{
+	/* One process-wide connection.  gui_context() marshals every RT-side
+	 * emit onto the GUI thread via PBD::AbstractUI::call_slot -- exactly
+	 * the path BasicUI::AccessAction uses (editor.cc). */
+	LuaProc::AccessLuaScript.connect (
+			*this, MISSING_INVALIDATOR,
+			std::bind (&LuaProcHandlers::dispatch, this,
+			           std::placeholders::_1,
+			           std::placeholders::_2,
+			           std::placeholders::_3),
+			gui_context ());
+}
+
+LuaProcHandlers::~LuaProcHandlers ()
+{
+	_vms.clear ();
+}
+
+LuaProcHandlers::HandlerVM::~HandlerVM ()
+{
+	delete dispatch_fn;
+	delete lua;
+}
+
+std::shared_ptr<LuaProcHandlers::HandlerVM>
+LuaProcHandlers::get_or_create (LuaProc* proc)
+{
+	VMMap::iterator i = _vms.find (proc);
+	if (i != _vms.end ()) {
+		return i->second;
+	}
+
+	std::shared_ptr<HandlerVM> vm (new HandlerVM ());
+
+	const bool sandbox = UIConfiguration::instance ().get_sandbox_all_lua_scripts ();
+	vm->lua = new LuaState (sandbox, true);
+	lua_State* L = vm->lua->getState ();
+
+	try {
+		/* GUI-owned bindings: the full action-script surface, so handlers
+		 * can do Editor:access_action, dialogs, OSC, etc. */
+		LuaInstance::register_classes (L, sandbox);
+		LuaInstance::register_hooks (L);
+
+		luabridge::push <PublicEditor *> (L, &PublicEditor::instance ());
+		lua_setglobal (L, "Editor");
+
+		/* libardour-owned bootstrap: dsp bindings, the LuaProc class,
+		 * self / Session / CtrlPorts, and do_command(_script). */
+		proc->setup_lua_handler_gui (vm->lua);
+
+		/* registry API + __dispatch entry point */
+		vm->lua->do_command (handler_prelude);
+
+		/* one-time GUI initialisation; this is where the script calls
+		 * register_handler(...) to populate __rt_handlers */
+		luabridge::LuaRef gi = luabridge::getGlobal (L, "gui_init");
+		if (gi.isFunction ()) {
+			gi ();
+		}
+
+		vm->dispatch_fn = new luabridge::LuaRef (luabridge::getGlobal (L, "__dispatch"));
+	} catch (luabridge::LuaException const& e) {
+		PBD::error << string_compose (_("LuaProc handler init failed: %1"), e.what ()) << endmsg;
+		vm->dispatch_fn = 0;
+	} catch (...) {
+		PBD::error << _("LuaProc handler init failed (unknown error)") << endmsg;
+		vm->dispatch_fn = 0;
+	}
+
+	/* tear the interpreter down when the plugin goes away.  We only use
+	 * 'proc' as a map key here, never dereference it, so a deferred
+	 * (gui_context) callback after the LuaProc is gone is safe. */
+	proc->DropReferences.connect (
+			vm->drop_connection, MISSING_INVALIDATOR,
+			std::bind (&LuaProcHandlers::drop, this, proc),
+			gui_context ());
+
+	_vms[proc] = vm;
+	return vm;
+}
+
+void
+LuaProcHandlers::dispatch (LuaProc* proc, int handler_id, int value)
+{
+	std::shared_ptr<HandlerVM> vm = get_or_create (proc);
+	if (!vm->dispatch_fn) {
+		return;
+	}
+	try {
+		(*vm->dispatch_fn) (handler_id, value);
+	} catch (luabridge::LuaException const& e) {
+		PBD::error << string_compose (_("LuaProc handler dispatch error: %1"), e.what ()) << endmsg;
+	} catch (...) {
+		PBD::error << _("LuaProc handler dispatch error (unknown)") << endmsg;
+	}
+}
+
+void
+LuaProcHandlers::drop (LuaProc* proc)
+{
+	VMMap::iterator i = _vms.find (proc);
+	if (i != _vms.end ()) {
+		_vms.erase (i);
+	}
+}

--- a/gtk2_ardour/lua_proc_handlers.h
+++ b/gtk2_ardour/lua_proc_handlers.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Brent Baccala <cosine@freesoft.org>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+
+#include "pbd/signals.h"
+
+namespace ARDOUR { class LuaProc; }
+class LuaState;
+namespace luabridge { class LuaRef; }
+
+/** GUI-thread side of the RT->GUI Lua dispatch (see project report
+ *  ardour-rt-gui-lua-dispatch-design.md / -impl-notes.md).
+ *
+ *  A process-wide singleton.  It connects ARDOUR::LuaProc::AccessLuaScript
+ *  once with gui_context(), so every RT-side self:dispatch(id,val) arrives
+ *  here on the GUI thread.  For each LuaProc that uses the feature it lazily
+ *  builds a dedicated "handler" Lua interpreter -- full GUI bindings
+ *  (LuaInstance::register_classes/register_hooks) plus the libardour-owned
+ *  per-plugin bootstrap (LuaProc::setup_lua_handler_gui: dsp bindings, the
+ *  script itself, and self/Session/CtrlPorts) -- runs the script's
+ *  gui_init(), and thereafter routes (id,val) to the Lua handler the script
+ *  registered.  The interpreter is torn down when the LuaProc is destroyed.
+ *
+ *  The interpreter is created lazily inside the dispatch slot itself (same
+ *  pattern as ProcessorEntry::LuaPluginDisplay's inline interpreter): the
+ *  first dispatch builds the VM, runs gui_init() -- which registers the
+ *  handlers -- and then handles that same event, so nothing is lost.
+ */
+class LuaProcHandlers : public PBD::ScopedConnectionList
+{
+public:
+	static LuaProcHandlers* instance ();
+	~LuaProcHandlers ();
+
+private:
+	LuaProcHandlers ();
+	static LuaProcHandlers* _instance;
+
+	struct HandlerVM {
+		HandlerVM () : lua (0), dispatch_fn (0) {}
+		~HandlerVM ();
+		LuaState*            lua;
+		luabridge::LuaRef*   dispatch_fn; /* the prelude's __dispatch(id,val) */
+		PBD::ScopedConnection drop_connection;
+	};
+
+	typedef std::map<ARDOUR::LuaProc*, std::shared_ptr<HandlerVM> > VMMap;
+	VMMap _vms;
+
+	/* slot for LuaProc::AccessLuaScript, always on the GUI thread */
+	void dispatch (ARDOUR::LuaProc* proc, int handler_id, int value);
+
+	std::shared_ptr<HandlerVM> get_or_create (ARDOUR::LuaProc* proc);
+	void drop (ARDOUR::LuaProc* proc);
+};

--- a/gtk2_ardour/lua_proc_handlers.h
+++ b/gtk2_ardour/lua_proc_handlers.h
@@ -27,23 +27,104 @@ namespace ARDOUR { class LuaProc; }
 class LuaState;
 namespace luabridge { class LuaRef; }
 
-/** GUI-thread side of the RT->GUI Lua dispatch (see project report
- *  ardour-rt-gui-lua-dispatch-design.md / -impl-notes.md).
+/** GUI-thread side of the realtime->GUI Lua dispatch primitive.
  *
- *  A process-wide singleton.  It connects ARDOUR::LuaProc::AccessLuaScript
- *  once with gui_context(), so every RT-side self:dispatch(id,val) arrives
- *  here on the GUI thread.  For each LuaProc that uses the feature it lazily
- *  builds a dedicated "handler" Lua interpreter -- full GUI bindings
- *  (LuaInstance::register_classes/register_hooks) plus the libardour-owned
- *  per-plugin bootstrap (LuaProc::setup_lua_handler_gui: dsp bindings, the
- *  script itself, and self/Session/CtrlPorts) -- runs the script's
- *  gui_init(), and thereafter routes (id,val) to the Lua handler the script
- *  registered.  The interpreter is torn down when the LuaProc is destroyed.
+ *  Problem
+ *  -------
+ *  A DSP (realtime) Lua plugin runs dsp_run() on the audio process thread,
+ *  where it must not allocate, take contended locks, or call code that does
+ *  either.  That rules out much of what a plugin might want to do in response
+ *  to incoming data: load()/compile Lua source, pcall() arbitrary user code,
+ *  mutate routes (Route::set_active), set controls (Session::set_control), or
+ *  iterate the route list.  The MIDI PC/CC plugin (midi_pc_and_cc.lua) needs
+ *  all of these, which is why this primitive exists.
  *
- *  The interpreter is created lazily inside the dispatch slot itself (same
- *  pattern as ProcessorEntry::LuaPluginDisplay's inline interpreter): the
- *  first dispatch builds the VM, runs gui_init() -- which registers the
- *  handlers -- and then handles that same event, so nothing is lost.
+ *  Approach: three interpreters per plugin
+ *  ----------------------------------------
+ *  A LuaProc script can be run by up to three independent Lua interpreters,
+ *  each a separate lua_State with its own globals.  The same script text is
+ *  loaded into each, so script-level constants and functions appear in all of
+ *  them; the three differ in which thread they run on and what they do:
+ *
+ *    - the RT interpreter (LuaProc's own lua_State).  Always present; runs the
+ *      script's realtime callbacks (dsp_run() on the audio thread).  It does
+ *      only RT-safe work and, when it wants something done off the RT thread,
+ *      calls self:dispatch(handler_id, value).
+ *
+ *    - the inline-display interpreter.  Present only if the script defines a
+ *      render_inline() function and its inline display is shown; runs on the
+ *      GUI thread, owned by ProcessorEntry::LuaPluginDisplay (gtk2_ardour) and
+ *      set up by LuaProc::setup_lua_inline_gui().  It draws the small in-mixer
+ *      plugin display and is otherwise unrelated to the dispatch feature -- it
+ *      is noted here only because the handler interpreter below is modelled on
+ *      it (a GUI-owned second interpreter over the same LuaProc).
+ *
+ *    - the handler interpreter (the subject of this file).  Present only
+ *      if the script uses dispatch; created and owned here on the GUI thread.
+ *      It runs the script again and calls the script's gui_init(), in
+ *      which the script should call register_handler(id, fn).  When a dispatch
+ *      arrives, the matching fn(value) runs here on the GUI thread, where the
+ *      non-RT-safe operations above are legal.
+ *
+ *  On the RT thread, self:dispatch() emits the static signal
+ *  LuaProc::AccessLuaScript (LuaProc*, handler_id, value).  This singleton
+ *  connects that signal once, with gui_context(), so the slot is marshalled
+ *  from the emitting RT thread onto the GUI thread over
+ *  PBD::AbstractUI::call_slot -- the per-thread lock-free ringbuffer +
+ *  pipe-wakeup path Ardour already treats as RT-callable, and the same path
+ *  BasicUI::AccessAction uses (see editor.cc).  The (LuaProc*, handler_id,
+ *  value) payload fits the std::function small-object buffer, so the RT-side
+ *  emit allocates nothing.
+ *
+ *  The dispatch payload is only two ints (handler_id, value).  A plugin that
+ *  needs to hand the GUI side more than that -- a multi-byte MIDI event, a
+ *  block of parameters -- can move the bulk of the data through self:shmem().
+ *  shmem() is the LuaProc's per-instance DSP::DspShm region; because self is
+ *  the same C++ LuaProc object in both the RT interpreter and the GUI
+ *  interpreter, both see the same physical memory.  The RT side writes the
+ *  data into shmem before calling self:dispatch(), passes an index/slot into
+ *  it as the int payload, and the GUI interpreter reads it back out.  The
+ *  dispatch ordering already gives a clean handoff -- the RT side writes the
+ *  slot before emitting, and call_slot publishes that write to the GUI thread
+ *  -- so for a write-then-dispatch payload no extra shmem synchronisation is
+ *  needed.  Where the GUI side instead polls shmem on its own (the midimon.lua
+ *  pattern), use an atomic write-index (shmem():atomic_set_int /
+ *  atomic_get_int) over the ring so the reader sees only completed writes.
+ *
+ *  Sizing the shmem region.  DSP::DspShm is a flat, fixed-size, cache-aligned
+ *  array of 4-byte cells (float and int32 alias the same storage); there is no
+ *  built-in slot or ring concept, so how the buffer is laid out and sized is
+ *  up to the script, which passes the total cell count to shmem():allocate(N).
+ *  allocate() calls malloc and is NOT RT-safe: call it once from dsp_init
+ *  (which runs off the RT thread), never from dsp_run.  The buffer is then
+ *  fixed for the plugin's life, so a burst that would exceed its capacity must
+ *  be dropped or coalesced, not grown into.
+ *
+ *  Why the handler interpreter lives here, not in LuaProc
+ *  ------------------------------------------------------
+ *  Handlers want the full action-script binding set -- Editor:access_action,
+ *  dialogs, OSC -- which is LuaInstance::register_classes(), defined in
+ *  gtk2_ardour.  libardour (where LuaProc lives) cannot depend on gtk2_ardour
+ *  (that would reverse the library layering), so LuaProc cannot register
+ *  those bindings itself.  The split mirrors the inline-display interpreter
+ *  (ProcessorEntry::LuaPluginDisplay): libardour provides a bootstrap hook
+ *  (LuaProc::setup_lua_handler_gui -- dsp bindings, the script, and
+ *  self/Session/CtrlPorts, all needing LuaProc's private members) and the GUI
+ *  side layers the GUI bindings + a register_handler() Lua prelude on top.
+ *
+ *  Lifetime
+ *  --------
+ *  The handler interpreter is built lazily, inside the dispatch slot itself
+ *  (same pattern as the inline-display interpreter): the first dispatch for a
+ *  given LuaProc builds the VM and runs gui_init() -- which registers the
+ *  handlers -- and then handles that same event, so the first dispatch is not
+ *  lost.  A plugin that never calls self:dispatch() never gets a handler
+ *  interpreter.
+ *
+ *  The VM is torn down when the LuaProc is destroyed, via its DropReferences
+ *  signal (also connected with gui_context()).  The LuaProc* is used only as
+ *  a map key, never dereferenced in the teardown slot, so a teardown callback
+ *  that runs after the LuaProc is already gone is safe.
  */
 class LuaProcHandlers : public PBD::ScopedConnectionList
 {

--- a/gtk2_ardour/luainstance.cc
+++ b/gtk2_ardour/luainstance.cc
@@ -50,6 +50,7 @@
 #include "region_selection.h"
 #include "luadialog.h"
 #include "luainstance.h"
+#include "lua_proc_handlers.h"
 #include "luasignal.h"
 #include "marker.h"
 #include "mixer_ui.h"
@@ -1460,6 +1461,11 @@ LuaInstance::init ()
 
 	luabridge::push <PublicEditor *> (L, &PublicEditor::instance());
 	lua_setglobal (L, "Editor");
+
+	/* bring up the RT->GUI Lua dispatch manager: this connects
+	 * ARDOUR::LuaProc::AccessLuaScript (gui_context) so DSP scripts can
+	 * marshal work to the GUI thread.  See lua_proc_handlers.h. */
+	LuaProcHandlers::instance ();
 
 	Selection& sel (PublicEditor::instance().get_selection ());
 	sel.TimeChanged.connect (sigc::mem_fun (*this, &LuaInstance::selection_changed));

--- a/gtk2_ardour/wscript
+++ b/gtk2_ardour/wscript
@@ -157,6 +157,7 @@ gtk2_ardour_sources = [
         'location_ui.cc',
         'loudness_dialog.cc',
         'loudness_settings.cc',
+        'lua_proc_handlers.cc',
         'lua_script_manager.cc',
         'luadialog.cc',
         'luainstance.cc',

--- a/libs/ardour/ardour/luaproc.h
+++ b/libs/ardour/ardour/luaproc.h
@@ -125,14 +125,16 @@ public:
 	bool has_inline_display () { return _lua_has_inline_display; }
 	void setup_lua_inline_gui (LuaState *lua_gui);
 
-	/* libardour-owned bootstrap for the GUI-thread "handler" interpreter
-	 * (interpreter #3 in the RT->GUI dispatch design).  Mirrors
-	 * setup_lua_inline_gui but also pushes the Session global and exposes
-	 * route()/name()/unique_id(), since handlers do route/session work that
-	 * the RT path used to do unsafely.  The GUI side (LuaProcHandlers, in
-	 * gtk2_ardour) layers LuaInstance::register_classes()/register_hooks()
-	 * and a small register_handler() prelude on top, then calls gui_init().
-	 * Kept here because _script / _control_data / _session are private. */
+	/* libardour-owned half of the GUI-thread "handler" interpreter setup
+	 * used by the realtime->GUI Lua dispatch (see LuaProcHandlers in
+	 * gtk2_ardour for the full design).  Mirrors setup_lua_inline_gui but
+	 * also pushes the Session global and exposes route()/name()/unique_id(),
+	 * since handlers do the route/session work that the RT path used to do
+	 * unsafely.  The GUI side (LuaProcHandlers) layers
+	 * LuaInstance::register_classes()/register_hooks() and a small
+	 * register_handler() prelude on top, then calls gui_init().  This half is
+	 * kept in libardour because it touches the private _script /
+	 * _control_data / _session. */
 	void setup_lua_handler_gui (LuaState *lua_handler);
 
 	DSP::DspShm* instance_shm () { return &lshm; }
@@ -143,10 +145,11 @@ public:
 	 * GUI-side manager connects with gui_context() so the registered Lua
 	 * handler runs on the GUI thread.  RT-safe: a pure signal emit over the
 	 * same cross-thread call_slot path Ardour already treats as RT-callable
-	 * for Session::request_* (per-thread SPSC ringbuffer + pipe wakeup, see
-	 * pbd/abstract_ui.inc.cc).  The (LuaProc*,int,int) payload fits the
-	 * std::function small-buffer, so no allocation on the RT side.
-	 * See project report ardour-rt-gui-lua-dispatch-design.md. */
+	 * for Session::request_* (per-thread lock-free ringbuffer + pipe-wakeup,
+	 * see pbd/abstract_ui.inc.cc).  The (LuaProc*,int,int) payload fits the
+	 * std::function small-object buffer, so no allocation on the RT side.  The
+	 * GUI-side manager (LuaProcHandlers, gtk2_ardour) carries the full
+	 * design overview. */
 	void dispatch (uint32_t handler_id, int value);
 	static PBD::Signal<void(LuaProc*, int, int)> AccessLuaScript;
 

--- a/libs/ardour/ardour/luaproc.h
+++ b/libs/ardour/ardour/luaproc.h
@@ -125,8 +125,30 @@ public:
 	bool has_inline_display () { return _lua_has_inline_display; }
 	void setup_lua_inline_gui (LuaState *lua_gui);
 
+	/* libardour-owned bootstrap for the GUI-thread "handler" interpreter
+	 * (interpreter #3 in the RT->GUI dispatch design).  Mirrors
+	 * setup_lua_inline_gui but also pushes the Session global and exposes
+	 * route()/name()/unique_id(), since handlers do route/session work that
+	 * the RT path used to do unsafely.  The GUI side (LuaProcHandlers, in
+	 * gtk2_ardour) layers LuaInstance::register_classes()/register_hooks()
+	 * and a small register_handler() prelude on top, then calls gui_init().
+	 * Kept here because _script / _control_data / _session are private. */
+	void setup_lua_handler_gui (LuaState *lua_handler);
+
 	DSP::DspShm* instance_shm () { return &lshm; }
 	LuaTableRef* instance_ref () { return &lref; }
+
+	/* RT->GUI Lua dispatch.  A script's realtime dsp_run() calls
+	 * self:dispatch(handler_id, value); this emits AccessLuaScript, which a
+	 * GUI-side manager connects with gui_context() so the registered Lua
+	 * handler runs on the GUI thread.  RT-safe: a pure signal emit over the
+	 * same cross-thread call_slot path Ardour already treats as RT-callable
+	 * for Session::request_* (per-thread SPSC ringbuffer + pipe wakeup, see
+	 * pbd/abstract_ui.inc.cc).  The (LuaProc*,int,int) payload fits the
+	 * std::function small-buffer, so no allocation on the RT side.
+	 * See project report ardour-rt-gui-lua-dispatch-design.md. */
+	void dispatch (uint32_t handler_id, int value);
+	static PBD::Signal<void(LuaProc*, int, int)> AccessLuaScript;
 
 	struct FactoryPreset {
 		std::string               name;

--- a/libs/ardour/luaproc.cc
+++ b/libs/ardour/luaproc.cc
@@ -43,6 +43,8 @@
 using namespace ARDOUR;
 using namespace PBD;
 
+PBD::Signal<void(LuaProc*, int, int)> LuaProc::AccessLuaScript;
+
 LuaProc::LuaProc (AudioEngine& engine,
                   Session& session,
                   const std::string &script)
@@ -164,6 +166,7 @@ LuaProc::init ()
 		.addFunction ("route", &LuaProc::route)
 		.addFunction ("unique_id", &LuaProc::unique_id)
 		.addFunction ("name", &LuaProc::name)
+		.addFunction ("dispatch", &LuaProc::dispatch)
 		.endClass ()
 		.endNamespace ();
 	lua_mlock (L, 0);
@@ -208,6 +211,18 @@ LuaProc::lua_print (std::string s) {
 	 * (see also fe0e997335c34af0d71e7536fd507e1cab322d24)
 	 */
 	PBD::info << "LuaProc: " << s << endmsg;
+}
+
+void
+LuaProc::dispatch (uint32_t handler_id, int value)
+{
+	/* Called from the RT DSP interpreter (dsp_run).  Emit only: the GUI-side
+	 * connection uses gui_context(), so the actual handler runs on the GUI
+	 * thread, marshalled via PBD::AbstractUI::call_slot.  This is the same
+	 * cross-thread path Ardour treats as RT-callable for Session::request_*
+	 * (luabindings.cc: "functions which can be used from realtime and
+	 * non-realtime contexts").  No load()/pcall()/route mutation on RT. */
+	AccessLuaScript (this, (int) handler_id, value); /* EMIT SIGNAL */
 }
 
 bool
@@ -1216,6 +1231,46 @@ LuaProc::setup_lua_inline_gui (LuaState *lua_gui)
 
 	luabridge::push <float *> (LG, _control_data);
 	lua_setglobal (LG, "CtrlPorts");
+}
+
+void
+LuaProc::setup_lua_handler_gui (LuaState *lua_handler)
+{
+	/* libardour-owned half of the handler interpreter setup.  The GUI-owned
+	 * half (LuaInstance::register_classes/register_hooks + the
+	 * register_handler() prelude + the gui_init() call) is done by
+	 * LuaProcHandlers in gtk2_ardour, which cannot reach _script /
+	 * _control_data / _session.  Compare setup_lua_inline_gui(). */
+	lua_State* LH = lua_handler->getState ();
+	LuaBindings::stddef (LH);
+	LuaBindings::common (LH);
+	LuaBindings::dsp (LH);
+	LuaBindings::osc (LH);
+
+	lua_handler->Print.connect (sigc::mem_fun (*this, &LuaProc::lua_print));
+
+	luabridge::getGlobalNamespace (LH)
+		.beginNamespace ("Ardour")
+		.beginClass <LuaProc> ("LuaProc")
+		.addFunction ("shmem", &LuaProc::instance_shm)
+		.addFunction ("table", &LuaProc::instance_ref)
+		.addFunction ("route", &LuaProc::route)
+		.addFunction ("unique_id", &LuaProc::unique_id)
+		.addFunction ("name", &LuaProc::name)
+		.endClass ()
+		.endNamespace ();
+
+	luabridge::push <Session *> (LH, &_session);
+	lua_setglobal (LH, "Session");
+
+	luabridge::push <LuaProc *> (LH, this);
+	lua_setglobal (LH, "self");
+
+	luabridge::push <float *> (LH, _control_data);
+	lua_setglobal (LH, "CtrlPorts");
+
+	lua_handler->do_command ("function ardour () end");
+	lua_handler->do_command (_script);
 }
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/share/scripts/_example_rt_dispatch.lua
+++ b/share/scripts/_example_rt_dispatch.lua
@@ -1,0 +1,57 @@
+ardour {
+	["type"]    = "dsp",
+	name        = "RT->GUI Dispatch Example",
+	category    = "Example",
+	author      = "Brent Baccala",
+	description = [[Minimal example of the RT->GUI Lua dispatch primitive.
+
+A DSP (realtime) Lua script may not safely call load(), pcall() of user
+code, route/Session mutators, or iterate the route list from dsp_run().
+This primitive lets the realtime side forward a tiny (handler_id, value)
+pair to the GUI thread, where a handler with the full action-script
+binding set does the unsafe work.
+
+Pattern:
+  * pick integer handler IDs (plain Lua constants -- both interpreters
+    run this script, so both see them);
+  * in dsp_run() (realtime), call self:dispatch(id, value) -- emit only;
+  * in gui_init() (GUI thread, called once), call register_handler(id, fn)
+    for each handler.  fn(value) runs on the GUI thread.
+
+For payloads wider than one int, write into self:shmem() at agreed
+offsets on the RT side and dispatch a slot index; read it back in the
+handler.  Two 7-bit MIDI bytes also pack into one int as (a << 7) | b.
+]]
+}
+
+function dsp_ioconfig ()
+	return { { midi_in = 1, midi_out = 1, audio_in = 0, audio_out = 0 } }
+end
+
+HANDLER_NOTE_ON = 1   -- value = (note_number << 7) | velocity
+
+-- realtime: forward every MIDI note-on to the GUI thread, pass the rest
+function dsp_run (_, _, n_samples)
+	local oi = 1
+	for _, b in pairs (midiin) do
+		local d = b["data"]
+		local consumed = false
+		if #d >= 3 and (d[1] >> 4) == 9 and d[3] > 0 then
+			self:dispatch (HANDLER_NOTE_ON, (d[2] << 7) | d[3])
+			consumed = true
+		end
+		if not consumed then
+			midiout[oi] = { time = b["time"], data = d }
+			oi = oi + 1
+		end
+	end
+end
+
+-- GUI thread: safe to touch Session/routes, print, run user code, etc.
+function gui_init ()
+	register_handler (HANDLER_NOTE_ON, function (value)
+		local note = value >> 7
+		local velocity = value & 127
+		print (string.format ("note-on %d velocity %d (handled on GUI thread)", note, velocity))
+	end)
+end

--- a/share/scripts/midi_pc_and_cc.lua
+++ b/share/scripts/midi_pc_and_cc.lua
@@ -1,0 +1,422 @@
+ardour {
+  ["type"]    = "dsp",
+  name        = "MIDI PC/CC",
+  category    = "Utility",
+  author      = "Brent Baccala",
+  description = [[Handle MIDI PC and CC messages
+
+It only needs to be on one track to hear the MIDI Program Change (PC) and Continuous Controller (CC) messages.
+
+It operates on all of the tracks based on commands set in their comment blocks.
+
+Every track with "MIDI Program #" in its comments is activated when that PC is sent, and is deactivated when any other PC is sent.
+
+The program number can be comma-separated ranges, as in "MIDI Program 0-7,9".
+
+Tracks can also be labeled "MIDI Bank # Program #", in which case both bank and program numbers have to match.
+
+Each such track can have MIDI CC lines with arbitrary Lua code.
+
+In such code, variables route (the current route) and value (the CC value) are defined.
+
+The following are working MIDI CC lines.
+
+Mute or unmute the current track:
+MIDI CC 93: Session:set_control(route:mute_control(), (value == 0) and 1 or 0, PBD.GroupControlDisposition.NoGroup)
+
+Program blocks are supported.  This makes CC 93 roll transport:
+MIDI CC 93: if value<40 then
+MIDI CC 93:    Session:request_stop (false, false, ARDOUR.TransportRequestSource.TRS_UI)
+MIDI CC 93: else
+MIDI CC 93:    Session:request_locate(0, false, ARDOUR.LocateTransportDisposition.MustStop, ARDOUR.TransportRequestSource.TRS_UI)
+MIDI CC 93:    Session:request_roll (ARDOUR.TransportRequestSource.TRS_UI)
+MIDI CC 93: end
+
+There's a convenience function to roll transport at a start time in seconds:
+MIDI CC 93: roll_transport(value, 0)
+
+You can also roll transport at a marker:
+MIDI CC 93: roll_transport(value, "01")
+
+Another convenience function to activate or deactivate a plugin:
+MIDI CC 91: activate_processor_by_name(route, value, "Gigaverb")
+
+A convenience function to select a preset:
+MIDI CC 93: load_preset(route, "plugin", "preset")
+
+Remember that a "MIDI Program #" (or "MIDI Bank # Program #") line is required for MIDI CC lines to be processed.
+
+Implementation note: the realtime DSP callback only inspects incoming MIDI
+and forwards Program Change / Control Change events to the GUI thread (via
+the RT->GUI Lua dispatch primitive).  All route activation, comment-block
+parsing and user-supplied CC code runs on the GUI thread, where load(),
+pcall() and Session/route mutation are safe.  There is, by design, almost
+no expectation that a program change is processed in hard real time.  All
+other MIDI (notes, etc.) passes through untouched.
+]]
+}
+
+function dsp_ioconfig ()
+  return { { midi_in = 1, midi_out = 1, audio_in = 0, audio_out = 0}, }
+end
+
+-- Handler IDs.  Plain Lua constants: both the RT interpreter and the GUI
+-- handler interpreter run this whole script, so both see these values.
+HANDLER_PROGRAM = 1   -- value = program number
+HANDLER_CC      = 2   -- value = (cc_number << 7) | cc_value
+
+--------------------------------------------------------------------------
+-- REALTIME SIDE
+--
+-- dsp_run() runs on the realtime DSP thread.  It must not call load(),
+-- pcall() of user code, route:set_active(), Session:set_control(), or
+-- iterate Session:get_routes().  It only classifies incoming MIDI and
+-- dispatches a tiny (handler_id, value) pair to the GUI thread.  Program
+-- Change and Control Change messages are consumed; everything else is
+-- passed through to the MIDI output (selective passthrough).
+--------------------------------------------------------------------------
+
+function dsp_run (_, _, n_samples)
+   local oi = 1
+   for _, b in pairs (midiin) do
+      local d = b["data"]
+      local consumed = false
+      if #d >= 1 then
+         local event_type = d[1] >> 4
+         if event_type == 12 and #d >= 2 then
+            -- Program Change
+            self:dispatch (HANDLER_PROGRAM, d[2])
+            consumed = true
+         elseif event_type == 11 and #d >= 3 then
+            -- Continuous Controller (includes Bank Select CC 0/32)
+            self:dispatch (HANDLER_CC, (d[2] << 7) | d[3])
+            consumed = true
+         end
+      end
+      if not consumed then
+         midiout[oi] = { time = b["time"], data = d }
+         oi = oi + 1
+      end
+   end
+end
+
+--------------------------------------------------------------------------
+-- GUI SIDE
+--
+-- gui_init() runs once on the GUI thread, in a dedicated interpreter that
+-- has the full action-script binding set.  It registers two handlers; the
+-- RT side's self:dispatch() calls them (on the GUI thread) with the
+-- forwarded MIDI.  All of the heavy lifting that used to run on the RT
+-- thread lives here.
+--------------------------------------------------------------------------
+
+-- a convenience function that enables or disables a plugin by name
+function get_processor_by_name(route, name)
+   local i = 0;
+   repeat
+      local proc = route:nth_plugin (i)
+      if (not proc:isnil()) and proc:display_name() == name then
+         return proc
+      end
+      i = i + 1
+   until proc:isnil()
+   return nil
+end
+
+function activate_processor_by_name(route, value, name)
+   local proc = get_processor_by_name(route, name)
+   if not proc:isnil() then
+      if value == 0 then
+         proc:deactivate()
+      else
+         proc:activate()
+      end
+   end
+end
+
+-- load a plugin's preset by name
+function load_preset(route, plugin, preset)
+   local proc = get_processor_by_name(route, plugin)
+   if not proc:isnil() then
+      local pp = proc:to_insert():plugin(0)
+      pp:load_preset(pp:preset_by_label(preset))
+   end
+end
+
+function string.starts(String,Start)
+   return string.sub(String,1,string.len(Start))==Start
+end
+
+-- roll_transport(value, location)
+-- value is 0 to stop transport and not 0 to start transport
+-- location is either a value in seconds or a string matching a marker
+-- (prefix match, preserved from the original; Ardour 9's
+-- Session:request_locate_to_mark() matches exact names only, so the
+-- prefix-match wrapper is kept for backward compatibility with existing
+-- session marker names).
+function roll_transport(value, location)
+   if value==0 then
+      Session:request_stop (false, false, ARDOUR.TransportRequestSource.TRS_UI)
+   else
+      local start_sample
+      if not location then
+        start_sample = 0
+      elseif type(location) == "string" then
+        for loc in Session:locations():list():iter() do
+          if loc:is_mark() then
+            if string.starts(loc:name(), location) then
+              start_sample = loc:start():samples();
+            end
+          end
+        end
+      else
+        start_sample = Session:nominal_sample_rate() * location;
+      end
+      if start_sample then
+        Session:request_locate(start_sample, false, ARDOUR.LocateTransportDisposition.MustStop, ARDOUR.TransportRequestSource.TRS_UI)
+        Session:request_roll (ARDOUR.TransportRequestSource.TRS_UI)
+      end
+   end
+end
+
+-- the currently active functions on the Continuous Controllers
+-- a list of pairs, indexed by CC number, each a Route object and a Lua function
+CC_functions = { }
+
+-- current bank and program (GUI-interpreter state; persists across dispatches)
+bank_msb = 0
+bank_lsb = 0
+bank = 0
+program = 0
+
+-- return true/false if number (an integer) is in range (a string)
+-- format of range is a comma-separated list of items, each either START-STOP or VALUE
+function match_number_range(number, range)
+    local fieldstart = 1
+    local match = false
+    range = range .. ','
+    repeat
+       local r,_,start,stop = string.find(range, "^(%d+)-(%d+)", fieldstart)
+       if r and number >= tonumber(start) and number <= tonumber(stop) then
+          match = true
+       end
+       r,_,value = string.find(range, "^(%d+)", fieldstart)
+       if r and number == tonumber(value) then
+          match = true
+       end
+       local nexti = string.find(range, ",", fieldstart)
+       fieldstart = nexti + 1
+    until fieldstart > string.len(range)
+    return match
+end
+
+function program_change()
+   -- Program Change or Bank Change message
+   -- program and bank are global variables
+   -- Parse/reparse the comment blocks
+   -- Clear the global table of CC functions; it'll be recreated during the parse
+   CC_functions = { }
+   -- Run through all comment blocks on all routes looking for certain strings
+   for route in Session:get_routes():iter() do
+      local nextchar = 1
+      local MIDI_Program_seen = false
+      local route_comment = route:comment()
+      local route_active = false
+      local local_CC_functions = { }
+      local program_functions = { }  -- to store functions to execute after track activation
+      -- Look for "MIDI Bank # Program #: code" statements with function calls
+      while true do
+          local MIDI_Program_start, MIDI_Program_end, bank_list, program_list, code
+          MIDI_Program_start,MIDI_Program_end,bank_list,program_list,code = string.find(route_comment, "MIDI Bank (%d[-%d,]*) Program (%d[-%d,]*): ([^\n]+)", nextchar)
+          if bank_list then
+              local matches = match_number_range(program, program_list) and match_number_range(bank, bank_list)
+              route_active = route_active or matches
+              MIDI_Program_seen = true
+              if matches and code then
+                  table.insert(program_functions, code)
+              end
+              nextchar = MIDI_Program_end + 1
+          else
+              break
+          end
+      end
+      -- Look for "MIDI Bank # Program #" statements that match both the program number and the bank number
+      nextchar = 1
+      while true do
+          local MIDI_Program_start, MIDI_Program_end, bank_list, program_list
+          MIDI_Program_start,MIDI_Program_end,bank_list,program_list = string.find(route_comment, "MIDI Bank (%d[-%d,]*) Program (%d[-%d,]*)", nextchar)
+          if bank_list then
+              route_active = route_active or (match_number_range(program, program_list) and match_number_range(bank, bank_list))
+              MIDI_Program_seen = true
+              nextchar = MIDI_Program_end + 1
+          else
+              break
+          end
+      end
+      -- Look for "MIDI Program #: code" statements with function calls
+      nextchar = 1
+      while true do
+          local MIDI_Program_start, MIDI_Program_end, program_list, code
+          MIDI_Program_start,MIDI_Program_end,program_list,code = string.find(route_comment, "MIDI Program (%d[-%d,]*): ([^\n]+)", nextchar)
+          if program_list then
+             local matches = match_number_range(program, program_list)
+             route_active = route_active or matches
+             MIDI_Program_seen = true
+             if matches and code then
+                 table.insert(program_functions, code)
+             end
+             nextchar = MIDI_Program_end + 1
+          else
+             break
+          end
+      end
+      -- Look for "MIDI Program #" statements that match just the program number
+      nextchar = 1
+      while true do
+          local MIDI_Program_start, MIDI_Program_end, program_list
+          MIDI_Program_start,MIDI_Program_end,program_list = string.find(route_comment, "MIDI Program (%d[-%d,]*)", nextchar)
+          if program_list then
+             route_active = route_active or match_number_range(program, program_list)
+             MIDI_Program_seen = true
+             nextchar = MIDI_Program_end + 1
+          else
+             break
+          end
+      end
+      -- if at least one of either kind of line was seen, there is further handling of this track
+      if MIDI_Program_seen then
+         -- all tracks with a "MIDI Program" line present are set either active or inactive, depending on if they matched
+         -- all other tracks (no "MIDI Progam" line) are not affected (they never get to this point)
+         route:set_active(route_active, nil);
+         -- if this route is active, execute any program change functions and parse any CC functions in the route's comment block
+         if route_active then
+           -- execute program change functions after track activation
+           for _, code in ipairs(program_functions) do
+              local func, err = load("return function(route) " .. code .. " end")
+              if func then
+                  local ok, generated_func = pcall(func)
+                  if ok then
+                      local success, exec_err = pcall(generated_func, route)
+                      if not success then
+                          print("Program function execution error:", exec_err)
+                      end
+                  else
+                      print("Program function generation error:", generated_func)
+                  end
+              else
+                  print("Program function compilation error:", err)
+              end
+           end
+           local nextchar = 1
+           local local_CC_functions = { }
+           -- we wrap the code inside "return function (route, value)" and "end"
+           -- so that when we pcall it with no argument it returns a function that takes two arguments
+           -- First parse "MIDI Bank # Program # CC #: code" patterns with bank and program restrictions
+           while true do
+              MIDI_CC_start, MIDI_CC_end, bank_list, program_list, CC_num, CC_program = string.find(route_comment, "MIDI Bank (%d[-%d,]*) Program (%d[-%d,]*) CC (%d+): ([^\n]+)", nextchar)
+              if MIDI_CC_start == nil then break end
+              local key = CC_num .. "|" .. bank_list .. "|" .. program_list
+              if (local_CC_functions[key] == nil) then
+                 local_CC_functions[key] = { code = "return function(route, value)\n", bank_list = bank_list, program_list = program_list, CC_num = CC_num }
+              end
+              local_CC_functions[key].code = local_CC_functions[key].code .. CC_program .. "\n"
+              nextchar = MIDI_CC_end + 1
+           end
+           -- Then parse "MIDI Program # CC #: code" patterns with only program restrictions
+           nextchar = 1
+           while true do
+              MIDI_CC_start, MIDI_CC_end, program_list, CC_num, CC_program = string.find(route_comment, "MIDI Program (%d[-%d,]*) CC (%d+): ([^\n]+)", nextchar)
+              if MIDI_CC_start == nil then break end
+              local key = CC_num .. "||" .. program_list
+              if (local_CC_functions[key] == nil) then
+                 local_CC_functions[key] = { code = "return function(route, value)\n", bank_list = nil, program_list = program_list, CC_num = CC_num }
+              end
+              local_CC_functions[key].code = local_CC_functions[key].code .. CC_program .. "\n"
+              nextchar = MIDI_CC_end + 1
+           end
+           -- Finally parse "MIDI CC #: code" patterns without restrictions
+           nextchar = 1
+           while true do
+              MIDI_CC_start, MIDI_CC_end, CC_num, CC_program = string.find(route_comment, "MIDI CC (%d+): ([^\n]+)", nextchar)
+              if MIDI_CC_start == nil then break end
+              if (local_CC_functions[CC_num] == nil) then
+                 local_CC_functions[CC_num] = { code = "return function(route, value)\n", bank_list = nil, program_list = nil, CC_num = CC_num }
+              end
+              local_CC_functions[CC_num].code = local_CC_functions[CC_num].code .. CC_program .. "\n"
+              nextchar = MIDI_CC_end + 1
+           end
+           -- done parsing (or at least gathering all of the lines together)
+           -- now compile the CC functions and insert them in the global table
+           for key, entry in pairs(local_CC_functions) do
+              local code = entry.code .. "\nend"
+              local generator, err = load(code)
+              if generator then
+                  local ok, func = pcall(generator)
+                  if ok then
+                      local cc_num = tonumber(entry.CC_num)
+                      if not CC_functions[cc_num] then
+                          CC_functions[cc_num] = { }
+                      end
+                      -- Store route, function, and program/bank restrictions
+                      table.insert(CC_functions[cc_num], {
+                          route = route,
+                          func = func,
+                          program_list = entry.program_list,
+                          bank_list = entry.bank_list
+                      })
+                  else
+                     print("Execution error:", func)
+                  end
+              else
+                  print("Compilation error:", err)
+              end
+           end
+         end
+      end
+   end
+end
+
+-- GUI handler for a Program Change (value = program number)
+function handle_program (value)
+   program = value
+   program_change()
+end
+
+-- GUI handler for a Control Change (value = (cc_number << 7) | cc_value)
+function handle_cc (value)
+   local num = value >> 7
+   local val = value & 127
+   -- Bank Select messages
+   if num == 0 or num == 32 then
+       if num == 0 then
+           bank_msb = val
+       else
+           bank_lsb = val
+       end
+       bank = 128 * bank_msb + bank_lsb
+       program_change()
+   end
+   -- if any functions are registered for this CC, call them with their
+   -- respective Route objects and the value of the controller
+   local lst = CC_functions[num]
+   if lst then
+     for _, entry in ipairs(lst) do
+           local program_match = true
+           local bank_match = true
+           if entry.program_list then
+               program_match = match_number_range(program, entry.program_list)
+           end
+           if entry.bank_list then
+               bank_match = match_number_range(bank, entry.bank_list)
+           end
+           if program_match and bank_match then
+               entry.func(entry.route, val)
+           end
+     end
+   end
+end
+
+function gui_init ()
+   register_handler (HANDLER_PROGRAM, handle_program)
+   register_handler (HANDLER_CC,      handle_cc)
+end

--- a/share/scripts/midi_pc_and_cc.lua
+++ b/share/scripts/midi_pc_and_cc.lua
@@ -110,6 +110,7 @@ end
 --------------------------------------------------------------------------
 
 -- a convenience function that enables or disables a plugin by name
+-- (route is an Ardour Route object, not a string)
 function get_processor_by_name(route, name)
    local i = 0;
    repeat
@@ -134,6 +135,7 @@ function activate_processor_by_name(route, value, name)
 end
 
 -- load a plugin's preset by name
+-- (route is an Ardour Route object; plugin and preset are strings)
 function load_preset(route, plugin, preset)
    local proc = get_processor_by_name(route, plugin)
    if not proc:isnil() then

--- a/share/scripts/midi_pc_and_cc.lua
+++ b/share/scripts/midi_pc_and_cc.lua
@@ -46,15 +46,15 @@ MIDI CC 93: load_preset(route, "plugin", "preset")
 
 Remember that a "MIDI Program #" (or "MIDI Bank # Program #") line is required for MIDI CC lines to be processed.
 
-Implementation note: the realtime DSP callback only inspects incoming MIDI
-and forwards Program Change / Control Change events to the GUI thread (via
-the RT->GUI Lua dispatch primitive).  All route activation, comment-block
-parsing and user-supplied CC code runs on the GUI thread, where load(),
-pcall() and Session/route mutation are safe.  There is, by design, almost
-no expectation that a program change is processed in hard real time.  All
-other MIDI (notes, etc.) passes through untouched.
+There is, by design, almost no expectation that a program change is processed in hard real time.  All other MIDI (notes, etc.) passes through untouched.
 ]]
 }
+
+-- Implementation note: the realtime DSP callback (dsp_run) only inspects
+-- incoming MIDI and forwards Program Change / Control Change events to the
+-- GUI thread via the RT->GUI Lua dispatch primitive.  All route activation,
+-- comment-block parsing and user-supplied CC code runs on the GUI thread,
+-- where load(), pcall() and Session/route mutation are safe.
 
 function dsp_ioconfig ()
   return { { midi_in = 1, midi_out = 1, audio_in = 0, audio_out = 0}, }
@@ -105,9 +105,8 @@ end
 --
 -- gui_init() runs once on the GUI thread, in a dedicated interpreter that
 -- has the full action-script binding set.  It registers two handlers; the
--- RT side's self:dispatch() calls them (on the GUI thread) with the
--- forwarded MIDI.  All of the heavy lifting that used to run on the RT
--- thread lives here.
+-- RT side's self:dispatch() signals them with the forwarded MIDI.  The GUI
+-- thread receives the signals and does all the heavy lifting.
 --------------------------------------------------------------------------
 
 -- a convenience function that enables or disables a plugin by name
@@ -286,7 +285,7 @@ function program_change()
       -- if at least one of either kind of line was seen, there is further handling of this track
       if MIDI_Program_seen then
          -- all tracks with a "MIDI Program" line present are set either active or inactive, depending on if they matched
-         -- all other tracks (no "MIDI Progam" line) are not affected (they never get to this point)
+         -- all other tracks (no "MIDI Program" line) are not affected (they never get to this point)
          route:set_active(route_active, nil);
          -- if this route is active, execute any program change functions and parse any CC functions in the route's comment block
          if route_active then


### PR DESCRIPTION
Initial version of a Lua script that handles MIDI Program Change (PC) and Continuous Controller (CC) messages.

Put this plugin on a track that can hear the PC and CC messages.  It will activate and deactivate tracks when PC messages are seen, and run arbitrary Lua code when CC messages are seen.

Configuration is done using statements in each track's comment block.

See the plugin description for more documentation.
