### PR TITLE
Add support to create midi regions from Lua

### DIFF
--- a/gtk2_ardour/luainstance.cc
+++ b/gtk2_ardour/luainstance.cc
@@ -54,6 +54,7 @@
 #include "region_view.h"
 #include "processor_box.h"
 #include "time_axis_view.h"
+#include "midi_time_axis.h"
 #include "time_axis_view_item.h"
 #include "selection.h"
 #include "script_selector.h"
@@ -811,11 +812,16 @@ LuaInstance::register_classes (lua_State* L, bool sandbox)
 		.endClass ()
 
 		.deriveClass <TimeAxisView, AxisView> ("TimeAxisView")
+		.addCast<MidiTimeAxisView> ("to_midi_time_axis_view")
 		.addFunction ("order", &TimeAxisView::order)
 		.addFunction ("y_position", &TimeAxisView::y_position)
 		.addFunction ("effective_height", &TimeAxisView::effective_height)
 		.addFunction ("current_height", &TimeAxisView::current_height)
 		.addFunction ("set_height", &TimeAxisView::set_height)
+		.endClass ()
+
+		.deriveClass <MidiTimeAxisView, TimeAxisView> ("MidiTimeAxisView")
+		.addFunction ("add_region", &MidiTimeAxisView::add_region)
 		.endClass ()
 
 		.deriveClass <StripableTimeAxisView, TimeAxisView> ("StripableTimeAxisView")
@@ -825,6 +831,7 @@ LuaInstance::register_classes (lua_State* L, bool sandbox)
 		.endClass ()
 
 		.deriveClass <TimeAxisViewItem, Selectable> ("TimeAxisViewItem")
+		.addFunction ("get_time_axis_view", &TimeAxisViewItem::get_time_axis_view)
 		.endClass ()
 
 		.deriveClass <RegionView, TimeAxisViewItem> ("RegionView")

--- a/share/scripts/blank_midi_region_clone.lua
+++ b/share/scripts/blank_midi_region_clone.lua
@@ -1,0 +1,33 @@
+ardour {
+  ["type"]    = "EditorAction",
+  name        = "Create blank midi region clone",
+  version     = "0.1.0",
+  license     = "MIT",
+  author      = "Daniel Appelt",
+  description = [[Create a blank clone of a midi region]]
+}
+
+function factory () return function ()
+  -- Get first selected region
+  local regionList = Editor:get_selection().regions:regionlist()
+  local region = regionList:front()
+
+  -- Bail out if no region was selected
+  if region:isnil() then
+    LuaDialog.Message("Create blank midi region clone", "Please select a region first!",
+      LuaDialog.MessageType.Info, LuaDialog.ButtonType.Close):run()
+    return
+  end
+
+  -- Get midi time axis view for region
+  local rv = Editor:regionview_from_region(region)
+  local tav = rv:get_time_axis_view()
+  local mtav = tav:to_midi_time_axis_view()
+
+  if mtav then
+    local pos = region:position()
+    local len = region:length()
+
+    mtav:add_region(pos, len, true)
+  end
+end end


### PR DESCRIPTION
This extension to the Lua API allows to create empty MIDI regions from a script. This may be useful to easily create layers of MIDI regions.