### PR TITLE
unlimited scrolling on pianoroll caused fpe

### DIFF
--- a/gtk2_ardour/pianoroll.cc
+++ b/gtk2_ardour/pianoroll.cc
@@ -649,6 +649,11 @@ Pianoroll::snap_to_internal (timepos_t& start, Temporal::RoundMode direction, Sn
 void
 Pianoroll::set_samples_per_pixel (samplecnt_t spp)
 {
+
+	if (spp < 1) {
+		return;
+	}
+
 	CueEditor::set_samples_per_pixel (spp);
 
 	if (view) {


### PR DESCRIPTION
Found that when I accidentally scrolled too much on the piano roll window, it triggered a floating point exception. I looked at how the Editor implemented set_samples_per_pixel, and did the same, just returning when spp < 1. I'm new to ardour development so I don't know if this is correct, but it fixed it for me.