### PR TITLE
Add patch file for Roland INTEGRA-7

### DIFF
--- a/share/patchfiles/Roland_INTEGRA-7.midnam
+++ b/share/patchfiles/Roland_INTEGRA-7.midnam
@@ -1,0 +1,8030 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE MIDINameDocument PUBLIC "-//MIDI Manufacturers Association//DTD MIDINameDocument 1.0//EN" "http://www.midi.org/dtds/MIDINameDocument10.dtd">
+<MIDINameDocument>
+  <Author>Brett Weir (adapted from the Sonar Instrument Definition files provided by Roland)</Author>
+  <MasterDeviceNames>
+    <Manufacturer>Roland</Manufacturer>
+    <Model>INTEGRA-7</Model>
+    <CustomDeviceMode Name="Default">
+      <ChannelNameSetAssignments>
+        <ChannelNameSetAssign Channel="1" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="2" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="3" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="4" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="5" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="6" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="7" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="8" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="9" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="10" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="11" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="12" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="13" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="14" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="15" NameSet="Presets" />
+        <ChannelNameSetAssign Channel="16" NameSet="Presets" />
+      </ChannelNameSetAssignments>
+    </CustomDeviceMode>
+    <ChannelNameSet Name="Presets">
+      <AvailableForChannels>
+        <AvailableChannel Channel="1" Available="true" />
+        <AvailableChannel Channel="2" Available="true" />
+        <AvailableChannel Channel="3" Available="true" />
+        <AvailableChannel Channel="4" Available="true" />
+        <AvailableChannel Channel="5" Available="true" />
+        <AvailableChannel Channel="6" Available="true" />
+        <AvailableChannel Channel="7" Available="true" />
+        <AvailableChannel Channel="8" Available="true" />
+        <AvailableChannel Channel="9" Available="true" />
+        <AvailableChannel Channel="10" Available="true" />
+        <AvailableChannel Channel="11" Available="true" />
+        <AvailableChannel Channel="12" Available="true" />
+        <AvailableChannel Channel="13" Available="true" />
+        <AvailableChannel Channel="14" Available="true" />
+        <AvailableChannel Channel="15" Available="true" />
+        <AvailableChannel Channel="16" Available="true" />
+      </AvailableForChannels>
+      <PatchBank Name="User PCM Synth Tone 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User PCM Synth Tone 1-128" />
+      </PatchBank>
+      <PatchBank Name="User PCM Synth Tone 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="1" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User PCM Synth Tone 129-256" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="64" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 1-128" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="65" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 129-256" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="66" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 257-384" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 385-512">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="67" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 385-512" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 513-640">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="68" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 513-640" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 641-768">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="69" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 641-768" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Synth Tone 769-896">
+        <MIDICommands>
+          <ControlChange Control="0" Value="87" />
+          <ControlChange Control="32" Value="70" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Synth Tone 769-896" />
+      </PatchBank>
+      <PatchBank Name="User SN Acoustic Tone 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Acoustic Tone 1-128" />
+      </PatchBank>
+      <PatchBank Name="User SN Acoustic Tone 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="1" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Acoustic Tone 129-256" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Acoustic Tone 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="64" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Acoustic Tone 1-128" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Acoustic Tone 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="65" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Acoustic Tone 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion SN Tone (ExSN1)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="96" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion SN Tone (ExSN1)" />
+      </PatchBank>
+      <PatchBank Name="Expansion SN Tone (ExSN2)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="97" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion SN Tone (ExSN2)" />
+      </PatchBank>
+      <PatchBank Name="Expansion SN Tone (ExSN3)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="98" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion SN Tone (ExSN3)" />
+      </PatchBank>
+      <PatchBank Name="Expansion SN Tone (ExSN4)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="99" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion SN Tone (ExSN4)" />
+      </PatchBank>
+      <PatchBank Name="Expansion SN Tone (ExSN5)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="89" />
+          <ControlChange Control="32" Value="100" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion SN Tone (ExSN5)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX01)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX01)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX02)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="1" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX02)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX03)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="2" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX03)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX04)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="3" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX04)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX05) 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="4" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX05) 1-128" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX05) 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="5" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX05) 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX05) 257-312">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="6" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX05) 257-312" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX06) 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="7" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX06) 1-128" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX06) 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="8" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX06) 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX06) 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="9" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX06) 257-384" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX06) 384-449">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="10" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX06) 384-449" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX07) 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="11" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX07) 1-128" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX07) 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="12" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX07) 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX07) 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="13" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX07) 257-384" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX07) 385-475">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="14" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX07) 385-475" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX08) 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="15" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX08) 1-128" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX08) 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="16" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX08) 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX08) 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="17" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX08) 257-384" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX08) 385-448">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="18" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX08) 385-448" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX09) 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="19" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX09) 1-128" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX09) 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="20" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX09) 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX09) 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="21" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX09) 257-384" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX09) 385-414">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="22" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX09) 385-414" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX10)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="23" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX10)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX11)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="24" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX11)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (SRX12)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="93" />
+          <ControlChange Control="32" Value="26" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (SRX12)" />
+      </PatchBank>
+      <PatchBank Name="User SN Synth Tone 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Synth Tone 1-128" />
+      </PatchBank>
+      <PatchBank Name="User SN Synth Tone 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="1" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Synth Tone 129-256" />
+      </PatchBank>
+      <PatchBank Name="User SN Synth Tone 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="2" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Synth Tone 257-384" />
+      </PatchBank>
+      <PatchBank Name="User SN Synth Tone 385-512">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="3" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Synth Tone 385-512" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="64" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 1-128" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="65" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 129-256" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="66" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 257-384" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 385-512">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="67" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 385-512" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 513-640">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="68" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 513-640" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 641-768">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="69" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 641-768" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 769-896">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="70" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 769-896" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 897-1024">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="71" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 897-1024" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Synth Tone 1025-1109">
+        <MIDICommands>
+          <ControlChange Control="0" Value="95" />
+          <ControlChange Control="32" Value="72" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Synth Tone 1025-1109" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (ExPCM) 1-128">
+        <MIDICommands>
+          <ControlChange Control="0" Value="97" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (ExPCM) 1-128" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (ExPCM) 129-256">
+        <MIDICommands>
+          <ControlChange Control="0" Value="97" />
+          <ControlChange Control="32" Value="1" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (ExPCM) 129-256" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (ExPCM) 257-384">
+        <MIDICommands>
+          <ControlChange Control="0" Value="97" />
+          <ControlChange Control="32" Value="2" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (ExPCM) 257-384" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Tone (ExPCM) 385-512">
+        <MIDICommands>
+          <ControlChange Control="0" Value="97" />
+          <ControlChange Control="32" Value="3" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Tone (ExPCM) 385-512" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Capital">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Capital" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #1">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="1" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #1" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #2">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="2" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #2" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #3">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="3" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #3" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #4">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="4" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #4" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #5">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="5" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #5" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #6">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="6" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #6" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #7">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="7" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #7" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #8">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="8" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #8" />
+      </PatchBank>
+      <PatchBank Name="GM2 Tone Var #9">
+        <MIDICommands>
+          <ControlChange Control="0" Value="121" />
+          <ControlChange Control="32" Value="9" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Tone Var #9" />
+      </PatchBank>
+      <PatchBank Name="Studio Set">
+        <MIDICommands>
+          <ControlChange Control="0" Value="85" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Studio Set" />
+      </PatchBank>
+      <PatchBank Name="User PCM Drum Kit">
+        <MIDICommands>
+          <ControlChange Control="0" Value="86" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User PCM Drum Kit" />
+      </PatchBank>
+      <PatchBank Name="Preset PCM Drum Kit">
+        <MIDICommands>
+          <ControlChange Control="0" Value="86" />
+          <ControlChange Control="32" Value="64" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset PCM Drum Kit" />
+      </PatchBank>
+      <PatchBank Name="User SN Drum Kit">
+        <MIDICommands>
+          <ControlChange Control="0" Value="88" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="User SN Drum Kit" />
+      </PatchBank>
+      <PatchBank Name="Preset SN Drum Kit">
+        <MIDICommands>
+          <ControlChange Control="0" Value="88" />
+          <ControlChange Control="32" Value="64" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Preset SN Drum Kit" />
+      </PatchBank>
+      <PatchBank Name="Expansion SN Drum (ExSN6)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="88" />
+          <ControlChange Control="32" Value="101" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion SN Drum (ExSN6)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX01)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX01)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX03)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="2" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX03)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX05)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="4" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX05)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX06)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="7" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX06)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX07)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="11" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX07)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX08)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="15" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX08)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (SRX09)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="92" />
+          <ControlChange Control="32" Value="19" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (SRX09)" />
+      </PatchBank>
+      <PatchBank Name="Expansion PCM Drum (ExPCM)">
+        <MIDICommands>
+          <ControlChange Control="0" Value="96" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="Expansion PCM Drum (ExPCM)" />
+      </PatchBank>
+      <PatchBank Name="GM2 Drum Kit">
+        <MIDICommands>
+          <ControlChange Control="0" Value="120" />
+          <ControlChange Control="32" Value="0" />
+        </MIDICommands>
+        <UsesPatchNameList Name="GM2 Drum Kit" />
+      </PatchBank>
+    </ChannelNameSet>
+    <PatchNameList Name="User PCM Synth Tone 1-128">
+      <Patch Number="001" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="002" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="003" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="004" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="005" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="006" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="007" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="008" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="009" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="010" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="011" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="012" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="013" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="014" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="015" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="016" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="017" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="018" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="019" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="020" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="021" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="022" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="023" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="024" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="025" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="026" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="027" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="028" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="029" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="030" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="031" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="032" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="033" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="034" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="035" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="036" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="037" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="038" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="039" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="040" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="041" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="042" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="043" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="044" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="045" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="046" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="047" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="048" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="049" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="050" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="051" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="052" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="053" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="054" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="055" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="056" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="057" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="058" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="059" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="060" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="061" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="062" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="063" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="064" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="065" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="066" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="067" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="068" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="069" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="070" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="071" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="072" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="073" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="074" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="075" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="076" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="077" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="078" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="079" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="080" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="081" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="082" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="083" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="084" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="085" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="086" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="087" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="088" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="089" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="090" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="091" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="092" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="093" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="094" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="095" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="096" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="097" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="098" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="099" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="100" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="101" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="102" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="103" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="104" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="105" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="106" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="107" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="108" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="109" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="110" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="111" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="112" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="113" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="114" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="115" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="116" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="117" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="118" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="119" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="120" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="121" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="122" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="123" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="124" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="125" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="126" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="127" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="128" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="User PCM Synth Tone 129-256">
+      <Patch Number="129" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="130" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="131" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="132" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="133" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="134" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="135" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="136" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="137" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="138" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="139" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="140" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="141" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="142" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="143" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="144" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="145" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="146" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="147" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="148" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="149" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="150" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="151" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="152" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="153" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="154" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="155" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="156" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="157" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="158" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="159" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="160" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="161" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="162" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="163" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="164" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="165" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="166" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="167" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="168" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="169" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="170" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="171" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="172" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="173" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="174" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="175" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="176" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="177" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="178" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="179" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="180" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="181" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="182" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="183" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="184" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="185" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="186" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="187" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="188" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="189" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="190" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="191" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="192" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="193" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="194" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="195" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="196" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="197" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="198" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="199" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="200" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="201" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="202" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="203" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="204" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="205" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="206" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="207" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="208" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="209" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="210" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="211" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="212" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="213" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="214" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="215" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="216" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="217" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="218" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="219" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="220" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="221" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="222" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="223" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="224" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="225" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="226" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="227" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="228" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="229" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="230" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="231" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="232" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="233" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="234" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="235" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="236" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="237" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="238" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="239" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="240" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="241" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="242" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="243" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="244" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="245" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="246" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="247" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="248" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="249" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="250" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="251" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="252" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="253" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="254" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="255" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="256" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 1-128">
+      <Patch Number="001" Name="128voicePno" ProgramChange="0" />
+      <Patch Number="002" Name="Bright Piano" ProgramChange="1" />
+      <Patch Number="003" Name="Classique" ProgramChange="2" />
+      <Patch Number="004" Name="Nice Piano" ProgramChange="3" />
+      <Patch Number="005" Name="Piano Thang" ProgramChange="4" />
+      <Patch Number="006" Name="Power Grand" ProgramChange="5" />
+      <Patch Number="007" Name="House Piano" ProgramChange="6" />
+      <Patch Number="008" Name="E.Grand" ProgramChange="7" />
+      <Patch Number="009" Name="MIDIed Grand" ProgramChange="8" />
+      <Patch Number="010" Name="Piano Blend" ProgramChange="9" />
+      <Patch Number="011" Name="West Coast" ProgramChange="10" />
+      <Patch Number="012" Name="PianoStrings" ProgramChange="11" />
+      <Patch Number="013" Name="Bs/Pno+Brs" ProgramChange="12" />
+      <Patch Number="014" Name="Water EP" ProgramChange="13" />
+      <Patch Number="015" Name="S.A.E.P." ProgramChange="14" />
+      <Patch Number="016" Name="SA EP 1" ProgramChange="15" />
+      <Patch Number="017" Name="SA EP 2" ProgramChange="16" />
+      <Patch Number="018" Name="Stiky EP" ProgramChange="17" />
+      <Patch Number="019" Name="Dig EP" ProgramChange="18" />
+      <Patch Number="020" Name="Nylon EPiano" ProgramChange="19" />
+      <Patch Number="021" Name="Nylon EP" ProgramChange="20" />
+      <Patch Number="022" Name="EP Mix" ProgramChange="21" />
+      <Patch Number="023" Name="Psycho EP" ProgramChange="22" />
+      <Patch Number="024" Name="Tremo EP" ProgramChange="23" />
+      <Patch Number="025" Name="MK-80 EP" ProgramChange="24" />
+      <Patch Number="026" Name="MK-80 Phaser" ProgramChange="25" />
+      <Patch Number="027" Name="Delicate EP" ProgramChange="26" />
+      <Patch Number="028" Name="Octa EP 1" ProgramChange="27" />
+      <Patch Number="029" Name="Octa EP 2" ProgramChange="28" />
+      <Patch Number="030" Name="JV EP+" ProgramChange="29" />
+      <Patch Number="031" Name="EP+Mod Pad" ProgramChange="30" />
+      <Patch Number="032" Name="Mr.Mellow" ProgramChange="31" />
+      <Patch Number="033" Name="Comp Clav" ProgramChange="32" />
+      <Patch Number="034" Name="Klavinet" ProgramChange="33" />
+      <Patch Number="035" Name="Winger Clav" ProgramChange="34" />
+      <Patch Number="036" Name="Phaze Clav 1" ProgramChange="35" />
+      <Patch Number="037" Name="Phaze Clav 2" ProgramChange="36" />
+      <Patch Number="038" Name="Phuzz Clav" ProgramChange="37" />
+      <Patch Number="039" Name="Chorus Clav" ProgramChange="38" />
+      <Patch Number="040" Name="Claviduck" ProgramChange="39" />
+      <Patch Number="041" Name="Velo-Rez Clv" ProgramChange="40" />
+      <Patch Number="042" Name="Clavicembalo" ProgramChange="41" />
+      <Patch Number="043" Name="Analog Clav1" ProgramChange="42" />
+      <Patch Number="044" Name="Analog Clav2" ProgramChange="43" />
+      <Patch Number="045" Name="Metal Clav" ProgramChange="44" />
+      <Patch Number="046" Name="Full Stops" ProgramChange="45" />
+      <Patch Number="047" Name="Ballad B" ProgramChange="46" />
+      <Patch Number="048" Name="Mellow Bars" ProgramChange="47" />
+      <Patch Number="049" Name="AugerMentive" ProgramChange="48" />
+      <Patch Number="050" Name="Perky B" ProgramChange="49" />
+      <Patch Number="051" Name="The Big Spin" ProgramChange="50" />
+      <Patch Number="052" Name="Gospel Spin" ProgramChange="51" />
+      <Patch Number="053" Name="Roller Spin" ProgramChange="52" />
+      <Patch Number="054" Name="Rocker Spin" ProgramChange="53" />
+      <Patch Number="055" Name="Tone Wh.Solo" ProgramChange="54" />
+      <Patch Number="056" Name="Purple Spin" ProgramChange="55" />
+      <Patch Number="057" Name="60's LeadORG" ProgramChange="56" />
+      <Patch Number="058" Name="Assalt Organ" ProgramChange="57" />
+      <Patch Number="059" Name="D-50 Organ" ProgramChange="58" />
+      <Patch Number="060" Name="Cathedral" ProgramChange="59" />
+      <Patch Number="061" Name="Church Pipes" ProgramChange="60" />
+      <Patch Number="062" Name="Poly Key" ProgramChange="61" />
+      <Patch Number="063" Name="Poly Saws" ProgramChange="62" />
+      <Patch Number="064" Name="Poly Pulse" ProgramChange="63" />
+      <Patch Number="065" Name="Dual Profs" ProgramChange="64" />
+      <Patch Number="066" Name="Saw Mass" ProgramChange="65" />
+      <Patch Number="067" Name="Poly Split" ProgramChange="66" />
+      <Patch Number="068" Name="Poly Brass" ProgramChange="67" />
+      <Patch Number="069" Name="Stackoid" ProgramChange="68" />
+      <Patch Number="070" Name="Poly Rock" ProgramChange="69" />
+      <Patch Number="071" Name="D-50 Stack" ProgramChange="70" />
+      <Patch Number="072" Name="Fantasia JV" ProgramChange="71" />
+      <Patch Number="073" Name="Jimmee Dee" ProgramChange="72" />
+      <Patch Number="074" Name="Heavenals" ProgramChange="73" />
+      <Patch Number="075" Name="Mallet Pad" ProgramChange="74" />
+      <Patch Number="076" Name="Huff N Stuff" ProgramChange="75" />
+      <Patch Number="077" Name="Puff 1080" ProgramChange="76" />
+      <Patch Number="078" Name="BellVox 1080" ProgramChange="77" />
+      <Patch Number="079" Name="Fantasy Vox" ProgramChange="78" />
+      <Patch Number="080" Name="Square Keys" ProgramChange="79" />
+      <Patch Number="081" Name="Childlike" ProgramChange="80" />
+      <Patch Number="082" Name="Music Box" ProgramChange="81" />
+      <Patch Number="083" Name="Toy Box" ProgramChange="82" />
+      <Patch Number="084" Name="Wave Bells" ProgramChange="83" />
+      <Patch Number="085" Name="Tria Bells" ProgramChange="84" />
+      <Patch Number="086" Name="Beauty Bells" ProgramChange="85" />
+      <Patch Number="087" Name="Music Bells" ProgramChange="86" />
+      <Patch Number="088" Name="Pretty Bells" ProgramChange="87" />
+      <Patch Number="089" Name="Pulse Key" ProgramChange="88" />
+      <Patch Number="090" Name="Wide Tubular" ProgramChange="89" />
+      <Patch Number="091" Name="AmbienceVibe" ProgramChange="90" />
+      <Patch Number="092" Name="Warm Vibes" ProgramChange="91" />
+      <Patch Number="093" Name="Dyna Marimba" ProgramChange="92" />
+      <Patch Number="094" Name="Bass Marimba" ProgramChange="93" />
+      <Patch Number="095" Name="Nomad Perc" ProgramChange="94" />
+      <Patch Number="096" Name="Ethno Metals" ProgramChange="95" />
+      <Patch Number="097" Name="Islands Mlt" ProgramChange="96" />
+      <Patch Number="098" Name="Steelin Keys" ProgramChange="97" />
+      <Patch Number="099" Name="Steel Drums" ProgramChange="98" />
+      <Patch Number="100" Name="Voicey Pizz" ProgramChange="99" />
+      <Patch Number="101" Name="Sitar" ProgramChange="100" />
+      <Patch Number="102" Name="Drone Split" ProgramChange="101" />
+      <Patch Number="103" Name="Ethnopluck" ProgramChange="102" />
+      <Patch Number="104" Name="Jamisen" ProgramChange="103" />
+      <Patch Number="105" Name="Dulcimer" ProgramChange="104" />
+      <Patch Number="106" Name="East Melody" ProgramChange="105" />
+      <Patch Number="107" Name="MandolinTrem" ProgramChange="106" />
+      <Patch Number="108" Name="Nylon Gtr" ProgramChange="107" />
+      <Patch Number="109" Name="Gtr Strings" ProgramChange="108" />
+      <Patch Number="110" Name="Steel Away" ProgramChange="109" />
+      <Patch Number="111" Name="Heavenly Gtr" ProgramChange="110" />
+      <Patch Number="112" Name="12str Gtr 1" ProgramChange="111" />
+      <Patch Number="113" Name="12str Gtr 2" ProgramChange="112" />
+      <Patch Number="114" Name="Jz Gtr Hall" ProgramChange="113" />
+      <Patch Number="115" Name="LetterFrmPat" ProgramChange="114" />
+      <Patch Number="116" Name="Jazz Scat" ProgramChange="115" />
+      <Patch Number="117" Name="Lounge Gig" ProgramChange="116" />
+      <Patch Number="118" Name="JC Strat" ProgramChange="117" />
+      <Patch Number="119" Name="Twin Strats" ProgramChange="118" />
+      <Patch Number="120" Name="JV Strat" ProgramChange="119" />
+      <Patch Number="121" Name="Syn Strat" ProgramChange="120" />
+      <Patch Number="122" Name="Rotary Gtr" ProgramChange="121" />
+      <Patch Number="123" Name="Muted Gtr" ProgramChange="122" />
+      <Patch Number="124" Name="SwitchOnMute" ProgramChange="123" />
+      <Patch Number="125" Name="Power Trip" ProgramChange="124" />
+      <Patch Number="126" Name="Crunch Split" ProgramChange="125" />
+      <Patch Number="127" Name="Rezodrive" ProgramChange="126" />
+      <Patch Number="128" Name="RockYurSocks" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 129-256">
+      <Patch Number="129" Name="Dist Gtr 1" ProgramChange="0" />
+      <Patch Number="130" Name="Dist Gtr 2" ProgramChange="1" />
+      <Patch Number="131" Name="R&amp;R Chunk" ProgramChange="2" />
+      <Patch Number="132" Name="Phripphuzz" ProgramChange="3" />
+      <Patch Number="133" Name="Grungeroni" ProgramChange="4" />
+      <Patch Number="134" Name="Black Widow" ProgramChange="5" />
+      <Patch Number="135" Name="Velo-Wah Gtr" ProgramChange="6" />
+      <Patch Number="136" Name="Mod-Wah Gtr" ProgramChange="7" />
+      <Patch Number="137" Name="Pick Bass" ProgramChange="8" />
+      <Patch Number="138" Name="Hip Bass" ProgramChange="9" />
+      <Patch Number="139" Name="Perc.Bass" ProgramChange="10" />
+      <Patch Number="140" Name="Homey Bass" ProgramChange="11" />
+      <Patch Number="141" Name="Finger Bass" ProgramChange="12" />
+      <Patch Number="142" Name="Nylon Bass" ProgramChange="13" />
+      <Patch Number="143" Name="Ac.Upright" ProgramChange="14" />
+      <Patch Number="144" Name="Wet Fretls" ProgramChange="15" />
+      <Patch Number="145" Name="Fretls Dry" ProgramChange="16" />
+      <Patch Number="146" Name="Slap Bass 1" ProgramChange="17" />
+      <Patch Number="147" Name="Slap Bass 2" ProgramChange="18" />
+      <Patch Number="148" Name="Slap Bass 3" ProgramChange="19" />
+      <Patch Number="149" Name="Slap Bass 4" ProgramChange="20" />
+      <Patch Number="150" Name="4 Pole Bass" ProgramChange="21" />
+      <Patch Number="151" Name="Tick Bass" ProgramChange="22" />
+      <Patch Number="152" Name="House Bass" ProgramChange="23" />
+      <Patch Number="153" Name="Mondo Bass" ProgramChange="24" />
+      <Patch Number="154" Name="Clk AnalogBs" ProgramChange="25" />
+      <Patch Number="155" Name="Bass In Face" ProgramChange="26" />
+      <Patch Number="156" Name="101  Bass" ProgramChange="27" />
+      <Patch Number="157" Name="Noiz Bass" ProgramChange="28" />
+      <Patch Number="158" Name="Super Jup Bs" ProgramChange="29" />
+      <Patch Number="159" Name="Occitan Bass" ProgramChange="30" />
+      <Patch Number="160" Name="Hugo Bass" ProgramChange="31" />
+      <Patch Number="161" Name="Multi Bass" ProgramChange="32" />
+      <Patch Number="162" Name="Moist Bass" ProgramChange="33" />
+      <Patch Number="163" Name="BritelowBass" ProgramChange="34" />
+      <Patch Number="164" Name="Untamed Bass" ProgramChange="35" />
+      <Patch Number="165" Name="Rubber Bass" ProgramChange="36" />
+      <Patch Number="166" Name="Stereoww Bs" ProgramChange="37" />
+      <Patch Number="167" Name="Wonder Bass" ProgramChange="38" />
+      <Patch Number="168" Name="Deep Bass" ProgramChange="39" />
+      <Patch Number="169" Name="Super JX Bs" ProgramChange="40" />
+      <Patch Number="170" Name="W&lt;RED&gt;-Bass" ProgramChange="41" />
+      <Patch Number="171" Name="HI-Ring Bass" ProgramChange="42" />
+      <Patch Number="172" Name="Euro Bass" ProgramChange="43" />
+      <Patch Number="173" Name="SinusoidRave" ProgramChange="44" />
+      <Patch Number="174" Name="Alternative" ProgramChange="45" />
+      <Patch Number="175" Name="Acid Line" ProgramChange="46" />
+      <Patch Number="176" Name="Auto TB-303" ProgramChange="47" />
+      <Patch Number="177" Name="Hihat Tekno" ProgramChange="48" />
+      <Patch Number="178" Name="Velo Tekno 1" ProgramChange="49" />
+      <Patch Number="179" Name="Raggatronic" ProgramChange="50" />
+      <Patch Number="180" Name="Blade Racer" ProgramChange="51" />
+      <Patch Number="181" Name="S&amp;H Pad" ProgramChange="52" />
+      <Patch Number="182" Name="Syncrosonix" ProgramChange="53" />
+      <Patch Number="183" Name="Fooled Again" ProgramChange="54" />
+      <Patch Number="184" Name="Alive" ProgramChange="55" />
+      <Patch Number="185" Name="Velo Tekno 2" ProgramChange="56" />
+      <Patch Number="186" Name="Rezoid" ProgramChange="57" />
+      <Patch Number="187" Name="Raverborg" ProgramChange="58" />
+      <Patch Number="188" Name="Blow Hit" ProgramChange="59" />
+      <Patch Number="189" Name="Hammer Bell" ProgramChange="60" />
+      <Patch Number="190" Name="Seq Mallet" ProgramChange="61" />
+      <Patch Number="191" Name="Intentions" ProgramChange="62" />
+      <Patch Number="192" Name="Pick It" ProgramChange="63" />
+      <Patch Number="193" Name="Analog Seq" ProgramChange="64" />
+      <Patch Number="194" Name="Impact Vox" ProgramChange="65" />
+      <Patch Number="195" Name="TeknoSoloVox" ProgramChange="66" />
+      <Patch Number="196" Name="X-Mod Man" ProgramChange="67" />
+      <Patch Number="197" Name="Paz &lt;==&gt; Zap" ProgramChange="68" />
+      <Patch Number="198" Name="4 Hits 4 You" ProgramChange="69" />
+      <Patch Number="199" Name="Impact" ProgramChange="70" />
+      <Patch Number="200" Name="Phase Hit" ProgramChange="71" />
+      <Patch Number="201" Name="Tekno Hit 1" ProgramChange="72" />
+      <Patch Number="202" Name="Tekno Hit 2" ProgramChange="73" />
+      <Patch Number="203" Name="Tekno Hit 3" ProgramChange="74" />
+      <Patch Number="204" Name="Reverse Hit" ProgramChange="75" />
+      <Patch Number="205" Name="SquareLead 1" ProgramChange="76" />
+      <Patch Number="206" Name="SquareLead 2" ProgramChange="77" />
+      <Patch Number="207" Name="You and Luck" ProgramChange="78" />
+      <Patch Number="208" Name="Belly Lead" ProgramChange="79" />
+      <Patch Number="209" Name="WhistlinAtom" ProgramChange="80" />
+      <Patch Number="210" Name="Edye Boost" ProgramChange="81" />
+      <Patch Number="211" Name="MG Solo" ProgramChange="82" />
+      <Patch Number="212" Name="FXM Saw Lead" ProgramChange="83" />
+      <Patch Number="213" Name="Sawteeth" ProgramChange="84" />
+      <Patch Number="214" Name="Smoothe" ProgramChange="85" />
+      <Patch Number="215" Name="MG Lead" ProgramChange="86" />
+      <Patch Number="216" Name="MG Interval" ProgramChange="87" />
+      <Patch Number="217" Name="Pulse Lead 1" ProgramChange="88" />
+      <Patch Number="218" Name="Pulse Lead 2" ProgramChange="89" />
+      <Patch Number="219" Name="Little Devil" ProgramChange="90" />
+      <Patch Number="220" Name="Loud SynLead" ProgramChange="91" />
+      <Patch Number="221" Name="Analog Lead" ProgramChange="92" />
+      <Patch Number="222" Name="5th Lead" ProgramChange="93" />
+      <Patch Number="223" Name="Flute" ProgramChange="94" />
+      <Patch Number="224" Name="Piccolo" ProgramChange="95" />
+      <Patch Number="225" Name="VOX Flute" ProgramChange="96" />
+      <Patch Number="226" Name="Air Lead" ProgramChange="97" />
+      <Patch Number="227" Name="Pan Pipes" ProgramChange="98" />
+      <Patch Number="228" Name="Airplaaane" ProgramChange="99" />
+      <Patch Number="229" Name="Taj Mahal" ProgramChange="100" />
+      <Patch Number="230" Name="Raya Shaku" ProgramChange="101" />
+      <Patch Number="231" Name="Oboe mf" ProgramChange="102" />
+      <Patch Number="232" Name="Oboe Express" ProgramChange="103" />
+      <Patch Number="233" Name="Clarinet mp" ProgramChange="104" />
+      <Patch Number="234" Name="ClariExpress" ProgramChange="105" />
+      <Patch Number="235" Name="Mitzva Split" ProgramChange="106" />
+      <Patch Number="236" Name="ChamberWinds" ProgramChange="107" />
+      <Patch Number="237" Name="ChamberWoods" ProgramChange="108" />
+      <Patch Number="238" Name="Film Orch" ProgramChange="109" />
+      <Patch Number="239" Name="Sop.Sax mf" ProgramChange="110" />
+      <Patch Number="240" Name="Alto Sax" ProgramChange="111" />
+      <Patch Number="241" Name="AltoLead Sax" ProgramChange="112" />
+      <Patch Number="242" Name="Tenor Sax" ProgramChange="113" />
+      <Patch Number="243" Name="Baritone Sax" ProgramChange="114" />
+      <Patch Number="244" Name="Take A Tenor" ProgramChange="115" />
+      <Patch Number="245" Name="Sax Section" ProgramChange="116" />
+      <Patch Number="246" Name="Bigband Sax" ProgramChange="117" />
+      <Patch Number="247" Name="Harmonica" ProgramChange="118" />
+      <Patch Number="248" Name="Harmo Blues" ProgramChange="119" />
+      <Patch Number="249" Name="BluesHarp" ProgramChange="120" />
+      <Patch Number="250" Name="Hillbillys" ProgramChange="121" />
+      <Patch Number="251" Name="French Bags" ProgramChange="122" />
+      <Patch Number="252" Name="Majestic Tpt" ProgramChange="123" />
+      <Patch Number="253" Name="Voluntare" ProgramChange="124" />
+      <Patch Number="254" Name="2Trumpets" ProgramChange="125" />
+      <Patch Number="255" Name="Tpt Sect" ProgramChange="126" />
+      <Patch Number="256" Name="Mute TP mod" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 257-384">
+      <Patch Number="257" Name="Harmon Mute" ProgramChange="0" />
+      <Patch Number="258" Name="Tp&amp;Sax Sect" ProgramChange="1" />
+      <Patch Number="259" Name="Sax+Tp+Tb" ProgramChange="2" />
+      <Patch Number="260" Name="Brass Sect" ProgramChange="3" />
+      <Patch Number="261" Name="Trombone" ProgramChange="4" />
+      <Patch Number="262" Name="Hybrid Bones" ProgramChange="5" />
+      <Patch Number="263" Name="Noble Horns" ProgramChange="6" />
+      <Patch Number="264" Name="Massed Horns" ProgramChange="7" />
+      <Patch Number="265" Name="Horn Swell" ProgramChange="8" />
+      <Patch Number="266" Name="Brass It!" ProgramChange="9" />
+      <Patch Number="267" Name="Brass Attack" ProgramChange="10" />
+      <Patch Number="268" Name="Archimede" ProgramChange="11" />
+      <Patch Number="269" Name="Rugby Horn" ProgramChange="12" />
+      <Patch Number="270" Name="MKS-80 Brass" ProgramChange="13" />
+      <Patch Number="271" Name="True ANALOG" ProgramChange="14" />
+      <Patch Number="272" Name="Dark Vox" ProgramChange="15" />
+      <Patch Number="273" Name="RandomVowels" ProgramChange="16" />
+      <Patch Number="274" Name="Angels Sing" ProgramChange="17" />
+      <Patch Number="275" Name="Pvox Oooze" ProgramChange="18" />
+      <Patch Number="276" Name="Longing..." ProgramChange="19" />
+      <Patch Number="277" Name="Arasian Morn" ProgramChange="20" />
+      <Patch Number="278" Name="Beauty Vox" ProgramChange="21" />
+      <Patch Number="279" Name="Mary-AnneVox" ProgramChange="22" />
+      <Patch Number="280" Name="Belltree Vox" ProgramChange="23" />
+      <Patch Number="281" Name="Vox Panner" ProgramChange="24" />
+      <Patch Number="282" Name="Spaced Voxx" ProgramChange="25" />
+      <Patch Number="283" Name="Glass Voices" ProgramChange="26" />
+      <Patch Number="284" Name="Tubular Vox" ProgramChange="27" />
+      <Patch Number="285" Name="Velo Voxx" ProgramChange="28" />
+      <Patch Number="286" Name="Wavox" ProgramChange="29" />
+      <Patch Number="287" Name="Doos" ProgramChange="30" />
+      <Patch Number="288" Name="Synvox Comps" ProgramChange="31" />
+      <Patch Number="289" Name="Vocal Oohz" ProgramChange="32" />
+      <Patch Number="290" Name="LFO Vox" ProgramChange="33" />
+      <Patch Number="291" Name="St.Strings" ProgramChange="34" />
+      <Patch Number="292" Name="Warm Strings" ProgramChange="35" />
+      <Patch Number="293" Name="Somber Str" ProgramChange="36" />
+      <Patch Number="294" Name="Marcato" ProgramChange="37" />
+      <Patch Number="295" Name="Bright Str" ProgramChange="38" />
+      <Patch Number="296" Name="String Ens" ProgramChange="39" />
+      <Patch Number="297" Name="TremoloStrng" ProgramChange="40" />
+      <Patch Number="298" Name="Chambers" ProgramChange="41" />
+      <Patch Number="299" Name="ViolinCello" ProgramChange="42" />
+      <Patch Number="300" Name="Symphonique" ProgramChange="43" />
+      <Patch Number="301" Name="Film Octaves" ProgramChange="44" />
+      <Patch Number="302" Name="Film Layers" ProgramChange="45" />
+      <Patch Number="303" Name="Bass Pizz" ProgramChange="46" />
+      <Patch Number="304" Name="Real Pizz" ProgramChange="47" />
+      <Patch Number="305" Name="Harp On It" ProgramChange="48" />
+      <Patch Number="306" Name="Harp" ProgramChange="49" />
+      <Patch Number="307" Name="JP-8 Str 1" ProgramChange="50" />
+      <Patch Number="308" Name="JP-8 Str 2" ProgramChange="51" />
+      <Patch Number="309" Name="E-Motion Pad" ProgramChange="52" />
+      <Patch Number="310" Name="JP-8 Str 3" ProgramChange="53" />
+      <Patch Number="311" Name="Vintage Orch" ProgramChange="54" />
+      <Patch Number="312" Name="JUNO Strings" ProgramChange="55" />
+      <Patch Number="313" Name="Gigantalog" ProgramChange="56" />
+      <Patch Number="314" Name="PWM Strings" ProgramChange="57" />
+      <Patch Number="315" Name="Warmth" ProgramChange="58" />
+      <Patch Number="316" Name="ORBit Pad" ProgramChange="59" />
+      <Patch Number="317" Name="Deep Strings" ProgramChange="60" />
+      <Patch Number="318" Name="Pulsify" ProgramChange="61" />
+      <Patch Number="319" Name="Pulse Pad" ProgramChange="62" />
+      <Patch Number="320" Name="Greek Power" ProgramChange="63" />
+      <Patch Number="321" Name="Harmonicum" ProgramChange="64" />
+      <Patch Number="322" Name="D-50 Heaven" ProgramChange="65" />
+      <Patch Number="323" Name="Afro Horns" ProgramChange="66" />
+      <Patch Number="324" Name="Pop Pad" ProgramChange="67" />
+      <Patch Number="325" Name="Dreamesque" ProgramChange="68" />
+      <Patch Number="326" Name="Square Pad" ProgramChange="69" />
+      <Patch Number="327" Name="JP-8 Hollow" ProgramChange="70" />
+      <Patch Number="328" Name="JP-8Haunting" ProgramChange="71" />
+      <Patch Number="329" Name="Heirborne" ProgramChange="72" />
+      <Patch Number="330" Name="Hush Pad" ProgramChange="73" />
+      <Patch Number="331" Name="Jet Pad 1" ProgramChange="74" />
+      <Patch Number="332" Name="Jet Pad 2" ProgramChange="75" />
+      <Patch Number="333" Name="Phaze Pad" ProgramChange="76" />
+      <Patch Number="334" Name="Phaze Str" ProgramChange="77" />
+      <Patch Number="335" Name="Jet Str Ens" ProgramChange="78" />
+      <Patch Number="336" Name="Pivotal Pad" ProgramChange="79" />
+      <Patch Number="337" Name="3D Flanged" ProgramChange="80" />
+      <Patch Number="338" Name="Fantawine" ProgramChange="81" />
+      <Patch Number="339" Name="Glassy Pad" ProgramChange="82" />
+      <Patch Number="340" Name="Moving Glass" ProgramChange="83" />
+      <Patch Number="341" Name="Glasswaves" ProgramChange="84" />
+      <Patch Number="342" Name="Shiny Pad" ProgramChange="85" />
+      <Patch Number="343" Name="ShiftedGlass" ProgramChange="86" />
+      <Patch Number="344" Name="Chime Pad" ProgramChange="87" />
+      <Patch Number="345" Name="Spin Pad" ProgramChange="88" />
+      <Patch Number="346" Name="Rotary Pad" ProgramChange="89" />
+      <Patch Number="347" Name="Dawn 2 Dusk" ProgramChange="90" />
+      <Patch Number="348" Name="Aurora" ProgramChange="91" />
+      <Patch Number="349" Name="Strobe Mode" ProgramChange="92" />
+      <Patch Number="350" Name="Albion" ProgramChange="93" />
+      <Patch Number="351" Name="Running Pad" ProgramChange="94" />
+      <Patch Number="352" Name="Stepped Pad" ProgramChange="95" />
+      <Patch Number="353" Name="Random Pad" ProgramChange="96" />
+      <Patch Number="354" Name="SoundtrkDANC" ProgramChange="97" />
+      <Patch Number="355" Name="Flying Waltz" ProgramChange="98" />
+      <Patch Number="356" Name="Vanishing" ProgramChange="99" />
+      <Patch Number="357" Name="5th Sweep" ProgramChange="100" />
+      <Patch Number="358" Name="Phazweep" ProgramChange="101" />
+      <Patch Number="359" Name="Big BPF" ProgramChange="102" />
+      <Patch Number="360" Name="MG Sweep" ProgramChange="103" />
+      <Patch Number="361" Name="CeremonyTimp" ProgramChange="104" />
+      <Patch Number="362" Name="Dyno Toms" ProgramChange="105" />
+      <Patch Number="363" Name="Sands ofTime" ProgramChange="106" />
+      <Patch Number="364" Name="Inertia" ProgramChange="107" />
+      <Patch Number="365" Name="Vektogram" ProgramChange="108" />
+      <Patch Number="366" Name="Crash Pad" ProgramChange="109" />
+      <Patch Number="367" Name="Feedback VOX" ProgramChange="110" />
+      <Patch Number="368" Name="Cascade" ProgramChange="111" />
+      <Patch Number="369" Name="Shattered" ProgramChange="112" />
+      <Patch Number="370" Name="NextFrontier" ProgramChange="113" />
+      <Patch Number="371" Name="Pure Tibet" ProgramChange="114" />
+      <Patch Number="372" Name="Chime Wash" ProgramChange="115" />
+      <Patch Number="373" Name="Night Shade" ProgramChange="116" />
+      <Patch Number="374" Name="Tortured" ProgramChange="117" />
+      <Patch Number="375" Name="Dissimilate" ProgramChange="118" />
+      <Patch Number="376" Name="Dunes" ProgramChange="119" />
+      <Patch Number="377" Name="Ocean Floor" ProgramChange="120" />
+      <Patch Number="378" Name="Cyber Space" ProgramChange="121" />
+      <Patch Number="379" Name="Biosphere" ProgramChange="122" />
+      <Patch Number="380" Name="Variable Run" ProgramChange="123" />
+      <Patch Number="381" Name="Ice Hall" ProgramChange="124" />
+      <Patch Number="382" Name="ComputerRoom" ProgramChange="125" />
+      <Patch Number="383" Name="Inverted" ProgramChange="126" />
+      <Patch Number="384" Name="Terminate" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 385-512">
+      <Patch Number="385" Name="Echo Piano" ProgramChange="0" />
+      <Patch Number="386" Name="Upright Pno" ProgramChange="1" />
+      <Patch Number="387" Name="RD-1000" ProgramChange="2" />
+      <Patch Number="388" Name="Player's EP" ProgramChange="3" />
+      <Patch Number="389" Name="D-50 EP" ProgramChange="4" />
+      <Patch Number="390" Name="Innocent EP" ProgramChange="5" />
+      <Patch Number="391" Name="Echo EP" ProgramChange="6" />
+      <Patch Number="392" Name="See-Thru EP" ProgramChange="7" />
+      <Patch Number="393" Name="FM BellPiano" ProgramChange="8" />
+      <Patch Number="394" Name="Ring E.Piano" ProgramChange="9" />
+      <Patch Number="395" Name="Soap Opera" ProgramChange="10" />
+      <Patch Number="396" Name="Dirty Organ" ProgramChange="11" />
+      <Patch Number="397" Name="Surf's Up!" ProgramChange="12" />
+      <Patch Number="398" Name="Organesque" ProgramChange="13" />
+      <Patch Number="399" Name="pp Harmonium" ProgramChange="14" />
+      <Patch Number="400" Name="PieceOfCheez" ProgramChange="15" />
+      <Patch Number="401" Name="Harpsy Clav" ProgramChange="16" />
+      <Patch Number="402" Name="Exotic Velo" ProgramChange="17" />
+      <Patch Number="403" Name="HolidayCheer" ProgramChange="18" />
+      <Patch Number="404" Name="Morning Lite" ProgramChange="19" />
+      <Patch Number="405" Name="Prefab Chime" ProgramChange="20" />
+      <Patch Number="406" Name="Belfry Chime" ProgramChange="21" />
+      <Patch Number="407" Name="Stacc.Heaven" ProgramChange="22" />
+      <Patch Number="408" Name="2.2 Bell Pad" ProgramChange="23" />
+      <Patch Number="409" Name="Far East" ProgramChange="24" />
+      <Patch Number="410" Name="Wire Pad" ProgramChange="25" />
+      <Patch Number="411" Name="PhaseBlipper" ProgramChange="26" />
+      <Patch Number="412" Name="Sweep Clav" ProgramChange="27" />
+      <Patch Number="413" Name="Glider" ProgramChange="28" />
+      <Patch Number="414" Name="Solo Steel" ProgramChange="29" />
+      <Patch Number="415" Name="DesertCrystl" ProgramChange="30" />
+      <Patch Number="416" Name="Clear Guitar" ProgramChange="31" />
+      <Patch Number="417" Name="Solo Strat" ProgramChange="32" />
+      <Patch Number="418" Name="Feed Me!" ProgramChange="33" />
+      <Patch Number="419" Name="Tube Smoke" ProgramChange="34" />
+      <Patch Number="420" Name="Creamy" ProgramChange="35" />
+      <Patch Number="421" Name="Blusey OD" ProgramChange="36" />
+      <Patch Number="422" Name="Grindstone" ProgramChange="37" />
+      <Patch Number="423" Name="OD 5ths" ProgramChange="38" />
+      <Patch Number="424" Name="East Europe" ProgramChange="39" />
+      <Patch Number="425" Name="Dulcitar" ProgramChange="40" />
+      <Patch Number="426" Name="Atmos Harp" ProgramChange="41" />
+      <Patch Number="427" Name="Pilgrimage" ProgramChange="42" />
+      <Patch Number="428" Name="202 Rude Bs" ProgramChange="43" />
+      <Patch Number="429" Name="2pole Bass" ProgramChange="44" />
+      <Patch Number="430" Name="4pole Bass" ProgramChange="45" />
+      <Patch Number="431" Name="Phaser MC" ProgramChange="46" />
+      <Patch Number="432" Name="Miniphaser" ProgramChange="47" />
+      <Patch Number="433" Name="Acid TB" ProgramChange="48" />
+      <Patch Number="434" Name="Full Orchest" ProgramChange="49" />
+      <Patch Number="435" Name="Str + Winds" ProgramChange="50" />
+      <Patch Number="436" Name="Flute 2080" ProgramChange="51" />
+      <Patch Number="437" Name="Scat Flute" ProgramChange="52" />
+      <Patch Number="438" Name="Sax Choir" ProgramChange="53" />
+      <Patch Number="439" Name="Ballad Trump" ProgramChange="54" />
+      <Patch Number="440" Name="Sm.Brass Grp" ProgramChange="55" />
+      <Patch Number="441" Name="Royale" ProgramChange="56" />
+      <Patch Number="442" Name="Brass Mutes" ProgramChange="57" />
+      <Patch Number="443" Name="Breathy Brs" ProgramChange="58" />
+      <Patch Number="444" Name="3 Osc Brass" ProgramChange="59" />
+      <Patch Number="445" Name="P5 Polymod" ProgramChange="60" />
+      <Patch Number="446" Name="Triumph Brs" ProgramChange="61" />
+      <Patch Number="447" Name="Techno Dream" ProgramChange="62" />
+      <Patch Number="448" Name="Organizer" ProgramChange="63" />
+      <Patch Number="449" Name="Civilization" ProgramChange="64" />
+      <Patch Number="450" Name="Mental Chord" ProgramChange="65" />
+      <Patch Number="451" Name="House Chord" ProgramChange="66" />
+      <Patch Number="452" Name="Sequalog" ProgramChange="67" />
+      <Patch Number="453" Name="Booster Bips" ProgramChange="68" />
+      <Patch Number="454" Name="VintagePlunk" ProgramChange="69" />
+      <Patch Number="455" Name="Plik-Plok" ProgramChange="70" />
+      <Patch Number="456" Name="RingSequence" ProgramChange="71" />
+      <Patch Number="457" Name="Cyber Swing" ProgramChange="72" />
+      <Patch Number="458" Name="Keep :-)" ProgramChange="73" />
+      <Patch Number="459" Name="Resojuice" ProgramChange="74" />
+      <Patch Number="460" Name="B'on d'moov!" ProgramChange="75" />
+      <Patch Number="461" Name="Dist TB-303" ProgramChange="76" />
+      <Patch Number="462" Name="Temple of JV" ProgramChange="77" />
+      <Patch Number="463" Name="Planet Asia" ProgramChange="78" />
+      <Patch Number="464" Name="Afterlife" ProgramChange="79" />
+      <Patch Number="465" Name="Trancing Pad" ProgramChange="80" />
+      <Patch Number="466" Name="Pulsatronic" ProgramChange="81" />
+      <Patch Number="467" Name="Cyber Dreams" ProgramChange="82" />
+      <Patch Number="468" Name="Warm Pipe" ProgramChange="83" />
+      <Patch Number="469" Name="Pure Pipe" ProgramChange="84" />
+      <Patch Number="470" Name="SH-2000" ProgramChange="85" />
+      <Patch Number="471" Name="X..? Whistle" ProgramChange="86" />
+      <Patch Number="472" Name="Jay Vee Solo" ProgramChange="87" />
+      <Patch Number="473" Name="Progresso Ld" ProgramChange="88" />
+      <Patch Number="474" Name="Adrenaline" ProgramChange="89" />
+      <Patch Number="475" Name="Enlighten" ProgramChange="90" />
+      <Patch Number="476" Name="Glass Blower" ProgramChange="91" />
+      <Patch Number="477" Name="Earth Blow" ProgramChange="92" />
+      <Patch Number="478" Name="JX SqrCarpet" ProgramChange="93" />
+      <Patch Number="479" Name="Dimensional" ProgramChange="94" />
+      <Patch Number="480" Name="Jupiterings" ProgramChange="95" />
+      <Patch Number="481" Name="Analog Drama" ProgramChange="96" />
+      <Patch Number="482" Name="Rich Dynapad" ProgramChange="97" />
+      <Patch Number="483" Name="Silky Way" ProgramChange="98" />
+      <Patch Number="484" Name="Gluey Pad" ProgramChange="99" />
+      <Patch Number="485" Name="BandPass Mod" ProgramChange="100" />
+      <Patch Number="486" Name="Soundtraque" ProgramChange="101" />
+      <Patch Number="487" Name="Translucence" ProgramChange="102" />
+      <Patch Number="488" Name="Darkshine" ProgramChange="103" />
+      <Patch Number="489" Name="D'light" ProgramChange="104" />
+      <Patch Number="490" Name="December Sky" ProgramChange="105" />
+      <Patch Number="491" Name="Octapad" ProgramChange="106" />
+      <Patch Number="492" Name="JUNO Power!" ProgramChange="107" />
+      <Patch Number="493" Name="Spectrum Mod" ProgramChange="108" />
+      <Patch Number="494" Name="Stringsheen" ProgramChange="109" />
+      <Patch Number="495" Name="GR500 TmpDly" ProgramChange="110" />
+      <Patch Number="496" Name="Mod DirtyWav" ProgramChange="111" />
+      <Patch Number="497" Name="Silicon Str" ProgramChange="112" />
+      <Patch Number="498" Name="D50FantaPerc" ProgramChange="113" />
+      <Patch Number="499" Name="Rotodreams" ProgramChange="114" />
+      <Patch Number="500" Name="Blue Notes" ProgramChange="115" />
+      <Patch Number="501" Name="RiversOfTime" ProgramChange="116" />
+      <Patch Number="502" Name="Phobos" ProgramChange="117" />
+      <Patch Number="503" Name="2  0  8  0" ProgramChange="118" />
+      <Patch Number="504" Name="Unearthly" ProgramChange="119" />
+      <Patch Number="505" Name="Glistening" ProgramChange="120" />
+      <Patch Number="506" Name="Sci-Fi Str" ProgramChange="121" />
+      <Patch Number="507" Name="Shadows" ProgramChange="122" />
+      <Patch Number="508" Name="Helium Queen" ProgramChange="123" />
+      <Patch Number="509" Name="Sci-Fi FX x4" ProgramChange="124" />
+      <Patch Number="510" Name="Perky Noize" ProgramChange="125" />
+      <Patch Number="511" Name="Droplet" ProgramChange="126" />
+      <Patch Number="512" Name="Rain Forest" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 513-640">
+      <Patch Number="513" Name="Grand XV" ProgramChange="0" />
+      <Patch Number="514" Name="Contemplate" ProgramChange="1" />
+      <Patch Number="515" Name="Rock Piano" ProgramChange="2" />
+      <Patch Number="516" Name="RockPiano Ch" ProgramChange="3" />
+      <Patch Number="517" Name="Pianomonics" ProgramChange="4" />
+      <Patch Number="518" Name="Piano+SftPad" ProgramChange="5" />
+      <Patch Number="519" Name="WarmVoxPiano" ProgramChange="6" />
+      <Patch Number="520" Name="Y2K Concerto" ProgramChange="7" />
+      <Patch Number="521" Name="Piano+AirPad" ProgramChange="8" />
+      <Patch Number="522" Name="ChoraLeader" ProgramChange="9" />
+      <Patch Number="523" Name="SparklePiano" ProgramChange="10" />
+      <Patch Number="524" Name="Retro EP" ProgramChange="11" />
+      <Patch Number="525" Name="Fat EP" ProgramChange="12" />
+      <Patch Number="526" Name="EP Trem" ProgramChange="13" />
+      <Patch Number="527" Name="Phaser Dyno" ProgramChange="14" />
+      <Patch Number="528" Name="Hit EP" ProgramChange="15" />
+      <Patch Number="529" Name="Sweet Tynes" ProgramChange="16" />
+      <Patch Number="530" Name="Pluk EP" ProgramChange="17" />
+      <Patch Number="531" Name="EP Trip" ProgramChange="18" />
+      <Patch Number="532" Name="Ambi EP" ProgramChange="19" />
+      <Patch Number="533" Name="Rholitzer" ProgramChange="20" />
+      <Patch Number="534" Name="Wurlie" ProgramChange="21" />
+      <Patch Number="535" Name="FM Delight" ProgramChange="22" />
+      <Patch Number="536" Name="Cutter Clav" ProgramChange="23" />
+      <Patch Number="537" Name="Mute Clav D6" ProgramChange="24" />
+      <Patch Number="538" Name="PhazeWahClav" ProgramChange="25" />
+      <Patch Number="539" Name="St.Harpsichd" ProgramChange="26" />
+      <Patch Number="540" Name="3PartInventn" ProgramChange="27" />
+      <Patch Number="541" Name="Soft Perky" ProgramChange="28" />
+      <Patch Number="542" Name="Fullness" ProgramChange="29" />
+      <Patch Number="543" Name="Paleface 1" ProgramChange="30" />
+      <Patch Number="544" Name="Paleface 2" ProgramChange="31" />
+      <Patch Number="545" Name="Soft B" ProgramChange="32" />
+      <Patch Number="546" Name="British B" ProgramChange="33" />
+      <Patch Number="547" Name="Rocker Org" ProgramChange="34" />
+      <Patch Number="548" Name="Split B" ProgramChange="35" />
+      <Patch Number="549" Name="PercInterval" ProgramChange="36" />
+      <Patch Number="550" Name="Happy 60s" ProgramChange="37" />
+      <Patch Number="551" Name="96 Years" ProgramChange="38" />
+      <Patch Number="552" Name="Glory Us Rok" ProgramChange="39" />
+      <Patch Number="553" Name="Church Harmn" ProgramChange="40" />
+      <Patch Number="554" Name="Cathdr Harmn" ProgramChange="41" />
+      <Patch Number="555" Name="Morph Pad" ProgramChange="42" />
+      <Patch Number="556" Name="Air Pad" ProgramChange="43" />
+      <Patch Number="557" Name="Soft Padding" ProgramChange="44" />
+      <Patch Number="558" Name="Warmth Pad" ProgramChange="45" />
+      <Patch Number="559" Name="ClassicJPpad" ProgramChange="46" />
+      <Patch Number="560" Name="Jupiter Str" ProgramChange="47" />
+      <Patch Number="561" Name="Fat Pad" ProgramChange="48" />
+      <Patch Number="562" Name="GR700 Pad" ProgramChange="49" />
+      <Patch Number="563" Name="Paradise" ProgramChange="50" />
+      <Patch Number="564" Name="Moonchimes" ProgramChange="51" />
+      <Patch Number="565" Name="SusPed Swap" ProgramChange="52" />
+      <Patch Number="566" Name="PhasingPad" ProgramChange="53" />
+      <Patch Number="567" Name="Ethereal Str" ProgramChange="54" />
+      <Patch Number="568" Name="Velcropad" ProgramChange="55" />
+      <Patch Number="569" Name="NothrnLights" ProgramChange="56" />
+      <Patch Number="570" Name="Sun Dive" ProgramChange="57" />
+      <Patch Number="571" Name="Brite Vox 1" ProgramChange="58" />
+      <Patch Number="572" Name="Brite Vox 2" ProgramChange="59" />
+      <Patch Number="573" Name="Ooh)Aah Mod" ProgramChange="60" />
+      <Patch Number="574" Name="Vocals: Ooh" ProgramChange="61" />
+      <Patch Number="575" Name="Vocals: Scat" ProgramChange="62" />
+      <Patch Number="576" Name="Vocals: Boys" ProgramChange="63" />
+      <Patch Number="577" Name="St. Choir" ProgramChange="64" />
+      <Patch Number="578" Name="SampleThe80s" ProgramChange="65" />
+      <Patch Number="579" Name="Sacred Tree" ProgramChange="66" />
+      <Patch Number="580" Name="VP330 OctEko" ProgramChange="67" />
+      <Patch Number="581" Name="XV Strings" ProgramChange="68" />
+      <Patch Number="582" Name="Fat Strings" ProgramChange="69" />
+      <Patch Number="583" Name="Dolce  p/m/f" ProgramChange="70" />
+      <Patch Number="584" Name="Sad Strings" ProgramChange="71" />
+      <Patch Number="585" Name="Lush Strings" ProgramChange="72" />
+      <Patch Number="586" Name="Strings4Film" ProgramChange="73" />
+      <Patch Number="587" Name="Marcato Str" ProgramChange="74" />
+      <Patch Number="588" Name="End Titles" ProgramChange="75" />
+      <Patch Number="589" Name="ChmbrQuartet" ProgramChange="76" />
+      <Patch Number="590" Name="ChamberSect." ProgramChange="77" />
+      <Patch Number="591" Name="FullChmbrStr" ProgramChange="78" />
+      <Patch Number="592" Name="Tape Strings" ProgramChange="79" />
+      <Patch Number="593" Name="Henry VIII" ProgramChange="80" />
+      <Patch Number="594" Name="Prelude" ProgramChange="81" />
+      <Patch Number="595" Name="Str&amp;Brs Orch" ProgramChange="82" />
+      <Patch Number="596" Name="Hornz" ProgramChange="83" />
+      <Patch Number="597" Name="TudorFanfare" ProgramChange="84" />
+      <Patch Number="598" Name="ChamberPlyrs" ProgramChange="85" />
+      <Patch Number="599" Name="Flute/Clari" ProgramChange="86" />
+      <Patch Number="600" Name="Orch Reeds" ProgramChange="87" />
+      <Patch Number="601" Name="Dual Flutes" ProgramChange="88" />
+      <Patch Number="602" Name="Jazzer Flute" ProgramChange="89" />
+      <Patch Number="603" Name="LegatoBamboo" ProgramChange="90" />
+      <Patch Number="604" Name="Ambience Flt" ProgramChange="91" />
+      <Patch Number="605" Name="The Andes" ProgramChange="92" />
+      <Patch Number="606" Name="Deja Vlute" ProgramChange="93" />
+      <Patch Number="607" Name="Simply Brass" ProgramChange="94" />
+      <Patch Number="608" Name="FullSt Brass" ProgramChange="95" />
+      <Patch Number="609" Name="Dragnet" ProgramChange="96" />
+      <Patch Number="610" Name="NewR&amp;RBrass" ProgramChange="97" />
+      <Patch Number="611" Name="Tower Trumps" ProgramChange="98" />
+      <Patch Number="612" Name="BigBrassBand" ProgramChange="99" />
+      <Patch Number="613" Name="Lil'BigHornz" ProgramChange="100" />
+      <Patch Number="614" Name="VoyagerBrass" ProgramChange="101" />
+      <Patch Number="615" Name="Symph Horns" ProgramChange="102" />
+      <Patch Number="616" Name="Trombone Atm" ProgramChange="103" />
+      <Patch Number="617" Name="XV Trombone" ProgramChange="104" />
+      <Patch Number="618" Name="XV Trumpet" ProgramChange="105" />
+      <Patch Number="619" Name="JupiterHorns" ProgramChange="106" />
+      <Patch Number="620" Name="Solo SoprSax" ProgramChange="107" />
+      <Patch Number="621" Name="Solo AltoSax" ProgramChange="108" />
+      <Patch Number="622" Name="XV DynoTenor" ProgramChange="109" />
+      <Patch Number="623" Name="Honker Bari" ProgramChange="110" />
+      <Patch Number="624" Name="Full Saxz" ProgramChange="111" />
+      <Patch Number="625" Name="Soaring Hrns" ProgramChange="112" />
+      <Patch Number="626" Name="Glass Orbit" ProgramChange="113" />
+      <Patch Number="627" Name="5th Atm /Aft" ProgramChange="114" />
+      <Patch Number="628" Name="Lo-fi Sweep" ProgramChange="115" />
+      <Patch Number="629" Name="Modular Life" ProgramChange="116" />
+      <Patch Number="630" Name="Oscillations" ProgramChange="117" />
+      <Patch Number="631" Name="Combing" ProgramChange="118" />
+      <Patch Number="632" Name="Rolling 5ths" ProgramChange="119" />
+      <Patch Number="633" Name="Analogue Str" ProgramChange="120" />
+      <Patch Number="634" Name="Lunar Strngs" ProgramChange="121" />
+      <Patch Number="635" Name="BPFsweep Mod" ProgramChange="122" />
+      <Patch Number="636" Name="Queen V" ProgramChange="123" />
+      <Patch Number="637" Name="SkinnyBounce" ProgramChange="124" />
+      <Patch Number="638" Name="SquareBounce" ProgramChange="125" />
+      <Patch Number="639" Name="Galactic" ProgramChange="126" />
+      <Patch Number="640" Name="Powerwiggle" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 641-768">
+      <Patch Number="641" Name="80s Retrosyn" ProgramChange="0" />
+      <Patch Number="642" Name="Power Stack" ProgramChange="1" />
+      <Patch Number="643" Name="Don't Jump" ProgramChange="2" />
+      <Patch Number="644" Name="Big Bubbles" ProgramChange="3" />
+      <Patch Number="645" Name="X-mod Sweep" ProgramChange="4" />
+      <Patch Number="646" Name="Bag O' Bones" ProgramChange="5" />
+      <Patch Number="647" Name="AirSoThin" ProgramChange="6" />
+      <Patch Number="648" Name="Analogical" ProgramChange="7" />
+      <Patch Number="649" Name="Waspy Pulse" ProgramChange="8" />
+      <Patch Number="650" Name="Soaring Saws" ProgramChange="9" />
+      <Patch Number="651" Name="Square Roots" ProgramChange="10" />
+      <Patch Number="652" Name="BOG" ProgramChange="11" />
+      <Patch Number="653" Name="Talking Box" ProgramChange="12" />
+      <Patch Number="654" Name="Retro Lead" ProgramChange="13" />
+      <Patch Number="655" Name="LivingInSync" ProgramChange="14" />
+      <Patch Number="656" Name="Leads United" ProgramChange="15" />
+      <Patch Number="657" Name="Dirty Sync" ProgramChange="16" />
+      <Patch Number="658" Name="DistortaSync" ProgramChange="17" />
+      <Patch Number="659" Name="Blistering" ProgramChange="18" />
+      <Patch Number="660" Name="Guttural" ProgramChange="19" />
+      <Patch Number="661" Name="Flyin' High" ProgramChange="20" />
+      <Patch Number="662" Name="Soft Tooth" ProgramChange="21" />
+      <Patch Number="663" Name="Soaring Sqr" ProgramChange="22" />
+      <Patch Number="664" Name="Soaring Sync" ProgramChange="23" />
+      <Patch Number="665" Name="Nasal Spray" ProgramChange="24" />
+      <Patch Number="666" Name="Lamb Lead" ProgramChange="25" />
+      <Patch Number="667" Name="Creamer" ProgramChange="26" />
+      <Patch Number="668" Name="Sine System" ProgramChange="27" />
+      <Patch Number="669" Name="Soft Nylon" ProgramChange="28" />
+      <Patch Number="670" Name="Nylozzicato" ProgramChange="29" />
+      <Patch Number="671" Name="Mutezzicato" ProgramChange="30" />
+      <Patch Number="672" Name="Hybrid Nylon" ProgramChange="31" />
+      <Patch Number="673" Name="XV SteelGt 1" ProgramChange="32" />
+      <Patch Number="674" Name="XV SteelGt 2" ProgramChange="33" />
+      <Patch Number="675" Name="Comp'Steel" ProgramChange="34" />
+      <Patch Number="676" Name="Double Steel" ProgramChange="35" />
+      <Patch Number="677" Name="Folk Guitar" ProgramChange="36" />
+      <Patch Number="678" Name="SpanishNight" ProgramChange="37" />
+      <Patch Number="679" Name="Plug n' Play" ProgramChange="38" />
+      <Patch Number="680" Name="Fab 4 Guitar" ProgramChange="39" />
+      <Patch Number="681" Name="Searing Lead" ProgramChange="40" />
+      <Patch Number="682" Name="Punker" ProgramChange="41" />
+      <Patch Number="683" Name="LouderPlease" ProgramChange="42" />
+      <Patch Number="684" Name="XV Upright" ProgramChange="43" />
+      <Patch Number="685" Name="XV Ac.Bass" ProgramChange="44" />
+      <Patch Number="686" Name="LookMaNoFret" ProgramChange="45" />
+      <Patch Number="687" Name="XV Fretless" ProgramChange="46" />
+      <Patch Number="688" Name="Basic F'less" ProgramChange="47" />
+      <Patch Number="689" Name="8-str F'less" ProgramChange="48" />
+      <Patch Number="690" Name="Tap Bass" ProgramChange="49" />
+      <Patch Number="691" Name="Pop Bass" ProgramChange="50" />
+      <Patch Number="692" Name="P.Bs Chorus" ProgramChange="51" />
+      <Patch Number="693" Name="TremCho Bs" ProgramChange="52" />
+      <Patch Number="694" Name="Creamy Bass" ProgramChange="53" />
+      <Patch Number="695" Name="Buster Bass" ProgramChange="54" />
+      <Patch Number="696" Name="TB Squelch" ProgramChange="55" />
+      <Patch Number="697" Name="Ticker Bass" ProgramChange="56" />
+      <Patch Number="698" Name="Muscle Bass" ProgramChange="57" />
+      <Patch Number="699" Name="Grounded Bs" ProgramChange="58" />
+      <Patch Number="700" Name="West End Bs" ProgramChange="59" />
+      <Patch Number="701" Name="Snap Bass" ProgramChange="60" />
+      <Patch Number="702" Name="700 Bassboy" ProgramChange="61" />
+      <Patch Number="703" Name="8VCO MonoSyn" ProgramChange="62" />
+      <Patch Number="704" Name="ResoMoist Bs" ProgramChange="63" />
+      <Patch Number="705" Name="Kickin' Bass" ProgramChange="64" />
+      <Patch Number="706" Name="Sub Zero" ProgramChange="65" />
+      <Patch Number="707" Name="Liquid Bass" ProgramChange="66" />
+      <Patch Number="708" Name="Hefty Bass" ProgramChange="67" />
+      <Patch Number="709" Name="Severe Ow Bs" ProgramChange="68" />
+      <Patch Number="710" Name="Chime Bells" ProgramChange="69" />
+      <Patch Number="711" Name="Celestabox" ProgramChange="70" />
+      <Patch Number="712" Name="Brass Tubes" ProgramChange="71" />
+      <Patch Number="713" Name="Dreams East" ProgramChange="72" />
+      <Patch Number="714" Name="Synergistic" ProgramChange="73" />
+      <Patch Number="715" Name="Andreas Cave" ProgramChange="74" />
+      <Patch Number="716" Name="AmbiPizza" ProgramChange="75" />
+      <Patch Number="717" Name="Voxy Nylon" ProgramChange="76" />
+      <Patch Number="718" Name="EastrnEurope" ProgramChange="77" />
+      <Patch Number="719" Name="Celtic Harp" ProgramChange="78" />
+      <Patch Number="720" Name="Reso Sitar" ProgramChange="79" />
+      <Patch Number="721" Name="The Ganges" ProgramChange="80" />
+      <Patch Number="722" Name="MountainFolk" ProgramChange="81" />
+      <Patch Number="723" Name="Byzantine" ProgramChange="82" />
+      <Patch Number="724" Name="AsiaPlectrum" ProgramChange="83" />
+      <Patch Number="725" Name="VelHarp)Harm" ProgramChange="84" />
+      <Patch Number="726" Name="Pluckaphone" ProgramChange="85" />
+      <Patch Number="727" Name="Slap Timps" ProgramChange="86" />
+      <Patch Number="728" Name="Suite Combo" ProgramChange="87" />
+      <Patch Number="729" Name="Jet Voxs" ProgramChange="88" />
+      <Patch Number="730" Name="Dirty Hit" ProgramChange="89" />
+      <Patch Number="731" Name="MOVE!" ProgramChange="90" />
+      <Patch Number="732" Name="Reel Slam" ProgramChange="91" />
+      <Patch Number="733" Name="OffTheRecord" ProgramChange="92" />
+      <Patch Number="734" Name="2ndRateChord" ProgramChange="93" />
+      <Patch Number="735" Name="RageInYouth" ProgramChange="94" />
+      <Patch Number="736" Name="MinorIncidnt" ProgramChange="95" />
+      <Patch Number="737" Name="Phunky DC" ProgramChange="96" />
+      <Patch Number="738" Name="Agent X" ProgramChange="97" />
+      <Patch Number="739" Name="Winky" ProgramChange="98" />
+      <Patch Number="740" Name="Looney 2nz" ProgramChange="99" />
+      <Patch Number="741" Name="Shortrave" ProgramChange="100" />
+      <Patch Number="742" Name="DeeperBeeper" ProgramChange="101" />
+      <Patch Number="743" Name="Percolator" ProgramChange="102" />
+      <Patch Number="744" Name="Filter Morph" ProgramChange="103" />
+      <Patch Number="745" Name="Choir Bounce" ProgramChange="104" />
+      <Patch Number="746" Name="Rippling" ProgramChange="105" />
+      <Patch Number="747" Name="SteppingPhsr" ProgramChange="106" />
+      <Patch Number="748" Name="Trance Fair" ProgramChange="107" />
+      <Patch Number="749" Name="GermanBounce" ProgramChange="108" />
+      <Patch Number="750" Name="Acid JaZZ" ProgramChange="109" />
+      <Patch Number="751" Name="Cutter&gt;ModWh" ProgramChange="110" />
+      <Patch Number="752" Name="Blades" ProgramChange="111" />
+      <Patch Number="753" Name="Mad Bender" ProgramChange="112" />
+      <Patch Number="754" Name="Shapeshifter" ProgramChange="113" />
+      <Patch Number="755" Name="ForestMoon" ProgramChange="114" />
+      <Patch Number="756" Name="Predator 2" ProgramChange="115" />
+      <Patch Number="757" Name="Dark Side" ProgramChange="116" />
+      <Patch Number="758" Name="The Beast" ProgramChange="117" />
+      <Patch Number="759" Name="X-mod Reso" ProgramChange="118" />
+      <Patch Number="760" Name="Planet Meta" ProgramChange="119" />
+      <Patch Number="761" Name="Nexus" ProgramChange="120" />
+      <Patch Number="762" Name="Halographix" ProgramChange="121" />
+      <Patch Number="763" Name="Moon Rise" ProgramChange="122" />
+      <Patch Number="764" Name="Gruvacious" ProgramChange="123" />
+      <Patch Number="765" Name="Windy Dunes" ProgramChange="124" />
+      <Patch Number="766" Name="Ice Blasts" ProgramChange="125" />
+      <Patch Number="767" Name="Ringy Thingy" ProgramChange="126" />
+      <Patch Number="768" Name="Atmospherics" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Synth Tone 769-896">
+      <Patch Number="769" Name="Power Octs" ProgramChange="0" />
+      <Patch Number="770" Name="WaterPiano2" ProgramChange="1" />
+      <Patch Number="771" Name="Swimming EP" ProgramChange="2" />
+      <Patch Number="772" Name="XV Crystal" ProgramChange="3" />
+      <Patch Number="773" Name="Cold Roadz" ProgramChange="4" />
+      <Patch Number="774" Name="Back EP" ProgramChange="5" />
+      <Patch Number="775" Name="Amped Wurlie" ProgramChange="6" />
+      <Patch Number="776" Name="Dirty Wurlie" ProgramChange="7" />
+      <Patch Number="777" Name="Musicbox XV" ProgramChange="8" />
+      <Patch Number="778" Name="Klubb Organ" ProgramChange="9" />
+      <Patch Number="779" Name="Drew's Bee" ProgramChange="10" />
+      <Patch Number="780" Name="Velvet Organ" ProgramChange="11" />
+      <Patch Number="781" Name="Distorted B" ProgramChange="12" />
+      <Patch Number="782" Name="Radikal B" ProgramChange="13" />
+      <Patch Number="783" Name="Boogie Organ" ProgramChange="14" />
+      <Patch Number="784" Name="Mood Ringz" ProgramChange="15" />
+      <Patch Number="785" Name="Wedo-Wodo" ProgramChange="16" />
+      <Patch Number="786" Name="S.O.S.trings" ProgramChange="17" />
+      <Patch Number="787" Name="Syncronicity" ProgramChange="18" />
+      <Patch Number="788" Name="DanceMachina" ProgramChange="19" />
+      <Patch Number="789" Name="Vox Chopper" ProgramChange="20" />
+      <Patch Number="790" Name="SlicingSyVox" ProgramChange="21" />
+      <Patch Number="791" Name="PressureDome" ProgramChange="22" />
+      <Patch Number="792" Name="Quasar  /Aft" ProgramChange="23" />
+      <Patch Number="793" Name="Ionizer" ProgramChange="24" />
+      <Patch Number="794" Name="MilleniumStr" ProgramChange="25" />
+      <Patch Number="795" Name="Bounce Baby!" ProgramChange="26" />
+      <Patch Number="796" Name="Bounce Daddy" ProgramChange="27" />
+      <Patch Number="797" Name="Bounce Mama!" ProgramChange="28" />
+      <Patch Number="798" Name="Bounce Noize" ProgramChange="29" />
+      <Patch Number="799" Name="What a Gate!" ProgramChange="30" />
+      <Patch Number="800" Name="Mini Sequenz" ProgramChange="31" />
+      <Patch Number="801" Name="Slice &amp; Dice" ProgramChange="32" />
+      <Patch Number="802" Name="BrushingSaw1" ProgramChange="33" />
+      <Patch Number="803" Name="BrushingSaw2" ProgramChange="34" />
+      <Patch Number="804" Name="Cultivate" ProgramChange="35" />
+      <Patch Number="805" Name="5080 Random" ProgramChange="36" />
+      <Patch Number="806" Name="XV Stepping" ProgramChange="37" />
+      <Patch Number="807" Name="India Garden" ProgramChange="38" />
+      <Patch Number="808" Name="Belly Pad" ProgramChange="39" />
+      <Patch Number="809" Name="Spectre" ProgramChange="40" />
+      <Patch Number="810" Name="SoaringHrns2" ProgramChange="41" />
+      <Patch Number="811" Name="Sabbath Day" ProgramChange="42" />
+      <Patch Number="812" Name="XV BlowPad" ProgramChange="43" />
+      <Patch Number="813" Name="White Arcade" ProgramChange="44" />
+      <Patch Number="814" Name="Borealis" ProgramChange="45" />
+      <Patch Number="815" Name="OvertoneScan" ProgramChange="46" />
+      <Patch Number="816" Name="Whisper Vox" ProgramChange="47" />
+      <Patch Number="817" Name="Jupiter 21" ProgramChange="48" />
+      <Patch Number="818" Name="Filt Strings" ProgramChange="49" />
+      <Patch Number="819" Name="HybStringsXV" ProgramChange="50" />
+      <Patch Number="820" Name="Soft Symphny" ProgramChange="51" />
+      <Patch Number="821" Name="Wood Symphny" ProgramChange="52" />
+      <Patch Number="822" Name="HybOrchestra" ProgramChange="53" />
+      <Patch Number="823" Name="Brassy Symph" ProgramChange="54" />
+      <Patch Number="824" Name="Biggie Brass" ProgramChange="55" />
+      <Patch Number="825" Name="BiggieBrass2" ProgramChange="56" />
+      <Patch Number="826" Name="LA Sax's" ProgramChange="57" />
+      <Patch Number="827" Name="Wind Wood" ProgramChange="58" />
+      <Patch Number="828" Name="Lonely Oboe" ProgramChange="59" />
+      <Patch Number="829" Name="Harmonica XV" ProgramChange="60" />
+      <Patch Number="830" Name="Tooters Lead" ProgramChange="61" />
+      <Patch Number="831" Name="Digi Phased" ProgramChange="62" />
+      <Patch Number="832" Name="Synth Ethics" ProgramChange="63" />
+      <Patch Number="833" Name="Harm is Fine" ProgramChange="64" />
+      <Patch Number="834" Name="D-2000" ProgramChange="65" />
+      <Patch Number="835" Name="Ackward East" ProgramChange="66" />
+      <Patch Number="836" Name="Powersoaker" ProgramChange="67" />
+      <Patch Number="837" Name="Mean Thing" ProgramChange="68" />
+      <Patch Number="838" Name="Jet Sync" ProgramChange="69" />
+      <Patch Number="839" Name="Crying Solo" ProgramChange="70" />
+      <Patch Number="840" Name="Southern Fry" ProgramChange="71" />
+      <Patch Number="841" Name="Strum Distrt" ProgramChange="72" />
+      <Patch Number="842" Name="Match Drive" ProgramChange="73" />
+      <Patch Number="843" Name="Stacked" ProgramChange="74" />
+      <Patch Number="844" Name="2-Stack Over" ProgramChange="75" />
+      <Patch Number="845" Name="COSM Searing" ProgramChange="76" />
+      <Patch Number="846" Name="COSM Loud Gt" ProgramChange="77" />
+      <Patch Number="847" Name="Blue Mutes" ProgramChange="78" />
+      <Patch Number="848" Name="Metal 5150" ProgramChange="79" />
+      <Patch Number="849" Name="Crunch Phase" ProgramChange="80" />
+      <Patch Number="850" Name="Alt Dist Gtr" ProgramChange="81" />
+      <Patch Number="851" Name="So nice!" ProgramChange="82" />
+      <Patch Number="852" Name="Punch Bass" ProgramChange="83" />
+      <Patch Number="853" Name="COSM Bass" ProgramChange="84" />
+      <Patch Number="854" Name="Stream Bell" ProgramChange="85" />
+      <Patch Number="855" Name="Shuffle Bell" ProgramChange="86" />
+      <Patch Number="856" Name="Echo Vibe" ProgramChange="87" />
+      <Patch Number="857" Name="Tremolo Vibe" ProgramChange="88" />
+      <Patch Number="858" Name="True Vibe" ProgramChange="89" />
+      <Patch Number="859" Name="Marimbula" ProgramChange="90" />
+      <Patch Number="860" Name="Hit Bitz" ProgramChange="91" />
+      <Patch Number="861" Name="80s LoFi Hit" ProgramChange="92" />
+      <Patch Number="862" Name="Auto Chord" ProgramChange="93" />
+      <Patch Number="863" Name="3rdTeenChord" ProgramChange="94" />
+      <Patch Number="864" Name="Bend a Chord" ProgramChange="95" />
+      <Patch Number="865" Name="DiscreteChrd" ProgramChange="96" />
+      <Patch Number="866" Name="Ambi Voices" ProgramChange="97" />
+      <Patch Number="867" Name="Say Yeah !" ProgramChange="98" />
+      <Patch Number="868" Name="Xcuse me" ProgramChange="99" />
+      <Patch Number="869" Name="5ths in 4ths" ProgramChange="100" />
+      <Patch Number="870" Name="Pretty Ugly" ProgramChange="101" />
+      <Patch Number="871" Name="Con Sequence" ProgramChange="102" />
+      <Patch Number="872" Name="BermudaShort" ProgramChange="103" />
+      <Patch Number="873" Name="Saw n' 202" ProgramChange="104" />
+      <Patch Number="874" Name="Technoheadz" ProgramChange="105" />
+      <Patch Number="875" Name="Boss'd Synth" ProgramChange="106" />
+      <Patch Number="876" Name="Cross Fire" ProgramChange="107" />
+      <Patch Number="877" Name="Techno Cave" ProgramChange="108" />
+      <Patch Number="878" Name="Generator" ProgramChange="109" />
+      <Patch Number="879" Name="GenderBender" ProgramChange="110" />
+      <Patch Number="880" Name="Xtremities" ProgramChange="111" />
+      <Patch Number="881" Name="AM 05:59" ProgramChange="112" />
+      <Patch Number="882" Name="Happy Brass" ProgramChange="113" />
+      <Patch Number="883" Name="Runaway Rez" ProgramChange="114" />
+      <Patch Number="884" Name="Dropplets" ProgramChange="115" />
+      <Patch Number="885" Name="Indian Guru" ProgramChange="116" />
+      <Patch Number="886" Name="Cosmic Rain" ProgramChange="117" />
+      <Patch Number="887" Name="Trying Winds" ProgramChange="118" />
+      <Patch Number="888" Name="Space Whiz" ProgramChange="119" />
+      <Patch Number="889" Name="DigitalDrone" ProgramChange="120" />
+      <Patch Number="890" Name="Space Race" ProgramChange="121" />
+      <Patch Number="891" Name="Bowed Bell" ProgramChange="122" />
+      <Patch Number="892" Name="X-Tension" ProgramChange="123" />
+      <Patch Number="893" Name="DUB!!!" ProgramChange="124" />
+      <Patch Number="894" Name="Dream Diver" ProgramChange="125" />
+      <Patch Number="895" Name="Flashback" ProgramChange="126" />
+      <Patch Number="896" Name="St.LoFiNoise" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Acoustic Tone 1-128">
+      <Patch Number="001" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="002" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="003" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="004" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="005" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="006" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="007" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="008" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="009" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="010" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="011" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="012" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="013" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="014" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="015" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="016" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="017" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="018" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="019" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="020" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="021" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="022" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="023" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="024" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="025" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="026" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="027" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="028" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="029" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="030" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="031" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="032" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="033" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="034" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="035" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="036" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="037" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="038" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="039" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="040" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="041" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="042" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="043" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="044" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="045" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="046" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="047" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="048" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="049" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="050" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="051" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="052" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="053" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="054" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="055" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="056" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="057" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="058" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="059" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="060" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="061" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="062" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="063" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="064" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="065" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="066" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="067" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="068" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="069" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="070" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="071" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="072" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="073" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="074" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="075" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="076" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="077" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="078" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="079" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="080" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="081" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="082" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="083" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="084" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="085" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="086" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="087" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="088" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="089" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="090" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="091" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="092" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="093" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="094" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="095" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="096" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="097" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="098" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="099" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="100" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="101" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="102" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="103" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="104" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="105" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="106" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="107" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="108" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="109" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="110" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="111" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="112" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="113" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="114" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="115" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="116" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="117" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="118" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="119" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="120" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="121" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="122" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="123" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="124" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="125" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="126" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="127" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="128" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Acoustic Tone 129-256">
+      <Patch Number="129" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="130" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="131" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="132" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="133" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="134" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="135" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="136" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="137" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="138" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="139" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="140" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="141" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="142" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="143" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="144" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="145" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="146" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="147" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="148" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="149" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="150" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="151" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="152" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="153" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="154" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="155" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="156" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="157" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="158" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="159" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="160" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="161" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="162" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="163" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="164" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="165" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="166" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="167" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="168" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="169" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="170" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="171" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="172" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="173" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="174" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="175" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="176" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="177" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="178" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="179" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="180" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="181" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="182" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="183" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="184" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="185" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="186" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="187" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="188" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="189" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="190" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="191" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="192" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="193" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="194" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="195" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="196" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="197" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="198" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="199" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="200" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="201" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="202" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="203" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="204" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="205" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="206" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="207" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="208" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="209" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="210" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="211" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="212" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="213" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="214" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="215" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="216" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="217" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="218" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="219" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="220" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="221" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="222" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="223" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="224" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="225" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="226" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="227" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="228" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="229" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="230" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="231" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="232" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="233" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="234" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="235" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="236" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="237" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="238" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="239" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="240" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="241" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="242" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="243" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="244" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="245" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="246" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="247" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="248" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="249" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="250" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="251" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="252" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="253" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="254" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="255" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="256" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Acoustic Tone 1-128">
+      <Patch Number="001" Name="Full Grand 1" ProgramChange="0" />
+      <Patch Number="002" Name="Full Grand 2" ProgramChange="1" />
+      <Patch Number="003" Name="Full Grand 3" ProgramChange="2" />
+      <Patch Number="004" Name="Deep Grand" ProgramChange="3" />
+      <Patch Number="005" Name="BrightGrand" ProgramChange="4" />
+      <Patch Number="006" Name="UprightPiano" ProgramChange="5" />
+      <Patch Number="007" Name="Mono Grand" ProgramChange="6" />
+      <Patch Number="008" Name="Rock Grand" ProgramChange="7" />
+      <Patch Number="009" Name="HonkyTonk Pf" ProgramChange="8" />
+      <Patch Number="010" Name="'76 Pure" ProgramChange="9" />
+      <Patch Number="011" Name="'73 Pure" ProgramChange="10" />
+      <Patch Number="012" Name="'76 Stage" ProgramChange="11" />
+      <Patch Number="013" Name="'73 Stage" ProgramChange="12" />
+      <Patch Number="014" Name="'76 Tine" ProgramChange="13" />
+      <Patch Number="015" Name="'73 Tine" ProgramChange="14" />
+      <Patch Number="016" Name="'81 Tine" ProgramChange="15" />
+      <Patch Number="017" Name="Felt Tine" ProgramChange="16" />
+      <Patch Number="018" Name="Dyno Tine" ProgramChange="17" />
+      <Patch Number="019" Name="Tea Time" ProgramChange="18" />
+      <Patch Number="020" Name="Small Space" ProgramChange="19" />
+      <Patch Number="021" Name="Phaser Dyno" ProgramChange="20" />
+      <Patch Number="022" Name="90 Shift EP" ProgramChange="21" />
+      <Patch Number="023" Name="SlowSpin EP" ProgramChange="22" />
+      <Patch Number="024" Name="Phaser Tine" ProgramChange="23" />
+      <Patch Number="025" Name="TcDlyEP CC18" ProgramChange="24" />
+      <Patch Number="026" Name="Flanger Tine" ProgramChange="25" />
+      <Patch Number="027" Name="Chorus Tine" ProgramChange="26" />
+      <Patch Number="028" Name="JC ChorusEP" ProgramChange="27" />
+      <Patch Number="029" Name="Dirty Tine" ProgramChange="28" />
+      <Patch Number="030" Name="Pure Reed" ProgramChange="29" />
+      <Patch Number="031" Name="'68 Reed" ProgramChange="30" />
+      <Patch Number="032" Name="Vibrato Reed" ProgramChange="31" />
+      <Patch Number="033" Name="Dirty Reed" ProgramChange="32" />
+      <Patch Number="034" Name="Super Clav" ProgramChange="33" />
+      <Patch Number="035" Name="Pure ClavCA1" ProgramChange="34" />
+      <Patch Number="036" Name="Pure ClavCA2" ProgramChange="35" />
+      <Patch Number="037" Name="Pure ClavCB1" ProgramChange="36" />
+      <Patch Number="038" Name="Pure ClavCB2" ProgramChange="37" />
+      <Patch Number="039" Name="Deep Clav" ProgramChange="38" />
+      <Patch Number="040" Name="Drive Clav" ProgramChange="39" />
+      <Patch Number="041" Name="Dist Clav" ProgramChange="40" />
+      <Patch Number="042" Name="Phaser Clav1" ProgramChange="41" />
+      <Patch Number="043" Name="Phaser Clav2" ProgramChange="42" />
+      <Patch Number="044" Name="Spacy Clav" ProgramChange="43" />
+      <Patch Number="045" Name="SoftSpinClav" ProgramChange="44" />
+      <Patch Number="046" Name="Twah Clav" ProgramChange="45" />
+      <Patch Number="047" Name="Awah Clav" ProgramChange="46" />
+      <Patch Number="048" Name="PwahClv1CC18" ProgramChange="47" />
+      <Patch Number="049" Name="PwahClv2CC18" ProgramChange="48" />
+      <Patch Number="050" Name="B3 Jazz 1" ProgramChange="49" />
+      <Patch Number="051" Name="B3 Jazz 2" ProgramChange="50" />
+      <Patch Number="052" Name="B3 Jazz 3" ProgramChange="51" />
+      <Patch Number="053" Name="B3 Jazz 4" ProgramChange="52" />
+      <Patch Number="054" Name="B3 Jazz 5" ProgramChange="53" />
+      <Patch Number="055" Name="B3 Jazz 6" ProgramChange="54" />
+      <Patch Number="056" Name="B3 Jazz 7" ProgramChange="55" />
+      <Patch Number="057" Name="B3 Full D" ProgramChange="56" />
+      <Patch Number="058" Name="B3 Bossa" ProgramChange="57" />
+      <Patch Number="059" Name="C3 Rock 1" ProgramChange="58" />
+      <Patch Number="060" Name="C3 Rock 2" ProgramChange="59" />
+      <Patch Number="061" Name="C3 Rock 3" ProgramChange="60" />
+      <Patch Number="062" Name="C3 Rock 4" ProgramChange="61" />
+      <Patch Number="063" Name="C3 Rock 5" ProgramChange="62" />
+      <Patch Number="064" Name="C3 Rock 6" ProgramChange="63" />
+      <Patch Number="065" Name="Pure Wheel 1" ProgramChange="64" />
+      <Patch Number="066" Name="Pure Wheel 2" ProgramChange="65" />
+      <Patch Number="067" Name="Pure Wheel 3" ProgramChange="66" />
+      <Patch Number="068" Name="Nostalgie 1" ProgramChange="67" />
+      <Patch Number="069" Name="Nostalgie 2" ProgramChange="68" />
+      <Patch Number="070" Name="Nostalgie 3" ProgramChange="69" />
+      <Patch Number="071" Name="Nostalgie 4" ProgramChange="70" />
+      <Patch Number="072" Name="Clean Cutter" ProgramChange="71" />
+      <Patch Number="073" Name="Flanger Cut" ProgramChange="72" />
+      <Patch Number="074" Name="Funk Cutting" ProgramChange="73" />
+      <Patch Number="075" Name="PhaseCutting" ProgramChange="74" />
+      <Patch Number="076" Name="Retro Phaser" ProgramChange="75" />
+      <Patch Number="077" Name="Twah Cutting" ProgramChange="76" />
+      <Patch Number="078" Name="PwahCut CC18" ProgramChange="77" />
+      <Patch Number="079" Name="AutoWah Back" ProgramChange="78" />
+      <Patch Number="080" Name="FunkMeister" ProgramChange="79" />
+      <Patch Number="081" Name="CleanTheater" ProgramChange="80" />
+      <Patch Number="082" Name="Warm Clean" ProgramChange="81" />
+      <Patch Number="083" Name="DelayedTwin" ProgramChange="82" />
+      <Patch Number="084" Name="Crunch Phase" ProgramChange="83" />
+      <Patch Number="085" Name="Clean Twin" ProgramChange="84" />
+      <Patch Number="086" Name="Clean Spirit" ProgramChange="85" />
+      <Patch Number="087" Name="Flange Clean" ProgramChange="86" />
+      <Patch Number="088" Name="Heart Break" ProgramChange="87" />
+      <Patch Number="089" Name="T-Bird Surf" ProgramChange="88" />
+      <Patch Number="090" Name="ClassicClean" ProgramChange="89" />
+      <Patch Number="091" Name="Groove Clean" ProgramChange="90" />
+      <Patch Number="092" Name="JC-Chorus" ProgramChange="91" />
+      <Patch Number="093" Name="Sweet Home" ProgramChange="92" />
+      <Patch Number="094" Name="Transistor" ProgramChange="93" />
+      <Patch Number="095" Name="Smooth Clean" ProgramChange="94" />
+      <Patch Number="096" Name="NY Clean" ProgramChange="95" />
+      <Patch Number="097" Name="Clean Dirty" ProgramChange="96" />
+      <Patch Number="098" Name="60s BritRock" ProgramChange="97" />
+      <Patch Number="099" Name="StandardJazz" ProgramChange="98" />
+      <Patch Number="100" Name="FingeredJazz" ProgramChange="99" />
+      <Patch Number="101" Name="Modern Jazz" ProgramChange="100" />
+      <Patch Number="102" Name="Mr.Octave" ProgramChange="101" />
+      <Patch Number="103" Name="Bright Live" ProgramChange="102" />
+      <Patch Number="104" Name="Stack Lead" ProgramChange="103" />
+      <Patch Number="105" Name="USA Legend" ProgramChange="104" />
+      <Patch Number="106" Name="Lead Legend" ProgramChange="105" />
+      <Patch Number="107" Name="Rotary Riff" ProgramChange="106" />
+      <Patch Number="108" Name="Big Wing" ProgramChange="107" />
+      <Patch Number="109" Name="Crunch Chord" ProgramChange="108" />
+      <Patch Number="110" Name="60s Fuzz" ProgramChange="109" />
+      <Patch Number="111" Name="Cream Crunch" ProgramChange="110" />
+      <Patch Number="112" Name="Bunch Crunch" ProgramChange="111" />
+      <Patch Number="113" Name="Pwah OD CC18" ProgramChange="112" />
+      <Patch Number="114" Name="60s RockRiff" ProgramChange="113" />
+      <Patch Number="115" Name="70s RockRiff" ProgramChange="114" />
+      <Patch Number="116" Name="Texas Tusher" ProgramChange="115" />
+      <Patch Number="117" Name="Blues Master" ProgramChange="116" />
+      <Patch Number="118" Name="House Blues" ProgramChange="117" />
+      <Patch Number="119" Name="Apartment" ProgramChange="118" />
+      <Patch Number="120" Name="TWah Lead" ProgramChange="119" />
+      <Patch Number="121" Name="Warm Drive" ProgramChange="120" />
+      <Patch Number="122" Name="Hi-Gain Rock" ProgramChange="121" />
+      <Patch Number="123" Name="Metal Stack" ProgramChange="122" />
+      <Patch Number="124" Name="Purple Stack" ProgramChange="123" />
+      <Patch Number="125" Name="Lead Stack" ProgramChange="124" />
+      <Patch Number="126" Name="Cah Solo" ProgramChange="125" />
+      <Patch Number="127" Name="FeelGood Doc" ProgramChange="126" />
+      <Patch Number="128" Name="BullsOnRage" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Acoustic Tone 129-256">
+      <Patch Number="129" Name="Big Riff" ProgramChange="0" />
+      <Patch Number="130" Name="Hi-GainMetal" ProgramChange="1" />
+      <Patch Number="131" Name="Nice Touch" ProgramChange="2" />
+      <Patch Number="132" Name="Mild Solo" ProgramChange="3" />
+      <Patch Number="133" Name="Chorale" ProgramChange="4" />
+      <Patch Number="134" Name="PwahDst CC18" ProgramChange="5" />
+      <Patch Number="135" Name="Ac Bass 1" ProgramChange="6" />
+      <Patch Number="136" Name="Ac Bass 2" ProgramChange="7" />
+      <Patch Number="137" Name="Fing Bass 1" ProgramChange="8" />
+      <Patch Number="138" Name="Fing Bass 2" ProgramChange="9" />
+      <Patch Number="139" Name="Comp FingBs" ProgramChange="10" />
+      <Patch Number="140" Name="Phaser Fing1" ProgramChange="11" />
+      <Patch Number="141" Name="Phaser Fing2" ProgramChange="12" />
+      <Patch Number="142" Name="Slap Bass" ProgramChange="13" />
+      <Patch Number="143" Name="Pick Bass" ProgramChange="14" />
+      <Patch Number="144" Name="Muted Bass" ProgramChange="15" />
+      <Patch Number="145" Name="LowBoostPick" ProgramChange="16" />
+      <Patch Number="146" Name="OD Pick Bass" ProgramChange="17" />
+      <Patch Number="147" Name="Fretless 1" ProgramChange="18" />
+      <Patch Number="148" Name="Fretless 2" ProgramChange="19" />
+      <Patch Number="149" Name="CompFretless" ProgramChange="20" />
+      <Patch Number="150" Name="Mr.Fretless" ProgramChange="21" />
+      <Patch Number="151" Name="Classic Gtr" ProgramChange="22" />
+      <Patch Number="152" Name="Solid GutGt" ProgramChange="23" />
+      <Patch Number="153" Name="Gut Guitar" ProgramChange="24" />
+      <Patch Number="154" Name="Flamenco Gtr" ProgramChange="25" />
+      <Patch Number="155" Name="Rasgueado" ProgramChange="26" />
+      <Patch Number="156" Name="Warm Spanish" ProgramChange="27" />
+      <Patch Number="157" Name="ArpegSteelGt" ProgramChange="28" />
+      <Patch Number="158" Name="StrumSteelGt" ProgramChange="29" />
+      <Patch Number="159" Name="French Accrd" ProgramChange="30" />
+      <Patch Number="160" Name="ItalianAccrd" ProgramChange="31" />
+      <Patch Number="161" Name="Bandoneon 1" ProgramChange="32" />
+      <Patch Number="162" Name="Bandoneon 2" ProgramChange="33" />
+      <Patch Number="163" Name="Harmonica" ProgramChange="34" />
+      <Patch Number="164" Name="Southern" ProgramChange="35" />
+      <Patch Number="165" Name="Blues Reed" ProgramChange="36" />
+      <Patch Number="166" Name="Vibraphone" ProgramChange="37" />
+      <Patch Number="167" Name="Vibes Hard" ProgramChange="38" />
+      <Patch Number="168" Name="Vibes Trem" ProgramChange="39" />
+      <Patch Number="169" Name="Vibes Soft" ProgramChange="40" />
+      <Patch Number="170" Name="Marimba" ProgramChange="41" />
+      <Patch Number="171" Name="Marimba Soft" ProgramChange="42" />
+      <Patch Number="172" Name="Marimba Hard" ProgramChange="43" />
+      <Patch Number="173" Name="Glocken Hard" ProgramChange="44" />
+      <Patch Number="174" Name="Glocken Soft" ProgramChange="45" />
+      <Patch Number="175" Name="Glocken Cho" ProgramChange="46" />
+      <Patch Number="176" Name="Xylophone" ProgramChange="47" />
+      <Patch Number="177" Name="Hard Xylo" ProgramChange="48" />
+      <Patch Number="178" Name="TubulrBells1" ProgramChange="49" />
+      <Patch Number="179" Name="TubulrBells2" ProgramChange="50" />
+      <Patch Number="180" Name="Steel Drums" ProgramChange="51" />
+      <Patch Number="181" Name="Timpani" ProgramChange="52" />
+      <Patch Number="182" Name="Timpani Roll" ProgramChange="53" />
+      <Patch Number="183" Name="Harp" ProgramChange="54" />
+      <Patch Number="184" Name="Gliss Dim" ProgramChange="55" />
+      <Patch Number="185" Name="Gliss C Mixo" ProgramChange="56" />
+      <Patch Number="186" Name="Gliss C HMin" ProgramChange="57" />
+      <Patch Number="187" Name="Gliss C Dori" ProgramChange="58" />
+      <Patch Number="188" Name="Harp Nail" ProgramChange="59" />
+      <Patch Number="189" Name="Violin 1" ProgramChange="60" />
+      <Patch Number="190" Name="Violin 2" ProgramChange="61" />
+      <Patch Number="191" Name="Viola" ProgramChange="62" />
+      <Patch Number="192" Name="Cello 1" ProgramChange="63" />
+      <Patch Number="193" Name="Cello 2" ProgramChange="64" />
+      <Patch Number="194" Name="Contrabass" ProgramChange="65" />
+      <Patch Number="195" Name="Violin1 Pizz" ProgramChange="66" />
+      <Patch Number="196" Name="Violin2 Pizz" ProgramChange="67" />
+      <Patch Number="197" Name="Violin1 Stac" ProgramChange="68" />
+      <Patch Number="198" Name="Viola Pizz" ProgramChange="69" />
+      <Patch Number="199" Name="Cello1 Pizz" ProgramChange="70" />
+      <Patch Number="200" Name="Cello2 Pizz" ProgramChange="71" />
+      <Patch Number="201" Name="Cello1 Stac" ProgramChange="72" />
+      <Patch Number="202" Name="ContrabassPz" ProgramChange="73" />
+      <Patch Number="203" Name="StringsSect1" ProgramChange="74" />
+      <Patch Number="204" Name="StringsSect2" ProgramChange="75" />
+      <Patch Number="205" Name="5th Down Str" ProgramChange="76" />
+      <Patch Number="206" Name="Slow Strings" ProgramChange="77" />
+      <Patch Number="207" Name="Tape Strings" ProgramChange="78" />
+      <Patch Number="208" Name="Marcato Str" ProgramChange="79" />
+      <Patch Number="209" Name="MarcatoWarm" ProgramChange="80" />
+      <Patch Number="210" Name="Strings Stac" ProgramChange="81" />
+      <Patch Number="211" Name="Strings Pizz" ProgramChange="82" />
+      <Patch Number="212" Name="Strings Trem" ProgramChange="83" />
+      <Patch Number="213" Name="LargeChoirAh" ProgramChange="84" />
+      <Patch Number="214" Name="LargeChoirOo" ProgramChange="85" />
+      <Patch Number="215" Name="BoysChoir Ah" ProgramChange="86" />
+      <Patch Number="216" Name="BoysChoir Oo" ProgramChange="87" />
+      <Patch Number="217" Name="Choir Pad" ProgramChange="88" />
+      <Patch Number="218" Name="Trumpet 1" ProgramChange="89" />
+      <Patch Number="219" Name="Light Tp" ProgramChange="90" />
+      <Patch Number="220" Name="Mellow Tp" ProgramChange="91" />
+      <Patch Number="221" Name="MutedTrumpet" ProgramChange="92" />
+      <Patch Number="222" Name="Bold MuteTp" ProgramChange="93" />
+      <Patch Number="223" Name="DooBapMuteTp" ProgramChange="94" />
+      <Patch Number="224" Name="Wah Trumpet" ProgramChange="95" />
+      <Patch Number="225" Name="Trombone 1" ProgramChange="96" />
+      <Patch Number="226" Name="Breathy Tb" ProgramChange="97" />
+      <Patch Number="227" Name="Tb Staccato" ProgramChange="98" />
+      <Patch Number="228" Name="Muted Tb" ProgramChange="99" />
+      <Patch Number="229" Name="Bold MuteTb" ProgramChange="100" />
+      <Patch Number="230" Name="French Horn" ProgramChange="101" />
+      <Patch Number="231" Name="Sop Sax 1" ProgramChange="102" />
+      <Patch Number="232" Name="SopSax1 Soft" ProgramChange="103" />
+      <Patch Number="233" Name="Alto Sax 1" ProgramChange="104" />
+      <Patch Number="234" Name="A.Sax 1 Soft" ProgramChange="105" />
+      <Patch Number="235" Name="TenorSax 1" ProgramChange="106" />
+      <Patch Number="236" Name="T.Sax 1 Soft" ProgramChange="107" />
+      <Patch Number="237" Name="T.Sax Growl" ProgramChange="108" />
+      <Patch Number="238" Name="Bari Sax 1" ProgramChange="109" />
+      <Patch Number="239" Name="B.Sax 1 Soft" ProgramChange="110" />
+      <Patch Number="240" Name="Oboe 1" ProgramChange="111" />
+      <Patch Number="241" Name="Oboe 2" ProgramChange="112" />
+      <Patch Number="242" Name="Bassoon" ProgramChange="113" />
+      <Patch Number="243" Name="Clarinet 1" ProgramChange="114" />
+      <Patch Number="244" Name="Clarinet 2" ProgramChange="115" />
+      <Patch Number="245" Name="ClassicFlute" ProgramChange="116" />
+      <Patch Number="246" Name="Jazz Flute" ProgramChange="117" />
+      <Patch Number="247" Name="Piccolo Fl" ProgramChange="118" />
+      <Patch Number="248" Name="Pan Flute" ProgramChange="119" />
+      <Patch Number="249" Name="Sitar 1" ProgramChange="120" />
+      <Patch Number="250" Name="Sitar 2" ProgramChange="121" />
+      <Patch Number="251" Name="Elec Sitar" ProgramChange="122" />
+      <Patch Number="252" Name="Shakuhachi" ProgramChange="123" />
+      <Patch Number="253" Name="UilleanPipes" ProgramChange="124" />
+      <Patch Number="254" Name="Bag Pipes" ProgramChange="125" />
+      <Patch Number="255" Name="Erhu" ProgramChange="126" />
+      <Patch Number="256" Name="AirFromChina" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion SN Tone (ExSN1)">
+      <Patch Number="001" Name="YangChin 1" ProgramChange="0" />
+      <Patch Number="002" Name="YangChin 2" ProgramChange="1" />
+      <Patch Number="003" Name="YangChin 3" ProgramChange="2" />
+      <Patch Number="004" Name="Santoor 1" ProgramChange="3" />
+      <Patch Number="005" Name="Santoor 2" ProgramChange="4" />
+      <Patch Number="006" Name="Sarangi" ProgramChange="5" />
+      <Patch Number="007" Name="Ryuteki" ProgramChange="6" />
+      <Patch Number="008" Name="Kalimba" ProgramChange="7" />
+      <Patch Number="009" Name="Kalimba Buzz" ProgramChange="8" />
+      <Patch Number="010" Name="Tsugaru" ProgramChange="9" />
+      <Patch Number="011" Name="TsugaruUpPck" ProgramChange="10" />
+      <Patch Number="012" Name="Sanshin" ProgramChange="11" />
+      <Patch Number="013" Name="SanshinUpPck" ProgramChange="12" />
+      <Patch Number="014" Name="Koto" ProgramChange="13" />
+      <Patch Number="015" Name="Koto Gliss" ProgramChange="14" />
+      <Patch Number="016" Name="Taisho Koto" ProgramChange="15" />
+      <Patch Number="017" Name="Tin Whistle" ProgramChange="16" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion SN Tone (ExSN2)">
+      <Patch Number="001" Name="Sop Sax 2" ProgramChange="0" />
+      <Patch Number="002" Name="Alto Sax 2" ProgramChange="1" />
+      <Patch Number="003" Name="A.Sax Fuzz" ProgramChange="2" />
+      <Patch Number="004" Name="Tenor Sax 2" ProgramChange="3" />
+      <Patch Number="005" Name="T.Sax Blow" ProgramChange="4" />
+      <Patch Number="006" Name="Bari Sax 2" ProgramChange="5" />
+      <Patch Number="007" Name="Flute 2" ProgramChange="6" />
+      <Patch Number="008" Name="Bass Cl" ProgramChange="7" />
+      <Patch Number="009" Name="English Horn" ProgramChange="8" />
+      <Patch Number="010" Name="Sop Ocarina1" ProgramChange="9" />
+      <Patch Number="011" Name="Sop Ocarina2" ProgramChange="10" />
+      <Patch Number="012" Name="Alto Ocarina" ProgramChange="11" />
+      <Patch Number="013" Name="Bass Ocarina" ProgramChange="12" />
+      <Patch Number="014" Name="Sop Recorder" ProgramChange="13" />
+      <Patch Number="015" Name="AltoRecorder" ProgramChange="14" />
+      <Patch Number="016" Name="TenrRecorder" ProgramChange="15" />
+      <Patch Number="017" Name="BassRecorder" ProgramChange="16" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion SN Tone (ExSN3)">
+      <Patch Number="001" Name="Warm Cutting" ProgramChange="0" />
+      <Patch Number="002" Name="LP Clean" ProgramChange="1" />
+      <Patch Number="003" Name="LP Chorus" ProgramChange="2" />
+      <Patch Number="004" Name="Old Clean" ProgramChange="3" />
+      <Patch Number="005" Name="J.B. Goode" ProgramChange="4" />
+      <Patch Number="006" Name="60s Surfing" ProgramChange="5" />
+      <Patch Number="007" Name="Long Train" ProgramChange="6" />
+      <Patch Number="008" Name="Aero Dream" ProgramChange="7" />
+      <Patch Number="009" Name="Modern Blues" ProgramChange="8" />
+      <Patch Number="010" Name="Contemporary" ProgramChange="9" />
+      <Patch Number="011" Name="Progressive" ProgramChange="10" />
+      <Patch Number="012" Name="The Fingers" ProgramChange="11" />
+      <Patch Number="013" Name="Thumb Octave" ProgramChange="12" />
+      <Patch Number="014" Name="Jazz Clean" ProgramChange="13" />
+      <Patch Number="015" Name="Smooth Lead" ProgramChange="14" />
+      <Patch Number="016" Name="Early Blues" ProgramChange="15" />
+      <Patch Number="017" Name="BluesSession" ProgramChange="16" />
+      <Patch Number="018" Name="Hecka-Caster" ProgramChange="17" />
+      <Patch Number="019" Name="CountryShred" ProgramChange="18" />
+      <Patch Number="020" Name="Chorus Lead" ProgramChange="19" />
+      <Patch Number="021" Name="Bontique OD" ProgramChange="20" />
+      <Patch Number="022" Name="On The HWY" ProgramChange="21" />
+      <Patch Number="023" Name="Nu-Punk" ProgramChange="22" />
+      <Patch Number="024" Name="Driven Rock" ProgramChange="23" />
+      <Patch Number="025" Name="80s RockRiff" ProgramChange="24" />
+      <Patch Number="026" Name="The Erupting" ProgramChange="25" />
+      <Patch Number="027" Name="Texas Riff" ProgramChange="26" />
+      <Patch Number="028" Name="FX Lead" ProgramChange="27" />
+      <Patch Number="029" Name="R-Fier Lead" ProgramChange="28" />
+      <Patch Number="030" Name="Lead Flanger" ProgramChange="29" />
+      <Patch Number="031" Name="Bottom Line" ProgramChange="30" />
+      <Patch Number="032" Name="Soakin'Metal" ProgramChange="31" />
+      <Patch Number="033" Name="Walking Way" ProgramChange="32" />
+      <Patch Number="034" Name="Tone Journey" ProgramChange="33" />
+      <Patch Number="035" Name="Phatt Rock" ProgramChange="34" />
+      <Patch Number="036" Name="Jungle Guns" ProgramChange="35" />
+      <Patch Number="037" Name="Sweet Baby" ProgramChange="36" />
+      <Patch Number="038" Name="Baby DS CC18" ProgramChange="37" />
+      <Patch Number="039" Name="Upright Bs" ProgramChange="38" />
+      <Patch Number="040" Name="Rockabilly" ProgramChange="39" />
+      <Patch Number="041" Name="Jazz Bass 1" ProgramChange="40" />
+      <Patch Number="042" Name="Jazz Bass 2" ProgramChange="41" />
+      <Patch Number="043" Name="Comp JazzBs" ProgramChange="42" />
+      <Patch Number="044" Name="Phaser Jazz1" ProgramChange="43" />
+      <Patch Number="045" Name="Phaser Jazz2" ProgramChange="44" />
+      <Patch Number="046" Name="Slap Jazz" ProgramChange="45" />
+      <Patch Number="047" Name="Rock Bass" ProgramChange="46" />
+      <Patch Number="048" Name="Muted Rock" ProgramChange="47" />
+      <Patch Number="049" Name="Boost Rock" ProgramChange="48" />
+      <Patch Number="050" Name="Drive Bass" ProgramChange="49" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion SN Tone (ExSN4)">
+      <Patch Number="001" Name="12StringsGtr" ProgramChange="0" />
+      <Patch Number="002" Name="Deturned12Gt" ProgramChange="1" />
+      <Patch Number="003" Name="Ukulele" ProgramChange="2" />
+      <Patch Number="004" Name="UkuleleStrum" ProgramChange="3" />
+      <Patch Number="005" Name="FingSteelGtr" ProgramChange="4" />
+      <Patch Number="006" Name="FingStlStrum" ProgramChange="5" />
+      <Patch Number="007" Name="SoftPckStlGt" ProgramChange="6" />
+      <Patch Number="008" Name="SftPkStlStrm" ProgramChange="7" />
+      <Patch Number="009" Name="NylonGt2" ProgramChange="8" />
+      <Patch Number="010" Name="NylonGt2Strm" ProgramChange="9" />
+      <Patch Number="011" Name="MandolinGt" ProgramChange="10" />
+      <Patch Number="012" Name="MandolinStum" ProgramChange="11" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion SN Tone (ExSN5)">
+      <Patch Number="001" Name="Flugel Horn" ProgramChange="0" />
+      <Patch Number="002" Name="Trumpet 2" ProgramChange="1" />
+      <Patch Number="003" Name="Mariachi Tp" ProgramChange="2" />
+      <Patch Number="004" Name="Classic Tp" ProgramChange="3" />
+      <Patch Number="005" Name="CupMute Tp" ProgramChange="4" />
+      <Patch Number="006" Name="StraightMtTp" ProgramChange="5" />
+      <Patch Number="007" Name="FrenchHorn2" ProgramChange="6" />
+      <Patch Number="008" Name="FHorn2 Stc" ProgramChange="7" />
+      <Patch Number="009" Name="Trombone 2" ProgramChange="8" />
+      <Patch Number="010" Name="Bass Tb" ProgramChange="9" />
+      <Patch Number="011" Name="Tuba" ProgramChange="10" />
+      <Patch Number="012" Name="TubaStaccato" ProgramChange="11" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX01)">
+      <Patch Number="001" Name="Kick 1  Menu" ProgramChange="0" />
+      <Patch Number="002" Name="Kick 2  Menu" ProgramChange="1" />
+      <Patch Number="003" Name="Kick 3  Menu" ProgramChange="2" />
+      <Patch Number="004" Name="Kick 4  Menu" ProgramChange="3" />
+      <Patch Number="005" Name="OldFnkS Menu" ProgramChange="4" />
+      <Patch Number="006" Name="Latin S Menu" ProgramChange="5" />
+      <Patch Number="007" Name="HiPiccS Menu" ProgramChange="6" />
+      <Patch Number="008" Name="Tight S Menu" ProgramChange="7" />
+      <Patch Number="009" Name="StdRk1S Menu" ProgramChange="8" />
+      <Patch Number="010" Name="StdRk2S Menu" ProgramChange="9" />
+      <Patch Number="011" Name="OhBabyS Menu" ProgramChange="10" />
+      <Patch Number="012" Name="PoppinS Menu" ProgramChange="11" />
+      <Patch Number="013" Name="StdFatS Menu" ProgramChange="12" />
+      <Patch Number="014" Name="JazStkS Menu" ProgramChange="13" />
+      <Patch Number="015" Name="StdJazS Menu" ProgramChange="14" />
+      <Patch Number="016" Name="BalladS Menu" ProgramChange="15" />
+      <Patch Number="017" Name="PwrBldS Menu" ProgramChange="16" />
+      <Patch Number="018" Name="AlBeefS Menu" ProgramChange="17" />
+      <Patch Number="019" Name="BigRckS Menu" ProgramChange="18" />
+      <Patch Number="020" Name="70BrshS Menu" ProgramChange="19" />
+      <Patch Number="021" Name="JzBrshS Menu" ProgramChange="20" />
+      <Patch Number="022" Name="CrsStk  Menu" ProgramChange="21" />
+      <Patch Number="023" Name="Latin T Menu" ProgramChange="22" />
+      <Patch Number="024" Name="Tight T Menu" ProgramChange="23" />
+      <Patch Number="025" Name="JazStkT Menu" ProgramChange="24" />
+      <Patch Number="026" Name="OldFnkT Menu" ProgramChange="25" />
+      <Patch Number="027" Name="OhBabyT Menu" ProgramChange="26" />
+      <Patch Number="028" Name="PwrBldT Menu" ProgramChange="27" />
+      <Patch Number="029" Name="BigRckT Menu" ProgramChange="28" />
+      <Patch Number="030" Name="OldBrsT Menu" ProgramChange="29" />
+      <Patch Number="031" Name="OhBabyH Menu" ProgramChange="30" />
+      <Patch Number="032" Name="JazStkH Menu" ProgramChange="31" />
+      <Patch Number="033" Name="Latin H Menu" ProgramChange="32" />
+      <Patch Number="034" Name="Disco H Menu" ProgramChange="33" />
+      <Patch Number="035" Name="OldFnkH Menu" ProgramChange="34" />
+      <Patch Number="036" Name="StreetH Menu" ProgramChange="35" />
+      <Patch Number="037" Name="BigRckH Menu" ProgramChange="36" />
+      <Patch Number="038" Name="OldBrsH Menu" ProgramChange="37" />
+      <Patch Number="039" Name="Crash   Menu" ProgramChange="38" />
+      <Patch Number="040" Name="Ride    Menu" ProgramChange="39" />
+      <Patch Number="041" Name="OthrCym Menu" ProgramChange="40" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX02)">
+      <Patch Number="001" Name="PremierGrand" ProgramChange="0" />
+      <Patch Number="002" Name="Steady Grand" ProgramChange="1" />
+      <Patch Number="003" Name="DynamicGrand" ProgramChange="2" />
+      <Patch Number="004" Name="Concert Hall" ProgramChange="3" />
+      <Patch Number="005" Name="Bright Grand" ProgramChange="4" />
+      <Patch Number="006" Name="Classical" ProgramChange="5" />
+      <Patch Number="007" Name="SoftPdlGrand" ProgramChange="6" />
+      <Patch Number="008" Name="OnMicPremier" ProgramChange="7" />
+      <Patch Number="009" Name="OnMic Bright" ProgramChange="8" />
+      <Patch Number="010" Name="OnMicSoftPdl" ProgramChange="9" />
+      <Patch Number="011" Name="Premier Mono" ProgramChange="10" />
+      <Patch Number="012" Name="Bright Mono" ProgramChange="11" />
+      <Patch Number="013" Name="SoftPdl Mono" ProgramChange="12" />
+      <Patch Number="014" Name="Mellow Piano" ProgramChange="13" />
+      <Patch Number="015" Name="Enhanced Pno" ProgramChange="14" />
+      <Patch Number="016" Name="Comp.Piano" ProgramChange="15" />
+      <Patch Number="017" Name="HonkytonkPno" ProgramChange="16" />
+      <Patch Number="018" Name="NewAgeGrand1" ProgramChange="17" />
+      <Patch Number="019" Name="NewAgeGrand2" ProgramChange="18" />
+      <Patch Number="020" Name="Requiem" ProgramChange="19" />
+      <Patch Number="021" Name="Soundscape" ProgramChange="20" />
+      <Patch Number="022" Name="Grand w/Str" ProgramChange="21" />
+      <Patch Number="023" Name="Concerto 1" ProgramChange="22" />
+      <Patch Number="024" Name="Concerto 2" ProgramChange="23" />
+      <Patch Number="025" Name="SoftpadGrand" ProgramChange="24" />
+      <Patch Number="026" Name="Synpad Grand" ProgramChange="25" />
+      <Patch Number="027" Name="Vox Grand 1" ProgramChange="26" />
+      <Patch Number="028" Name="Vox Grand 2" ProgramChange="27" />
+      <Patch Number="029" Name="Oohs Piano" ProgramChange="28" />
+      <Patch Number="030" Name="Air Grand" ProgramChange="29" />
+      <Patch Number="031" Name="GtrPad Grand" ProgramChange="30" />
+      <Patch Number="032" Name="PhasePad Pno" ProgramChange="31" />
+      <Patch Number="033" Name="HeavenPadPno" ProgramChange="32" />
+      <Patch Number="034" Name="Somber Pad" ProgramChange="33" />
+      <Patch Number="035" Name="Wet Chorus" ProgramChange="34" />
+      <Patch Number="036" Name="Nylon Grand" ProgramChange="35" />
+      <Patch Number="037" Name="FM EP Grand" ProgramChange="36" />
+      <Patch Number="038" Name="Bell Grand" ProgramChange="37" />
+      <Patch Number="039" Name="Bellvox Pno" ProgramChange="38" />
+      <Patch Number="040" Name="StackedGrand" ProgramChange="39" />
+      <Patch Number="041" Name="Hard Stack 1" ProgramChange="40" />
+      <Patch Number="042" Name="Hard Stack 2" ProgramChange="41" />
+      <Patch Number="043" Name="PianoBrass" ProgramChange="42" />
+      <Patch Number="044" Name="PianoBrs fff" ProgramChange="43" />
+      <Patch Number="045" Name="Gig Split 1" ProgramChange="44" />
+      <Patch Number="046" Name="Gig Split 2" ProgramChange="45" />
+      <Patch Number="047" Name="Gig Split 3" ProgramChange="46" />
+      <Patch Number="048" Name="Throb Piano" ProgramChange="47" />
+      <Patch Number="049" Name="Feedback Pno" ProgramChange="48" />
+      <Patch Number="050" Name="Eastern 5th" ProgramChange="49" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX03)">
+      <Patch Number="001" Name="Y2K Plus One" ProgramChange="0" />
+      <Patch Number="002" Name="Pastoral" ProgramChange="1" />
+      <Patch Number="003" Name="Majestic" ProgramChange="2" />
+      <Patch Number="004" Name="Twin Strings" ProgramChange="3" />
+      <Patch Number="005" Name="Taxi EP" ProgramChange="4" />
+      <Patch Number="006" Name="Peru Heights" ProgramChange="5" />
+      <Patch Number="007" Name="String Cloud" ProgramChange="6" />
+      <Patch Number="008" Name="Mysteria" ProgramChange="7" />
+      <Patch Number="009" Name="Mutes To Go" ProgramChange="8" />
+      <Patch Number="010" Name="HeavyMute/sw" ProgramChange="9" />
+      <Patch Number="011" Name="Wheel D-bar" ProgramChange="10" />
+      <Patch Number="012" Name="Kid's Glory" ProgramChange="11" />
+      <Patch Number="013" Name="GuitarInMist" ProgramChange="12" />
+      <Patch Number="014" Name="Overdrones" ProgramChange="13" />
+      <Patch Number="015" Name="RockAcoustic" ProgramChange="14" />
+      <Patch Number="016" Name="Piano Duel" ProgramChange="15" />
+      <Patch Number="017" Name="Chorus LA" ProgramChange="16" />
+      <Patch Number="018" Name="70's Blend" ProgramChange="17" />
+      <Patch Number="019" Name="OctopusPiano" ProgramChange="18" />
+      <Patch Number="020" Name="Rehoisal" ProgramChange="19" />
+      <Patch Number="021" Name="US EP" ProgramChange="20" />
+      <Patch Number="022" Name="Studio EP" ProgramChange="21" />
+      <Patch Number="023" Name="All EP" ProgramChange="22" />
+      <Patch Number="024" Name="Sens. EP" ProgramChange="23" />
+      <Patch Number="025" Name="Harmonic Seq" ProgramChange="24" />
+      <Patch Number="026" Name="Still drumin" ProgramChange="25" />
+      <Patch Number="027" Name="B3 Mod/Aft" ProgramChange="26" />
+      <Patch Number="028" Name="B3 Perc" ProgramChange="27" />
+      <Patch Number="029" Name="DynOrgan" ProgramChange="28" />
+      <Patch Number="030" Name="Voxx Organ" ProgramChange="29" />
+      <Patch Number="031" Name="South Border" ProgramChange="30" />
+      <Patch Number="032" Name="Bright Nyle" ProgramChange="31" />
+      <Patch Number="033" Name="Rolin'Fingrs" ProgramChange="32" />
+      <Patch Number="034" Name="Nylon Vel" ProgramChange="33" />
+      <Patch Number="035" Name="Flamenco&amp;Gtr" ProgramChange="34" />
+      <Patch Number="036" Name="Studio 12Str" ProgramChange="35" />
+      <Patch Number="037" Name="All AGuitars" ProgramChange="36" />
+      <Patch Number="038" Name="RichElec12st" ProgramChange="37" />
+      <Patch Number="039" Name="Electro-Ac." ProgramChange="38" />
+      <Patch Number="040" Name="Jazzy /Slide" ProgramChange="39" />
+      <Patch Number="041" Name="Clean Comp" ProgramChange="40" />
+      <Patch Number="042" Name="Jazz Clean" ProgramChange="41" />
+      <Patch Number="043" Name="Jazz VelOct" ProgramChange="42" />
+      <Patch Number="044" Name="335 Amp+Chrs" ProgramChange="43" />
+      <Patch Number="045" Name="Switched On" ProgramChange="44" />
+      <Patch Number="046" Name="Tremolo Gtr" ProgramChange="45" />
+      <Patch Number="047" Name="NoThat Clean" ProgramChange="46" />
+      <Patch Number="048" Name="OhWow Guitar" ProgramChange="47" />
+      <Patch Number="049" Name="RED 5ths" ProgramChange="48" />
+      <Patch Number="050" Name="Touch Solo" ProgramChange="49" />
+      <Patch Number="051" Name="Fingr Tap'n" ProgramChange="50" />
+      <Patch Number="052" Name="Blues Grunge" ProgramChange="51" />
+      <Patch Number="053" Name="6-Str Bass" ProgramChange="52" />
+      <Patch Number="054" Name="Thumb&amp;PullBs" ProgramChange="53" />
+      <Patch Number="055" Name="42nd Bass" ProgramChange="54" />
+      <Patch Number="056" Name="Mr. Jazz" ProgramChange="55" />
+      <Patch Number="057" Name="Picked JBass" ProgramChange="56" />
+      <Patch Number="058" Name="Upright Pizz" ProgramChange="57" />
+      <Patch Number="059" Name="Gt/BsNz MENU" ProgramChange="58" />
+      <Patch Number="060" Name="Lo Pizz Sect" ProgramChange="59" />
+      <Patch Number="061" Name="Octo Orch" ProgramChange="60" />
+      <Patch Number="062" Name="WindsFX MENU" ProgramChange="61" />
+      <Patch Number="063" Name="FluteVibrato" ProgramChange="62" />
+      <Patch Number="064" Name="Legato Flt 3" ProgramChange="63" />
+      <Patch Number="065" Name="Alto Flute" ProgramChange="64" />
+      <Patch Number="066" Name="Atk Flute" ProgramChange="65" />
+      <Patch Number="067" Name="SpaceFlute 2" ProgramChange="66" />
+      <Patch Number="068" Name="The Pan Pipe" ProgramChange="67" />
+      <Patch Number="069" Name="Breathy Pan" ProgramChange="68" />
+      <Patch Number="070" Name="Moceno" ProgramChange="69" />
+      <Patch Number="071" Name="Puffers" ProgramChange="70" />
+      <Patch Number="072" Name="Amazone" ProgramChange="71" />
+      <Patch Number="073" Name="Aztek ketzA" ProgramChange="72" />
+      <Patch Number="074" Name="Afro Flute" ProgramChange="73" />
+      <Patch Number="075" Name="SingingFlute" ProgramChange="74" />
+      <Patch Number="076" Name="GTR/Flt Scat" ProgramChange="75" />
+      <Patch Number="077" Name="Vox/Flt Scat" ProgramChange="76" />
+      <Patch Number="078" Name="Tape Flute" ProgramChange="77" />
+      <Patch Number="079" Name="Solo Trumpet" ProgramChange="78" />
+      <Patch Number="080" Name="Penny Tpt" ProgramChange="79" />
+      <Patch Number="081" Name="Mello TrBone" ProgramChange="80" />
+      <Patch Number="082" Name="DynamicBones" ProgramChange="81" />
+      <Patch Number="083" Name="Trumps&amp;Bones" ProgramChange="82" />
+      <Patch Number="084" Name="Bigger Brass" ProgramChange="83" />
+      <Patch Number="085" Name="Brass Cooker" ProgramChange="84" />
+      <Patch Number="086" Name="Mod Sfz" ProgramChange="85" />
+      <Patch Number="087" Name="After Hours" ProgramChange="86" />
+      <Patch Number="088" Name="Mic'd Mute" ProgramChange="87" />
+      <Patch Number="089" Name="WarmBrsPad" ProgramChange="88" />
+      <Patch Number="090" Name="VCOs and As" ProgramChange="89" />
+      <Patch Number="091" Name="MG Brass" ProgramChange="90" />
+      <Patch Number="092" Name="Alto Sax Vel" ProgramChange="91" />
+      <Patch Number="093" Name="Honky Tenor" ProgramChange="92" />
+      <Patch Number="094" Name="Barely Bari" ProgramChange="93" />
+      <Patch Number="095" Name="Sax Sect mp" ProgramChange="94" />
+      <Patch Number="096" Name="Saxx-shun" ProgramChange="95" />
+      <Patch Number="097" Name="Psycho Sax" ProgramChange="96" />
+      <Patch Number="098" Name="HardSlidLead" ProgramChange="97" />
+      <Patch Number="099" Name="MonoLeads x2" ProgramChange="98" />
+      <Patch Number="100" Name="Tiny Love" ProgramChange="99" />
+      <Patch Number="101" Name="Soft Jup' LD" ProgramChange="100" />
+      <Patch Number="102" Name="MultiTap OB" ProgramChange="101" />
+      <Patch Number="103" Name="Night Blade" ProgramChange="102" />
+      <Patch Number="104" Name="Velo OB Str" ProgramChange="103" />
+      <Patch Number="105" Name="Meadow" ProgramChange="104" />
+      <Patch Number="106" Name="OB 5th Strng" ProgramChange="105" />
+      <Patch Number="107" Name="GhettoStrngz" ProgramChange="106" />
+      <Patch Number="108" Name="Octa Poly" ProgramChange="107" />
+      <Patch Number="109" Name="Pipewind" ProgramChange="108" />
+      <Patch Number="110" Name="Big &amp; Gentle" ProgramChange="109" />
+      <Patch Number="111" Name="Ethernal" ProgramChange="110" />
+      <Patch Number="112" Name="3D MovingPad" ProgramChange="111" />
+      <Patch Number="113" Name="VintgStackSt" ProgramChange="112" />
+      <Patch Number="114" Name="St.ChldChoir" ProgramChange="113" />
+      <Patch Number="115" Name="HybrdChoirVS" ProgramChange="114" />
+      <Patch Number="116" Name="Swirly Mist" ProgramChange="115" />
+      <Patch Number="117" Name="St M+F Choir" ProgramChange="116" />
+      <Patch Number="118" Name="Cool Choir" ProgramChange="117" />
+      <Patch Number="119" Name="Mutatovox" ProgramChange="118" />
+      <Patch Number="120" Name="Dance Doos" ProgramChange="119" />
+      <Patch Number="121" Name="Dance OB" ProgramChange="120" />
+      <Patch Number="122" Name="Sliced Bread" ProgramChange="121" />
+      <Patch Number="123" Name="On&amp;On&amp;On" ProgramChange="122" />
+      <Patch Number="124" Name="Temptation" ProgramChange="123" />
+      <Patch Number="125" Name="Old Cartoon" ProgramChange="124" />
+      <Patch Number="126" Name="Swingtime" ProgramChange="125" />
+      <Patch Number="127" Name="Solar Winds" ProgramChange="126" />
+      <Patch Number="128" Name="Western" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX04)">
+      <Patch Number="001" Name="Epic Strings" ProgramChange="0" />
+      <Patch Number="002" Name="sfz! Crsc/sw" ProgramChange="1" />
+      <Patch Number="003" Name="Trem/sw Fine" ProgramChange="2" />
+      <Patch Number="004" Name="Fast Stac/sw" ProgramChange="3" />
+      <Patch Number="005" Name="Str Attack" ProgramChange="4" />
+      <Patch Number="006" Name="Full Pizz mp" ProgramChange="5" />
+      <Patch Number="007" Name="Violins ^/sw" ProgramChange="6" />
+      <Patch Number="008" Name="Violas ^/sw" ProgramChange="7" />
+      <Patch Number="009" Name="Celli  ^/sw" ProgramChange="8" />
+      <Patch Number="010" Name="Basses ^/sw" ProgramChange="9" />
+      <Patch Number="011" Name="Fast Section" ProgramChange="10" />
+      <Patch Number="012" Name="F.Str  ^/sw" ProgramChange="11" />
+      <Patch Number="013" Name="SymphStrings" ProgramChange="12" />
+      <Patch Number="014" Name="SymphStrngs2" ProgramChange="13" />
+      <Patch Number="015" Name="Vibrato /Aft" ProgramChange="14" />
+      <Patch Number="016" Name="Expressimo" ProgramChange="15" />
+      <Patch Number="017" Name="Spc release" ProgramChange="16" />
+      <Patch Number="018" Name="Hall Strings" ProgramChange="17" />
+      <Patch Number="019" Name="Warm Section" ProgramChange="18" />
+      <Patch Number="020" Name="4Section ^" ProgramChange="19" />
+      <Patch Number="021" Name="4Section Vib" ProgramChange="20" />
+      <Patch Number="022" Name="Sad Strings2" ProgramChange="21" />
+      <Patch Number="023" Name="Pizz&amp;ArcSplt" ProgramChange="22" />
+      <Patch Number="024" Name="So Swell" ProgramChange="23" />
+      <Patch Number="025" Name="Full Section" ProgramChange="24" />
+      <Patch Number="026" Name="Vibrato /sw" ProgramChange="25" />
+      <Patch Number="027" Name="Octave ^" ProgramChange="26" />
+      <Patch Number="028" Name="Full Sect 2" ProgramChange="27" />
+      <Patch Number="029" Name="Attack Sect" ProgramChange="28" />
+      <Patch Number="030" Name="Velo Strings" ProgramChange="29" />
+      <Patch Number="031" Name="Full Tremolo" ProgramChange="30" />
+      <Patch Number="032" Name="Trem Decresc" ProgramChange="31" />
+      <Patch Number="033" Name="Tension Trem" ProgramChange="32" />
+      <Patch Number="034" Name="F.StrTrm/Mrc" ProgramChange="33" />
+      <Patch Number="035" Name="F.Str Trm/sw" ProgramChange="34" />
+      <Patch Number="036" Name="Trm /Mod&amp;Aft" ProgramChange="35" />
+      <Patch Number="037" Name="F.Str/ModTrm" ProgramChange="36" />
+      <Patch Number="038" Name="Spc Marc /sw" ProgramChange="37" />
+      <Patch Number="039" Name="WarmStaccSec" ProgramChange="38" />
+      <Patch Number="040" Name="StackNirvana" ProgramChange="39" />
+      <Patch Number="041" Name="Spc Sect.8va" ProgramChange="40" />
+      <Patch Number="042" Name="Spc-Mrc /sw" ProgramChange="41" />
+      <Patch Number="043" Name="Mrc-Spc /sw" ProgramChange="42" />
+      <Patch Number="044" Name="Full Spc /sw" ProgramChange="43" />
+      <Patch Number="045" Name="Marc &amp; Pizz" ProgramChange="44" />
+      <Patch Number="046" Name="PizzL+SpiccR" ProgramChange="45" />
+      <Patch Number="047" Name="Pizz Sect" ProgramChange="46" />
+      <Patch Number="048" Name="Full Pizz pp" ProgramChange="47" />
+      <Patch Number="049" Name="Full Pizz ff" ProgramChange="48" />
+      <Patch Number="050" Name="4Sect. Pz ff" ProgramChange="49" />
+      <Patch Number="051" Name="Double Pizz" ProgramChange="50" />
+      <Patch Number="052" Name="sfz! Vln /sw" ProgramChange="51" />
+      <Patch Number="053" Name="Violin Sect1" ProgramChange="52" />
+      <Patch Number="054" Name="Violin Sect2" ProgramChange="53" />
+      <Patch Number="055" Name="Violin Sect3" ProgramChange="54" />
+      <Patch Number="056" Name="Warm Vln Sec" ProgramChange="55" />
+      <Patch Number="057" Name="GrandVln&amp;Vcs" ProgramChange="56" />
+      <Patch Number="058" Name="Vln Sect mp" ProgramChange="57" />
+      <Patch Number="059" Name="Slow Atk Vln" ProgramChange="58" />
+      <Patch Number="060" Name="Vln/Mod Pizz" ProgramChange="59" />
+      <Patch Number="061" Name="Vln  Stc/Mrc" ProgramChange="60" />
+      <Patch Number="062" Name="Vn Piz/Spcff" ProgramChange="61" />
+      <Patch Number="063" Name="Vln Marcato" ProgramChange="62" />
+      <Patch Number="064" Name="Vln Pizz /sw" ProgramChange="63" />
+      <Patch Number="065" Name="sfz! Va /sw" ProgramChange="64" />
+      <Patch Number="066" Name="Viola Sect 1" ProgramChange="65" />
+      <Patch Number="067" Name="Viola Sect 2" ProgramChange="66" />
+      <Patch Number="068" Name="Va  Stc/Mrc" ProgramChange="67" />
+      <Patch Number="069" Name="Va /Mod Pizz" ProgramChange="68" />
+      <Patch Number="070" Name="Va Marcato" ProgramChange="69" />
+      <Patch Number="071" Name="Va Pizz /sw" ProgramChange="70" />
+      <Patch Number="072" Name="sfz! Vc /sw" ProgramChange="71" />
+      <Patch Number="073" Name="Cello Sect 1" ProgramChange="72" />
+      <Patch Number="074" Name="Cello Sect 2" ProgramChange="73" />
+      <Patch Number="075" Name="Warm Vc Sect" ProgramChange="74" />
+      <Patch Number="076" Name="Vc Pizz /sw" ProgramChange="75" />
+      <Patch Number="077" Name="Vc /Mod Pizz" ProgramChange="76" />
+      <Patch Number="078" Name="Vc Marcato" ProgramChange="77" />
+      <Patch Number="079" Name="Vc  Stc/Mrc" ProgramChange="78" />
+      <Patch Number="080" Name="Vc Piz/Spcff" ProgramChange="79" />
+      <Patch Number="081" Name="sfz! Cb /sw" ProgramChange="80" />
+      <Patch Number="082" Name="Cb /Mod Pizz" ProgramChange="81" />
+      <Patch Number="083" Name="Bass Sect 1" ProgramChange="82" />
+      <Patch Number="084" Name="Cbs Marcato" ProgramChange="83" />
+      <Patch Number="085" Name="Cbs  Stc/Mrc" ProgramChange="84" />
+      <Patch Number="086" Name="Cbs Pizz /sw" ProgramChange="85" />
+      <Patch Number="087" Name="Symphonique2" ProgramChange="86" />
+      <Patch Number="088" Name="Soundtrk Str" ProgramChange="87" />
+      <Patch Number="089" Name="LargeStrings" ProgramChange="88" />
+      <Patch Number="090" Name="Slow Atk Str" ProgramChange="89" />
+      <Patch Number="091" Name="LushStrings2" ProgramChange="90" />
+      <Patch Number="092" Name="Pop Strings" ProgramChange="91" />
+      <Patch Number="093" Name="102 Violins" ProgramChange="92" />
+      <Patch Number="094" Name="MultiStakato" ProgramChange="93" />
+      <Patch Number="095" Name="Spicatto Arp" ProgramChange="94" />
+      <Patch Number="096" Name="Dim. Pizz" ProgramChange="95" />
+      <Patch Number="097" Name="RhythmicPizz" ProgramChange="96" />
+      <Patch Number="098" Name="Harp StrPad" ProgramChange="97" />
+      <Patch Number="099" Name="Trem-Guitar" ProgramChange="98" />
+      <Patch Number="100" Name="Baroque Ens2" ProgramChange="99" />
+      <Patch Number="101" Name="ImitatEP Pad" ProgramChange="100" />
+      <Patch Number="102" Name="Daybreak Ens" ProgramChange="101" />
+      <Patch Number="103" Name="Grand Unison" ProgramChange="102" />
+      <Patch Number="104" Name="Va Sect&amp;Glkn" ProgramChange="103" />
+      <Patch Number="105" Name="SRX Symphony" ProgramChange="104" />
+      <Patch Number="106" Name="XV Orchestra" ProgramChange="105" />
+      <Patch Number="107" Name="Full Orch 1" ProgramChange="106" />
+      <Patch Number="108" Name="Orc with Str" ProgramChange="107" />
+      <Patch Number="109" Name="Symphnic Orc" ProgramChange="108" />
+      <Patch Number="110" Name="Strings&amp;Hrns" ProgramChange="109" />
+      <Patch Number="111" Name="Strgs&amp;Hrns 2" ProgramChange="110" />
+      <Patch Number="112" Name="Octa StrEns" ProgramChange="111" />
+      <Patch Number="113" Name="Antique Str" ProgramChange="112" />
+      <Patch Number="114" Name="SweepSectStr" ProgramChange="113" />
+      <Patch Number="115" Name="Stereo Tron!" ProgramChange="114" />
+      <Patch Number="116" Name="Horror Str." ProgramChange="115" />
+      <Patch Number="117" Name="DanzSurround" ProgramChange="116" />
+      <Patch Number="118" Name="Ether Strngs" ProgramChange="117" />
+      <Patch Number="119" Name="MoveFX Str" ProgramChange="118" />
+      <Patch Number="120" Name="Phase /Aft" ProgramChange="119" />
+      <Patch Number="121" Name="PhazeStrngs2" ProgramChange="120" />
+      <Patch Number="122" Name="Reverse Str2" ProgramChange="121" />
+      <Patch Number="123" Name="Haunted" ProgramChange="122" />
+      <Patch Number="124" Name="Rewind Vln" ProgramChange="123" />
+      <Patch Number="125" Name="Synthy Sweep" ProgramChange="124" />
+      <Patch Number="126" Name="Ripple" ProgramChange="125" />
+      <Patch Number="127" Name="Mystery 2" ProgramChange="126" />
+      <Patch Number="128" Name="Rising STR" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX05) 1-128">
+      <Patch Number="001" Name="SecretDancer" ProgramChange="0" />
+      <Patch Number="002" Name="Mean Streets" ProgramChange="1" />
+      <Patch Number="003" Name="E-tronic" ProgramChange="2" />
+      <Patch Number="004" Name="License2chil" ProgramChange="3" />
+      <Patch Number="005" Name="Scratch Menu" ProgramChange="4" />
+      <Patch Number="006" Name="Hit Specials" ProgramChange="5" />
+      <Patch Number="007" Name="Motivation" ProgramChange="6" />
+      <Patch Number="008" Name="Sine Vibrato" ProgramChange="7" />
+      <Patch Number="009" Name="Acid Punch" ProgramChange="8" />
+      <Patch Number="010" Name="E.Gtr Menu" ProgramChange="9" />
+      <Patch Number="011" Name="Brite Flange" ProgramChange="10" />
+      <Patch Number="012" Name="Dance Vibes" ProgramChange="11" />
+      <Patch Number="013" Name="N-Trance" ProgramChange="12" />
+      <Patch Number="014" Name="Phatt" ProgramChange="13" />
+      <Patch Number="015" Name="DoubleDown" ProgramChange="14" />
+      <Patch Number="016" Name="LoopFX Dark" ProgramChange="15" />
+      <Patch Number="017" Name="Yo DJ" ProgramChange="16" />
+      <Patch Number="018" Name="HH Piledrivr" ProgramChange="17" />
+      <Patch Number="019" Name="Trush Head" ProgramChange="18" />
+      <Patch Number="020" Name="Rap 21" ProgramChange="19" />
+      <Patch Number="021" Name="Teknobeat" ProgramChange="20" />
+      <Patch Number="022" Name="Filter Beat" ProgramChange="21" />
+      <Patch Number="023" Name="FashionStyle" ProgramChange="22" />
+      <Patch Number="024" Name="Strobobeat" ProgramChange="23" />
+      <Patch Number="025" Name="SpaceGroove2" ProgramChange="24" />
+      <Patch Number="026" Name="Underground" ProgramChange="25" />
+      <Patch Number="027" Name="Extra Drive" ProgramChange="26" />
+      <Patch Number="028" Name="NakedPrey" ProgramChange="27" />
+      <Patch Number="029" Name="Mod It!" ProgramChange="28" />
+      <Patch Number="030" Name="Broken'Roll" ProgramChange="29" />
+      <Patch Number="031" Name="Drew Groove" ProgramChange="30" />
+      <Patch Number="032" Name="Beat Menu" ProgramChange="31" />
+      <Patch Number="033" Name="Sinewave Bs" ProgramChange="32" />
+      <Patch Number="034" Name="808 Bass" ProgramChange="33" />
+      <Patch Number="035" Name="Low Bass 2" ProgramChange="34" />
+      <Patch Number="036" Name="Low Bass 3" ProgramChange="35" />
+      <Patch Number="037" Name="Low Bass 4" ProgramChange="36" />
+      <Patch Number="038" Name="Hood Bass 2" ProgramChange="37" />
+      <Patch Number="039" Name="Rubber Bs 21" ProgramChange="38" />
+      <Patch Number="040" Name="Cheezee Bass" ProgramChange="39" />
+      <Patch Number="041" Name="Bend Bs /sw" ProgramChange="40" />
+      <Patch Number="042" Name="Saws Bass" ProgramChange="41" />
+      <Patch Number="043" Name="Bass Kadett" ProgramChange="42" />
+      <Patch Number="044" Name="Qube Bass" ProgramChange="43" />
+      <Patch Number="045" Name="LegatoSynBs" ProgramChange="44" />
+      <Patch Number="046" Name="15inch Bass" ProgramChange="45" />
+      <Patch Number="047" Name="MG Filter Bs" ProgramChange="46" />
+      <Patch Number="048" Name="Plk Bass" ProgramChange="47" />
+      <Patch Number="049" Name="Flat SawBass" ProgramChange="48" />
+      <Patch Number="050" Name="SH-101 Bass" ProgramChange="49" />
+      <Patch Number="051" Name="Pulsing Bs" ProgramChange="50" />
+      <Patch Number="052" Name="Arrpy" ProgramChange="51" />
+      <Patch Number="053" Name="Acid Bass 2" ProgramChange="52" />
+      <Patch Number="054" Name="Euro Bass 21" ProgramChange="53" />
+      <Patch Number="055" Name="DarkEchoBass" ProgramChange="54" />
+      <Patch Number="056" Name="UnisonSwBass" ProgramChange="55" />
+      <Patch Number="057" Name="Dirty Bass" ProgramChange="56" />
+      <Patch Number="058" Name="Comp NzBass" ProgramChange="57" />
+      <Patch Number="059" Name="JunoDistBass" ProgramChange="58" />
+      <Patch Number="060" Name="TB Dist Bs 1" ProgramChange="59" />
+      <Patch Number="061" Name="TB Dist Bs 2" ProgramChange="60" />
+      <Patch Number="062" Name="TB Dist Bs 3" ProgramChange="61" />
+      <Patch Number="063" Name="Human Bass" ProgramChange="62" />
+      <Patch Number="064" Name="Interferenz" ProgramChange="63" />
+      <Patch Number="065" Name="16th SeqBass" ProgramChange="64" />
+      <Patch Number="066" Name="Woofer Blow" ProgramChange="65" />
+      <Patch Number="067" Name="Guitaron Oct" ProgramChange="66" />
+      <Patch Number="068" Name="Finger Bass6" ProgramChange="67" />
+      <Patch Number="069" Name="Noisy P.Bass" ProgramChange="68" />
+      <Patch Number="070" Name="FeelBass" ProgramChange="69" />
+      <Patch Number="071" Name="Ethno Bass 3" ProgramChange="70" />
+      <Patch Number="072" Name="FAT Rave" ProgramChange="71" />
+      <Patch Number="073" Name="JUNO Rave" ProgramChange="72" />
+      <Patch Number="074" Name="4 x Saws" ProgramChange="73" />
+      <Patch Number="075" Name="Euro Saws" ProgramChange="74" />
+      <Patch Number="076" Name="Super Sawz" ProgramChange="75" />
+      <Patch Number="077" Name="Step Phaser" ProgramChange="76" />
+      <Patch Number="078" Name="Vade Retro" ProgramChange="77" />
+      <Patch Number="079" Name="Pulse Keys" ProgramChange="78" />
+      <Patch Number="080" Name="P5 Pluck" ProgramChange="79" />
+      <Patch Number="081" Name="Alpha Waves" ProgramChange="80" />
+      <Patch Number="082" Name="Andes" ProgramChange="81" />
+      <Patch Number="083" Name="Northern Pls" ProgramChange="82" />
+      <Patch Number="084" Name="R&amp;B Pluck 2" ProgramChange="83" />
+      <Patch Number="085" Name="SynHarpsi" ProgramChange="84" />
+      <Patch Number="086" Name="Saw Wave HQ" ProgramChange="85" />
+      <Patch Number="087" Name="Sqr Wave HQ" ProgramChange="86" />
+      <Patch Number="088" Name="JU2 Wave 1" ProgramChange="87" />
+      <Patch Number="089" Name="JU2 Wave 2" ProgramChange="88" />
+      <Patch Number="090" Name="Pulse Wave 1" ProgramChange="89" />
+      <Patch Number="091" Name="Pulse Wave 2" ProgramChange="90" />
+      <Patch Number="092" Name="SpectrumWave" ProgramChange="91" />
+      <Patch Number="093" Name="Pure Sine 2" ProgramChange="92" />
+      <Patch Number="094" Name="Slippers" ProgramChange="93" />
+      <Patch Number="095" Name="Climb Maj7th" ProgramChange="94" />
+      <Patch Number="096" Name="Return2Minor" ProgramChange="95" />
+      <Patch Number="097" Name="FallingStar" ProgramChange="96" />
+      <Patch Number="098" Name="Convulsions" ProgramChange="97" />
+      <Patch Number="099" Name="CrazZzeee" ProgramChange="98" />
+      <Patch Number="100" Name="Creative" ProgramChange="99" />
+      <Patch Number="101" Name="Juno Slice" ProgramChange="100" />
+      <Patch Number="102" Name="Epic Slice" ProgramChange="101" />
+      <Patch Number="103" Name="Klang Werk" ProgramChange="102" />
+      <Patch Number="104" Name="Ouverture" ProgramChange="103" />
+      <Patch Number="105" Name="Tropic Slice" ProgramChange="104" />
+      <Patch Number="106" Name="Strained" ProgramChange="105" />
+      <Patch Number="107" Name="Wicked DJ 2" ProgramChange="106" />
+      <Patch Number="108" Name="Ultra Noise" ProgramChange="107" />
+      <Patch Number="109" Name="JunoArpeggio" ProgramChange="108" />
+      <Patch Number="110" Name="Autoarpeggio" ProgramChange="109" />
+      <Patch Number="111" Name="SeqOctarveEP" ProgramChange="110" />
+      <Patch Number="112" Name="Sync Vox" ProgramChange="111" />
+      <Patch Number="113" Name="Stack Clavi" ProgramChange="112" />
+      <Patch Number="114" Name="Pump up" ProgramChange="113" />
+      <Patch Number="115" Name="Sine Seq" ProgramChange="114" />
+      <Patch Number="116" Name="Seq Saws" ProgramChange="115" />
+      <Patch Number="117" Name="Finale Hit" ProgramChange="116" />
+      <Patch Number="118" Name="Big Hit 3" ProgramChange="117" />
+      <Patch Number="119" Name="AnswerMe!Hit" ProgramChange="118" />
+      <Patch Number="120" Name="LoungeLizard" ProgramChange="119" />
+      <Patch Number="121" Name="Disco Stabs" ProgramChange="120" />
+      <Patch Number="122" Name="12x12'sDisco" ProgramChange="121" />
+      <Patch Number="123" Name="LittleDots" ProgramChange="122" />
+      <Patch Number="124" Name="TribalTechno" ProgramChange="123" />
+      <Patch Number="125" Name="Minor Bumwah" ProgramChange="124" />
+      <Patch Number="126" Name="Bobs Slide" ProgramChange="125" />
+      <Patch Number="127" Name="BrassHit 1" ProgramChange="126" />
+      <Patch Number="128" Name="BrassHit 2" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX05) 129-256">
+      <Patch Number="129" Name="BrassHit 3" ProgramChange="0" />
+      <Patch Number="130" Name="BrassHit 4" ProgramChange="1" />
+      <Patch Number="131" Name="BrassHit 5" ProgramChange="2" />
+      <Patch Number="132" Name="BrassHit 6" ProgramChange="3" />
+      <Patch Number="133" Name="BrassHit 7" ProgramChange="4" />
+      <Patch Number="134" Name="SymphHit 1" ProgramChange="5" />
+      <Patch Number="135" Name="SymphHit 2" ProgramChange="6" />
+      <Patch Number="136" Name="SymphHit 3" ProgramChange="7" />
+      <Patch Number="137" Name="OrgTrnsplnt" ProgramChange="8" />
+      <Patch Number="138" Name="Organ Hit 3" ProgramChange="9" />
+      <Patch Number="139" Name="Organ Hit 4" ProgramChange="10" />
+      <Patch Number="140" Name="Chord Hit 1" ProgramChange="11" />
+      <Patch Number="141" Name="Chord Hit 2" ProgramChange="12" />
+      <Patch Number="142" Name="Chord Hit 3" ProgramChange="13" />
+      <Patch Number="143" Name="Chord Hit 4" ProgramChange="14" />
+      <Patch Number="144" Name="Crystal Hit" ProgramChange="15" />
+      <Patch Number="145" Name="Stamp Hit" ProgramChange="16" />
+      <Patch Number="146" Name="ThousandHit" ProgramChange="17" />
+      <Patch Number="147" Name="9th Hit" ProgramChange="18" />
+      <Patch Number="148" Name="Slap Hit 1" ProgramChange="19" />
+      <Patch Number="149" Name="Slap Hit 2" ProgramChange="20" />
+      <Patch Number="150" Name="Dust Hit" ProgramChange="21" />
+      <Patch Number="151" Name="Dist Hit 1" ProgramChange="22" />
+      <Patch Number="152" Name="Dist Hit 2" ProgramChange="23" />
+      <Patch Number="153" Name="Wah Hit" ProgramChange="24" />
+      <Patch Number="154" Name="Tremble Hit" ProgramChange="25" />
+      <Patch Number="155" Name="Dah Hit" ProgramChange="26" />
+      <Patch Number="156" Name="Pretty Hit" ProgramChange="27" />
+      <Patch Number="157" Name="Smoky Hit" ProgramChange="28" />
+      <Patch Number="158" Name="Fist Hit" ProgramChange="29" />
+      <Patch Number="159" Name="Clavy Hit" ProgramChange="30" />
+      <Patch Number="160" Name="Tread Hit" ProgramChange="31" />
+      <Patch Number="161" Name="Old Org Hit" ProgramChange="32" />
+      <Patch Number="162" Name="Cave Hit" ProgramChange="33" />
+      <Patch Number="163" Name="Thru Hit" ProgramChange="34" />
+      <Patch Number="164" Name="Mull Hit" ProgramChange="35" />
+      <Patch Number="165" Name="Electronica" ProgramChange="36" />
+      <Patch Number="166" Name="Ripper" ProgramChange="37" />
+      <Patch Number="167" Name="Bounce Hit1" ProgramChange="38" />
+      <Patch Number="168" Name="Bounce Hit2" ProgramChange="39" />
+      <Patch Number="169" Name="Hit OneShots" ProgramChange="40" />
+      <Patch Number="170" Name="Brass Stab" ProgramChange="41" />
+      <Patch Number="171" Name="Null Zone" ProgramChange="42" />
+      <Patch Number="172" Name="Loop Techno" ProgramChange="43" />
+      <Patch Number="173" Name="Tribal RaveX" ProgramChange="44" />
+      <Patch Number="174" Name="Raverlisious" ProgramChange="45" />
+      <Patch Number="175" Name="2FingerRifff" ProgramChange="46" />
+      <Patch Number="176" Name="UK Garage 01" ProgramChange="47" />
+      <Patch Number="177" Name="UKgarage2002" ProgramChange="48" />
+      <Patch Number="178" Name="XV-303" ProgramChange="49" />
+      <Patch Number="179" Name="Psy-Tron" ProgramChange="50" />
+      <Patch Number="180" Name="House128bpm" ProgramChange="51" />
+      <Patch Number="181" Name="NewAcid Line" ProgramChange="52" />
+      <Patch Number="182" Name="Raver Saws" ProgramChange="53" />
+      <Patch Number="183" Name="Dist Saws" ProgramChange="54" />
+      <Patch Number="184" Name="BoosterBips2" ProgramChange="55" />
+      <Patch Number="185" Name="Auto 101" ProgramChange="56" />
+      <Patch Number="186" Name="BPF Sweep" ProgramChange="57" />
+      <Patch Number="187" Name="Elektrico" ProgramChange="58" />
+      <Patch Number="188" Name="What The ??" ProgramChange="59" />
+      <Patch Number="189" Name="PlayEuroRiff" ProgramChange="60" />
+      <Patch Number="190" Name="MayhemAppegi" ProgramChange="61" />
+      <Patch Number="191" Name="AmbientTranz" ProgramChange="62" />
+      <Patch Number="192" Name="DanceStrSect" ProgramChange="63" />
+      <Patch Number="193" Name="5thIn4th Tri" ProgramChange="64" />
+      <Patch Number="194" Name="5th Vox" ProgramChange="65" />
+      <Patch Number="195" Name="Kompakt Voic" ProgramChange="66" />
+      <Patch Number="196" Name="Resound" ProgramChange="67" />
+      <Patch Number="197" Name="StrikeWhstle" ProgramChange="68" />
+      <Patch Number="198" Name="Rocket Blast" ProgramChange="69" />
+      <Patch Number="199" Name="Future Drain" ProgramChange="70" />
+      <Patch Number="200" Name="Foilage" ProgramChange="71" />
+      <Patch Number="201" Name="JP-8000 Pad" ProgramChange="72" />
+      <Patch Number="202" Name="SynthChord01" ProgramChange="73" />
+      <Patch Number="203" Name="PWM" ProgramChange="74" />
+      <Patch Number="204" Name="Introductory" ProgramChange="75" />
+      <Patch Number="205" Name="Miracle Pad" ProgramChange="76" />
+      <Patch Number="206" Name="5th Sweep 2" ProgramChange="77" />
+      <Patch Number="207" Name="Choir Sweep" ProgramChange="78" />
+      <Patch Number="208" Name="Retro Pad" ProgramChange="79" />
+      <Patch Number="209" Name="Beautiful:-]" ProgramChange="80" />
+      <Patch Number="210" Name="Steam Pad" ProgramChange="81" />
+      <Patch Number="211" Name="AggressiveLd" ProgramChange="82" />
+      <Patch Number="212" Name="I know Juno" ProgramChange="83" />
+      <Patch Number="213" Name="Def Lead 21" ProgramChange="84" />
+      <Patch Number="214" Name="HiPass" ProgramChange="85" />
+      <Patch Number="215" Name="DynaPulseLd" ProgramChange="86" />
+      <Patch Number="216" Name="Dist Lead" ProgramChange="87" />
+      <Patch Number="217" Name="80's Memory" ProgramChange="88" />
+      <Patch Number="218" Name="OD SyncLead" ProgramChange="89" />
+      <Patch Number="219" Name="80'sTechLead" ProgramChange="90" />
+      <Patch Number="220" Name="3-SquareLead" ProgramChange="91" />
+      <Patch Number="221" Name="PortaSynLead" ProgramChange="92" />
+      <Patch Number="222" Name="Tri Lead" ProgramChange="93" />
+      <Patch Number="223" Name="Corrupt Sine" ProgramChange="94" />
+      <Patch Number="224" Name="Neonlight" ProgramChange="95" />
+      <Patch Number="225" Name="Higher&amp;Highr" ProgramChange="96" />
+      <Patch Number="226" Name="Waspy Solo1" ProgramChange="97" />
+      <Patch Number="227" Name="Waspy Solo2" ProgramChange="98" />
+      <Patch Number="228" Name="Vib Sine" ProgramChange="99" />
+      <Patch Number="229" Name="Legato Saw" ProgramChange="100" />
+      <Patch Number="230" Name="Wet Saw Ld" ProgramChange="101" />
+      <Patch Number="231" Name="Dry BassLead" ProgramChange="102" />
+      <Patch Number="232" Name="PluckLead" ProgramChange="103" />
+      <Patch Number="233" Name="Comp Piano 2" ProgramChange="104" />
+      <Patch Number="234" Name="a Tack Piano" ProgramChange="105" />
+      <Patch Number="235" Name="Analog Piano" ProgramChange="106" />
+      <Patch Number="236" Name="Tri EP" ProgramChange="107" />
+      <Patch Number="237" Name="Pulsing EP" ProgramChange="108" />
+      <Patch Number="238" Name="Cool EP 2" ProgramChange="109" />
+      <Patch Number="239" Name="EP Chd Menu" ProgramChange="110" />
+      <Patch Number="240" Name="EP Maj 9th" ProgramChange="111" />
+      <Patch Number="241" Name="EP Maj 11th" ProgramChange="112" />
+      <Patch Number="242" Name="EP Min 11th" ProgramChange="113" />
+      <Patch Number="243" Name="NoisySynthEP" ProgramChange="114" />
+      <Patch Number="244" Name="CompClav/Rls" ProgramChange="115" />
+      <Patch Number="245" Name="Comp Clavi" ProgramChange="116" />
+      <Patch Number="246" Name="HarmoOrg/Mod" ProgramChange="117" />
+      <Patch Number="247" Name="ZigZag Organ" ProgramChange="118" />
+      <Patch Number="248" Name="Notre Organ" ProgramChange="119" />
+      <Patch Number="249" Name="SpectrumBell" ProgramChange="120" />
+      <Patch Number="250" Name="Square Bell1" ProgramChange="121" />
+      <Patch Number="251" Name="Square Bell2" ProgramChange="122" />
+      <Patch Number="252" Name="ClnGtr Slide" ProgramChange="123" />
+      <Patch Number="253" Name="Gtr TrmDown" ProgramChange="124" />
+      <Patch Number="254" Name="Waw Chord" ProgramChange="125" />
+      <Patch Number="255" Name="Wha Wha Wha" ProgramChange="126" />
+      <Patch Number="256" Name="Wha De Da" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX05) 257-312">
+      <Patch Number="257" Name="Fuzz Phaze" ProgramChange="0" />
+      <Patch Number="258" Name="Ringmod Ting" ProgramChange="1" />
+      <Patch Number="259" Name="BPF Strings" ProgramChange="2" />
+      <Patch Number="260" Name="LoFiStringz" ProgramChange="3" />
+      <Patch Number="261" Name="LightStrings" ProgramChange="4" />
+      <Patch Number="262" Name="Flange Str" ProgramChange="5" />
+      <Patch Number="263" Name="4th-LayerStr" ProgramChange="6" />
+      <Patch Number="264" Name="LA Pizz" ProgramChange="7" />
+      <Patch Number="265" Name="DanceClustor" ProgramChange="8" />
+      <Patch Number="266" Name="CaveStrHit" ProgramChange="9" />
+      <Patch Number="267" Name="StrChd Menu" ProgramChange="10" />
+      <Patch Number="268" Name="StrScaleMaj" ProgramChange="11" />
+      <Patch Number="269" Name="StrSpread" ProgramChange="12" />
+      <Patch Number="270" Name="EuroBeat Brs" ProgramChange="13" />
+      <Patch Number="271" Name="OB Brass 2" ProgramChange="14" />
+      <Patch Number="272" Name="Funny Brass" ProgramChange="15" />
+      <Patch Number="273" Name="Saws Brass" ProgramChange="16" />
+      <Patch Number="274" Name="AnalogMaster" ProgramChange="17" />
+      <Patch Number="275" Name="OneKeyMajor" ProgramChange="18" />
+      <Patch Number="276" Name="Danz Braz" ProgramChange="19" />
+      <Patch Number="277" Name="WindFX Menu" ProgramChange="20" />
+      <Patch Number="278" Name="Flute FX 1" ProgramChange="21" />
+      <Patch Number="279" Name="Flute FX 2" ProgramChange="22" />
+      <Patch Number="280" Name="Flute FX 3" ProgramChange="23" />
+      <Patch Number="281" Name="Sax FX 1" ProgramChange="24" />
+      <Patch Number="282" Name="Sax FX 2" ProgramChange="25" />
+      <Patch Number="283" Name="Sax FX 3" ProgramChange="26" />
+      <Patch Number="284" Name="VINYL VOX" ProgramChange="27" />
+      <Patch Number="285" Name="PsycheVocals" ProgramChange="28" />
+      <Patch Number="286" Name="Vox Menu" ProgramChange="29" />
+      <Patch Number="287" Name="Yeah F" ProgramChange="30" />
+      <Patch Number="288" Name="Ho F" ProgramChange="31" />
+      <Patch Number="289" Name="Oh F" ProgramChange="32" />
+      <Patch Number="290" Name="Wow Yeah F" ProgramChange="33" />
+      <Patch Number="291" Name="Ring Mod" ProgramChange="34" />
+      <Patch Number="292" Name="Hydrolyze" ProgramChange="35" />
+      <Patch Number="293" Name="Hydrolyze 2" ProgramChange="36" />
+      <Patch Number="294" Name="Danger Zone" ProgramChange="37" />
+      <Patch Number="295" Name="Danger Zone2" ProgramChange="38" />
+      <Patch Number="296" Name="Horror" ProgramChange="39" />
+      <Patch Number="297" Name="Space Scrach" ProgramChange="40" />
+      <Patch Number="298" Name="OldSkool FX" ProgramChange="41" />
+      <Patch Number="299" Name="Snare Bomb" ProgramChange="42" />
+      <Patch Number="300" Name="CymbalMusic" ProgramChange="43" />
+      <Patch Number="301" Name="Recollection" ProgramChange="44" />
+      <Patch Number="302" Name="Dive Start !" ProgramChange="45" />
+      <Patch Number="303" Name="DJ Mayhem" ProgramChange="46" />
+      <Patch Number="304" Name="TurnOff&gt;Rev" ProgramChange="47" />
+      <Patch Number="305" Name="Scratch 4" ProgramChange="48" />
+      <Patch Number="306" Name="Scratch 5" ProgramChange="49" />
+      <Patch Number="307" Name="Scratch 6" ProgramChange="50" />
+      <Patch Number="308" Name="Scratch 7" ProgramChange="51" />
+      <Patch Number="309" Name="Scratch 8" ProgramChange="52" />
+      <Patch Number="310" Name="Scratch 9" ProgramChange="53" />
+      <Patch Number="311" Name="Scratch 10" ProgramChange="54" />
+      <Patch Number="312" Name="Vinyl Nz" ProgramChange="55" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX06) 1-128">
+      <Patch Number="001" Name="WarmVlns SRX" ProgramChange="0" />
+      <Patch Number="002" Name="Legato Vlns" ProgramChange="1" />
+      <Patch Number="003" Name="NaturalVlnsS" ProgramChange="2" />
+      <Patch Number="004" Name="Agitato Vlns" ProgramChange="3" />
+      <Patch Number="005" Name="Vlns-Spc /" ProgramChange="4" />
+      <Patch Number="006" Name="Vl&amp;Va Spicct" ProgramChange="5" />
+      <Patch Number="007" Name="Arco Vas SRX" ProgramChange="6" />
+      <Patch Number="008" Name="Agitato Vas" ProgramChange="7" />
+      <Patch Number="009" Name="Vlas-Spc /" ProgramChange="8" />
+      <Patch Number="010" Name="Marc Vas SRX" ProgramChange="9" />
+      <Patch Number="011" Name="Vc Sec mf" ProgramChange="10" />
+      <Patch Number="012" Name="Fast Cellos" ProgramChange="11" />
+      <Patch Number="013" Name="Vcs Legato" ProgramChange="12" />
+      <Patch Number="014" Name="3 Cellos" ProgramChange="13" />
+      <Patch Number="015" Name="Cellos" ProgramChange="14" />
+      <Patch Number="016" Name="CelloSectMrc" ProgramChange="15" />
+      <Patch Number="017" Name="Marcato Vcs" ProgramChange="16" />
+      <Patch Number="018" Name="Agitato Vcs" ProgramChange="17" />
+      <Patch Number="019" Name="Vcs+Cbs SRX" ProgramChange="18" />
+      <Patch Number="020" Name="Arco Vcs+Cbs" ProgramChange="19" />
+      <Patch Number="021" Name="Thick Basses" ProgramChange="20" />
+      <Patch Number="022" Name="Cb Sect SRX" ProgramChange="21" />
+      <Patch Number="023" Name="WideBasses S" ProgramChange="22" />
+      <Patch Number="024" Name="Agitato Cbs" ProgramChange="23" />
+      <Patch Number="025" Name="BIG StrgEns" ProgramChange="24" />
+      <Patch Number="026" Name="Big Strings2" ProgramChange="25" />
+      <Patch Number="027" Name="Orch p" ProgramChange="26" />
+      <Patch Number="028" Name="Orch p&gt;f/Mod" ProgramChange="27" />
+      <Patch Number="029" Name="StrsArco SRX" ProgramChange="28" />
+      <Patch Number="030" Name="StrSwel/ModS" ProgramChange="29" />
+      <Patch Number="031" Name="StStrOrcp/fS" ProgramChange="30" />
+      <Patch Number="032" Name="SlowResinStr" ProgramChange="31" />
+      <Patch Number="033" Name="Adagio Strs" ProgramChange="32" />
+      <Patch Number="034" Name="LegatoStrngs" ProgramChange="33" />
+      <Patch Number="035" Name="Intim StrSec" ProgramChange="34" />
+      <Patch Number="036" Name="DramaStrsSRX" ProgramChange="35" />
+      <Patch Number="037" Name="St Str p/f" ProgramChange="36" />
+      <Patch Number="038" Name="SlowEpic Str" ProgramChange="37" />
+      <Patch Number="039" Name="Real Strings" ProgramChange="38" />
+      <Patch Number="040" Name="4Seasons SRX" ProgramChange="39" />
+      <Patch Number="041" Name="VlVaVcCb SRX" ProgramChange="40" />
+      <Patch Number="042" Name="StudioString" ProgramChange="41" />
+      <Patch Number="043" Name="Quartet SRX" ProgramChange="42" />
+      <Patch Number="044" Name="VibSwStrings" ProgramChange="43" />
+      <Patch Number="045" Name="Str Swell" ProgramChange="44" />
+      <Patch Number="046" Name="OuvertureSRX" ProgramChange="45" />
+      <Patch Number="047" Name="Cluster Sect" ProgramChange="46" />
+      <Patch Number="048" Name="Velo Str SRX" ProgramChange="47" />
+      <Patch Number="049" Name="Agitato to 0" ProgramChange="48" />
+      <Patch Number="050" Name="DynaMarc SRX" ProgramChange="49" />
+      <Patch Number="051" Name="VivaceStrSRX" ProgramChange="50" />
+      <Patch Number="052" Name="Agitato STR" ProgramChange="51" />
+      <Patch Number="053" Name="STR SpiccSRX" ProgramChange="52" />
+      <Patch Number="054" Name="StacctoSectn" ProgramChange="53" />
+      <Patch Number="055" Name="Spicc/releas" ProgramChange="54" />
+      <Patch Number="056" Name="STR Marcato" ProgramChange="55" />
+      <Patch Number="057" Name="Big Marcato!" ProgramChange="56" />
+      <Patch Number="058" Name="Spicc Sect" ProgramChange="57" />
+      <Patch Number="059" Name="Spc+Pz/rleas" ProgramChange="58" />
+      <Patch Number="060" Name="Piz-Spc /" ProgramChange="59" />
+      <Patch Number="061" Name="RoomPizz SRX" ProgramChange="60" />
+      <Patch Number="062" Name="Stage Pizz" ProgramChange="61" />
+      <Patch Number="063" Name="Nite Pizzico" ProgramChange="62" />
+      <Patch Number="064" Name="VIOLIN solo" ProgramChange="63" />
+      <Patch Number="065" Name="Solo Vln /" ProgramChange="64" />
+      <Patch Number="066" Name="Solo Violin" ProgramChange="65" />
+      <Patch Number="067" Name="Sad S.VlnSRX" ProgramChange="66" />
+      <Patch Number="068" Name="Solo Viola" ProgramChange="67" />
+      <Patch Number="069" Name="AgitatoVaSRX" ProgramChange="68" />
+      <Patch Number="070" Name="Solo Cello 1" ProgramChange="69" />
+      <Patch Number="071" Name="Solo Cello 2" ProgramChange="70" />
+      <Patch Number="072" Name="The V Cello" ProgramChange="71" />
+      <Patch Number="073" Name="Solo Vc /" ProgramChange="72" />
+      <Patch Number="074" Name="Marcato Vc" ProgramChange="73" />
+      <Patch Number="075" Name="Vln&amp;Vcl" ProgramChange="74" />
+      <Patch Number="076" Name="Solo Cb /" ProgramChange="75" />
+      <Patch Number="077" Name="Tape Orc SRX" ProgramChange="76" />
+      <Patch Number="078" Name="Tape Str SRX" ProgramChange="77" />
+      <Patch Number="079" Name="Old Tale" ProgramChange="78" />
+      <Patch Number="080" Name="Mellow Tape" ProgramChange="79" />
+      <Patch Number="081" Name="Cystaline Pd" ProgramChange="80" />
+      <Patch Number="082" Name="SynStrings" ProgramChange="81" />
+      <Patch Number="083" Name="Full Orc SRX" ProgramChange="82" />
+      <Patch Number="084" Name="St.OrcUniSRX" ProgramChange="83" />
+      <Patch Number="085" Name="OrchUnif SRX" ProgramChange="84" />
+      <Patch Number="086" Name="GRAND OrcSRX" ProgramChange="85" />
+      <Patch Number="087" Name="WavinGoodbye" ProgramChange="86" />
+      <Patch Number="088" Name="DynOrchestr1" ProgramChange="87" />
+      <Patch Number="089" Name="Pathetique" ProgramChange="88" />
+      <Patch Number="090" Name="Oboes &amp; Sect" ProgramChange="89" />
+      <Patch Number="091" Name="SlowEpicOrch" ProgramChange="90" />
+      <Patch Number="092" Name="Grand Tutti" ProgramChange="91" />
+      <Patch Number="093" Name="Ultimate Orc" ProgramChange="92" />
+      <Patch Number="094" Name="SuspenceOrch" ProgramChange="93" />
+      <Patch Number="095" Name="Tremolo /" ProgramChange="94" />
+      <Patch Number="096" Name="TremOrc /Mod" ProgramChange="95" />
+      <Patch Number="097" Name="ORC full+BD" ProgramChange="96" />
+      <Patch Number="098" Name="Finally Orch" ProgramChange="97" />
+      <Patch Number="099" Name="Orch &amp; Choir" ProgramChange="98" />
+      <Patch Number="100" Name="NowWeAreFree" ProgramChange="99" />
+      <Patch Number="101" Name="Too Tense" ProgramChange="100" />
+      <Patch Number="102" Name="OrchestrlSRX" ProgramChange="101" />
+      <Patch Number="103" Name="DynOrchestr2" ProgramChange="102" />
+      <Patch Number="104" Name="GiantOrchest" ProgramChange="103" />
+      <Patch Number="105" Name="Strngs&amp;Horns" ProgramChange="104" />
+      <Patch Number="106" Name="Full Orch. 1" ProgramChange="105" />
+      <Patch Number="107" Name="Full Orch. 2" ProgramChange="106" />
+      <Patch Number="108" Name="Full Orch. 3" ProgramChange="107" />
+      <Patch Number="109" Name="End Titles" ProgramChange="108" />
+      <Patch Number="110" Name="HornStrs SRX" ProgramChange="109" />
+      <Patch Number="111" Name="SRX Full Orc" ProgramChange="110" />
+      <Patch Number="112" Name="Harp &amp; Flute" ProgramChange="111" />
+      <Patch Number="113" Name="Celesta&amp;Flt" ProgramChange="112" />
+      <Patch Number="114" Name="ProkofievSRX" ProgramChange="113" />
+      <Patch Number="115" Name="MassInCeeSRX" ProgramChange="114" />
+      <Patch Number="116" Name="PentatnicSRX" ProgramChange="115" />
+      <Patch Number="117" Name="DawnSynphony" ProgramChange="116" />
+      <Patch Number="118" Name="Bad Ending" ProgramChange="117" />
+      <Patch Number="119" Name="Epic Ending" ProgramChange="118" />
+      <Patch Number="120" Name="Catwalk" ProgramChange="119" />
+      <Patch Number="121" Name="OrchStaccato" ProgramChange="120" />
+      <Patch Number="122" Name="Staccato SRX" ProgramChange="121" />
+      <Patch Number="123" Name="OrchHitStack" ProgramChange="122" />
+      <Patch Number="124" Name="Dynam Hit" ProgramChange="123" />
+      <Patch Number="125" Name="MondoHit SRX" ProgramChange="124" />
+      <Patch Number="126" Name="OrchHit SRX" ProgramChange="125" />
+      <Patch Number="127" Name="OrcHitMajSRX" ProgramChange="126" />
+      <Patch Number="128" Name="OrcHitMinSRX" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX06) 129-256">
+      <Patch Number="129" Name="OrcHitDimSRX" ProgramChange="0" />
+      <Patch Number="130" Name="Big Hit Maj1" ProgramChange="1" />
+      <Patch Number="131" Name="Big Hit Maj2" ProgramChange="2" />
+      <Patch Number="132" Name="Big Hit Min" ProgramChange="3" />
+      <Patch Number="133" Name="Big Hit Dim" ProgramChange="4" />
+      <Patch Number="134" Name="Sfz! Hit-Maj" ProgramChange="5" />
+      <Patch Number="135" Name="Sfz! Hit-Min" ProgramChange="6" />
+      <Patch Number="136" Name="Suspense" ProgramChange="7" />
+      <Patch Number="137" Name="Hit/Off-Maj" ProgramChange="8" />
+      <Patch Number="138" Name="Trem Hit-Maj" ProgramChange="9" />
+      <Patch Number="139" Name="Trem Hit-Min" ProgramChange="10" />
+      <Patch Number="140" Name="Trem Hit-Dim" ProgramChange="11" />
+      <Patch Number="141" Name="Orc/Prc 5-1^" ProgramChange="12" />
+      <Patch Number="142" Name="Drama Stab" ProgramChange="13" />
+      <Patch Number="143" Name="Maj Concern" ProgramChange="14" />
+      <Patch Number="144" Name="OrcGlsMajSRX" ProgramChange="15" />
+      <Patch Number="145" Name="OrcGlsMinSRX" ProgramChange="16" />
+      <Patch Number="146" Name="Harp Up Hit" ProgramChange="17" />
+      <Patch Number="147" Name="Harp Dn Hit" ProgramChange="18" />
+      <Patch Number="148" Name="BrassStabSRX" ProgramChange="19" />
+      <Patch Number="149" Name="Finale" ProgramChange="20" />
+      <Patch Number="150" Name="Tuned HIT" ProgramChange="21" />
+      <Patch Number="151" Name="YourMissionS" ProgramChange="22" />
+      <Patch Number="152" Name="Big Hit SRX" ProgramChange="23" />
+      <Patch Number="153" Name="HorrorHitSRX" ProgramChange="24" />
+      <Patch Number="154" Name="Perc Hit" ProgramChange="25" />
+      <Patch Number="155" Name="BrassFallSRX" ProgramChange="26" />
+      <Patch Number="156" Name="Tp Fall" ProgramChange="27" />
+      <Patch Number="157" Name="BrsStacc SRX" ProgramChange="28" />
+      <Patch Number="158" Name="Finale SRX /" ProgramChange="29" />
+      <Patch Number="159" Name="Orch Piccolo" ProgramChange="30" />
+      <Patch Number="160" Name="Picc Vel Tr" ProgramChange="31" />
+      <Patch Number="161" Name="Piccolo Trio" ProgramChange="32" />
+      <Patch Number="162" Name="Orch Flute" ProgramChange="33" />
+      <Patch Number="163" Name="Vibra Flute" ProgramChange="34" />
+      <Patch Number="164" Name="FluteAtm/Aft" ProgramChange="35" />
+      <Patch Number="165" Name="Picc/Fl 8va" ProgramChange="36" />
+      <Patch Number="166" Name="Double Flute" ProgramChange="37" />
+      <Patch Number="167" Name="Fl/EH Usn" ProgramChange="38" />
+      <Patch Number="168" Name="Calliope SRX" ProgramChange="39" />
+      <Patch Number="169" Name="DynoCelt SRX" ProgramChange="40" />
+      <Patch Number="170" Name="Ethnic Flute" ProgramChange="41" />
+      <Patch Number="171" Name="AmbiFluteSRX" ProgramChange="42" />
+      <Patch Number="172" Name="T.WhistleDly" ProgramChange="43" />
+      <Patch Number="173" Name="TinWhistle" ProgramChange="44" />
+      <Patch Number="174" Name="Sop Recorder" ProgramChange="45" />
+      <Patch Number="175" Name="Tnr Recorder" ProgramChange="46" />
+      <Patch Number="176" Name="Whistle SRX" ProgramChange="47" />
+      <Patch Number="177" Name="Solo Clari" ProgramChange="48" />
+      <Patch Number="178" Name="Unison Clari" ProgramChange="49" />
+      <Patch Number="179" Name="Orch Clar" ProgramChange="50" />
+      <Patch Number="180" Name="Bs Clairenet" ProgramChange="51" />
+      <Patch Number="181" Name="Orch Bs Clar" ProgramChange="52" />
+      <Patch Number="182" Name="Cl/Bs Cl 8va" ProgramChange="53" />
+      <Patch Number="183" Name="Fl/Cl Usn" ProgramChange="54" />
+      <Patch Number="184" Name="Fl/Cl 8va" ProgramChange="55" />
+      <Patch Number="185" Name="Orch Oboe" ProgramChange="56" />
+      <Patch Number="186" Name="Sweet Oboe" ProgramChange="57" />
+      <Patch Number="187" Name="Cor Oboe" ProgramChange="58" />
+      <Patch Number="188" Name="OBOE Solo" ProgramChange="59" />
+      <Patch Number="189" Name="2 Close Oboe" ProgramChange="60" />
+      <Patch Number="190" Name="Orch Eng Hrn" ProgramChange="61" />
+      <Patch Number="191" Name="Horn'o U.K." ProgramChange="62" />
+      <Patch Number="192" Name="Orch Bassoon" ProgramChange="63" />
+      <Patch Number="193" Name="Bassoon III" ProgramChange="64" />
+      <Patch Number="194" Name="BassFoons" ProgramChange="65" />
+      <Patch Number="195" Name="Cl/Bsn Usn" ProgramChange="66" />
+      <Patch Number="196" Name="Cl/Bsn 8va" ProgramChange="67" />
+      <Patch Number="197" Name="Fl/Ob Usn" ProgramChange="68" />
+      <Patch Number="198" Name="Fl/EH 8va" ProgramChange="69" />
+      <Patch Number="199" Name="Fl/Bsn 8va" ProgramChange="70" />
+      <Patch Number="200" Name="BsCl/Bsn 8vb" ProgramChange="71" />
+      <Patch Number="201" Name="BsCl/Bsn Usn" ProgramChange="72" />
+      <Patch Number="202" Name="Cl/Hrn/Bsn 1" ProgramChange="73" />
+      <Patch Number="203" Name="Cl/Hrn/Bsn 2" ProgramChange="74" />
+      <Patch Number="204" Name="Ob/Hrns/Bsns" ProgramChange="75" />
+      <Patch Number="205" Name="Ob/Bsn 8va" ProgramChange="76" />
+      <Patch Number="206" Name="Ob/EH Usn" ProgramChange="77" />
+      <Patch Number="207" Name="Ob/EH 8va" ProgramChange="78" />
+      <Patch Number="208" Name="EH/Bsn Usn" ProgramChange="79" />
+      <Patch Number="209" Name="EH/Bsn 8va" ProgramChange="80" />
+      <Patch Number="210" Name="EH/Cl Usn" ProgramChange="81" />
+      <Patch Number="211" Name="EH/Bs Cl 8va" ProgramChange="82" />
+      <Patch Number="212" Name="Ob/Cl Usn" ProgramChange="83" />
+      <Patch Number="213" Name="Ob/BsCl 15va" ProgramChange="84" />
+      <Patch Number="214" Name="Hrns/Bsns" ProgramChange="85" />
+      <Patch Number="215" Name="Really Reeds" ProgramChange="86" />
+      <Patch Number="216" Name="Reed Duet" ProgramChange="87" />
+      <Patch Number="217" Name="Multi Reeds" ProgramChange="88" />
+      <Patch Number="218" Name="Medieval Rds" ProgramChange="89" />
+      <Patch Number="219" Name="ScottishPIPE" ProgramChange="90" />
+      <Patch Number="220" Name="Hill&amp;Sheeps" ProgramChange="91" />
+      <Patch Number="221" Name="HilndChr SRX" ProgramChange="92" />
+      <Patch Number="222" Name="Solo Fr.Horn" ProgramChange="93" />
+      <Patch Number="223" Name="SoloF.HrnSRX" ProgramChange="94" />
+      <Patch Number="224" Name="HrnAccompSRX" ProgramChange="95" />
+      <Patch Number="225" Name="Orch Hrns Sw" ProgramChange="96" />
+      <Patch Number="226" Name="Hornz Stereo" ProgramChange="97" />
+      <Patch Number="227" Name="Orch Hrns ff" ProgramChange="98" />
+      <Patch Number="228" Name="FizzHorns ff" ProgramChange="99" />
+      <Patch Number="229" Name="Fr.Horns SRX" ProgramChange="100" />
+      <Patch Number="230" Name="Dynamic Hrns" ProgramChange="101" />
+      <Patch Number="231" Name="Horn Sect /" ProgramChange="102" />
+      <Patch Number="232" Name="Fr.HrnSfzSRX" ProgramChange="103" />
+      <Patch Number="233" Name="MuteFr.Horns" ProgramChange="104" />
+      <Patch Number="234" Name="F.Horn Rip" ProgramChange="105" />
+      <Patch Number="235" Name="Trumpet Plus" ProgramChange="106" />
+      <Patch Number="236" Name="Natural Tmpt" ProgramChange="107" />
+      <Patch Number="237" Name="Real Tp SRX" ProgramChange="108" />
+      <Patch Number="238" Name="El Bono SRX" ProgramChange="109" />
+      <Patch Number="239" Name="Coronet" ProgramChange="110" />
+      <Patch Number="240" Name="Flugelhorn" ProgramChange="111" />
+      <Patch Number="241" Name="Mute Tp SRX" ProgramChange="112" />
+      <Patch Number="242" Name="HrmnMute SRX" ProgramChange="113" />
+      <Patch Number="243" Name="WahMute /Mod" ProgramChange="114" />
+      <Patch Number="244" Name="Trumpeters" ProgramChange="115" />
+      <Patch Number="245" Name="Tp Ens SRX" ProgramChange="116" />
+      <Patch Number="246" Name="Trumps fff!!" ProgramChange="117" />
+      <Patch Number="247" Name="Softy Bones" ProgramChange="118" />
+      <Patch Number="248" Name="Bone Fluegal" ProgramChange="119" />
+      <Patch Number="249" Name="Natural Tbn" ProgramChange="120" />
+      <Patch Number="250" Name="Trombone SRX" ProgramChange="121" />
+      <Patch Number="251" Name="SoloTb SRX 1" ProgramChange="122" />
+      <Patch Number="252" Name="SoloTb SRX 2" ProgramChange="123" />
+      <Patch Number="253" Name="Bs Tb" ProgramChange="124" />
+      <Patch Number="254" Name="Tbn One" ProgramChange="125" />
+      <Patch Number="255" Name="Bone Boys" ProgramChange="126" />
+      <Patch Number="256" Name="Bones sectn" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX06) 257-384">
+      <Patch Number="257" Name="BigBones SRX" ProgramChange="0" />
+      <Patch Number="258" Name="BsBoneSctSRX" ProgramChange="1" />
+      <Patch Number="259" Name="Noblesse" ProgramChange="2" />
+      <Patch Number="260" Name="Brass Choral" ProgramChange="3" />
+      <Patch Number="261" Name="BrassEns/Mod" ProgramChange="4" />
+      <Patch Number="262" Name="Small Brass" ProgramChange="5" />
+      <Patch Number="263" Name="Brass Orche" ProgramChange="6" />
+      <Patch Number="264" Name="Switch Fall" ProgramChange="7" />
+      <Patch Number="265" Name="4-Pc Brs Scn" ProgramChange="8" />
+      <Patch Number="266" Name="BiggieBrsSRX" ProgramChange="9" />
+      <Patch Number="267" Name="SoloTuba SRX" ProgramChange="10" />
+      <Patch Number="268" Name="Tuba sfz/Mod" ProgramChange="11" />
+      <Patch Number="269" Name="Tuba SRX" ProgramChange="12" />
+      <Patch Number="270" Name="Medieval Brs" ProgramChange="13" />
+      <Patch Number="271" Name="Full Brass" ProgramChange="14" />
+      <Patch Number="272" Name="Brass ff" ProgramChange="15" />
+      <Patch Number="273" Name="Brass Sect /" ProgramChange="16" />
+      <Patch Number="274" Name="Multi Sax" ProgramChange="17" />
+      <Patch Number="275" Name="St.EuroPiano" ProgramChange="18" />
+      <Patch Number="276" Name="JoyoClassics" ProgramChange="19" />
+      <Patch Number="277" Name="Empathy" ProgramChange="20" />
+      <Patch Number="278" Name="Piano &amp; Strs" ProgramChange="21" />
+      <Patch Number="279" Name="Pno Concerto" ProgramChange="22" />
+      <Patch Number="280" Name="Song Wish" ProgramChange="23" />
+      <Patch Number="281" Name="HpsFrntSRX 1" ProgramChange="24" />
+      <Patch Number="282" Name="HpsFrntSRX 2" ProgramChange="25" />
+      <Patch Number="283" Name="HpsFrntSRX 3" ProgramChange="26" />
+      <Patch Number="284" Name="HpsBackSRX 1" ProgramChange="27" />
+      <Patch Number="285" Name="HpsBackSRX 2" ProgramChange="28" />
+      <Patch Number="286" Name="HpsBackSRX 3" ProgramChange="29" />
+      <Patch Number="287" Name="Hps F/B SRX" ProgramChange="30" />
+      <Patch Number="288" Name="Hps F4/B SRX" ProgramChange="31" />
+      <Patch Number="289" Name="Hps F/B/B4 S" ProgramChange="32" />
+      <Patch Number="290" Name="HpsLuteSRX 1" ProgramChange="33" />
+      <Patch Number="291" Name="HpsLute 2" ProgramChange="34" />
+      <Patch Number="292" Name="HpsLute 3" ProgramChange="35" />
+      <Patch Number="293" Name="FullHarpsi 1" ProgramChange="36" />
+      <Patch Number="294" Name="FullHarpsi 2" ProgramChange="37" />
+      <Patch Number="295" Name="Continuo Pdl" ProgramChange="38" />
+      <Patch Number="296" Name="Celesta SRX" ProgramChange="39" />
+      <Patch Number="297" Name="MusicBellSRX" ProgramChange="40" />
+      <Patch Number="298" Name="Water Mallet" ProgramChange="41" />
+      <Patch Number="299" Name="Newborn" ProgramChange="42" />
+      <Patch Number="300" Name="Victoriana 1" ProgramChange="43" />
+      <Patch Number="301" Name="St.M.Box SRX" ProgramChange="44" />
+      <Patch Number="302" Name="Victoriana 2" ProgramChange="45" />
+      <Patch Number="303" Name="ChurchBellS1" ProgramChange="46" />
+      <Patch Number="304" Name="BlfryChm SRX" ProgramChange="47" />
+      <Patch Number="305" Name="ChurchBellS2" ProgramChange="48" />
+      <Patch Number="306" Name="Tub.Bells S1" ProgramChange="49" />
+      <Patch Number="307" Name="Tub.Bells S2" ProgramChange="50" />
+      <Patch Number="308" Name="BsMarimbSRX1" ProgramChange="51" />
+      <Patch Number="309" Name="BsMarimbSRX2" ProgramChange="52" />
+      <Patch Number="310" Name="MultiMallets" ProgramChange="53" />
+      <Patch Number="311" Name="Glocken" ProgramChange="54" />
+      <Patch Number="312" Name="Glockeneste" ProgramChange="55" />
+      <Patch Number="313" Name="GlocknlstSRX" ProgramChange="56" />
+      <Patch Number="314" Name="Clear Glock" ProgramChange="57" />
+      <Patch Number="315" Name="Xylorimba" ProgramChange="58" />
+      <Patch Number="316" Name="Xylophone S1" ProgramChange="59" />
+      <Patch Number="317" Name="Xylophone S2" ProgramChange="60" />
+      <Patch Number="318" Name="Mallet Stack" ProgramChange="61" />
+      <Patch Number="319" Name="OrgFlutes S1" ProgramChange="62" />
+      <Patch Number="320" Name="OrgFlutes S2" ProgramChange="63" />
+      <Patch Number="321" Name="OrgFlutes S3" ProgramChange="64" />
+      <Patch Number="322" Name="OrgFlute 8'S" ProgramChange="65" />
+      <Patch Number="323" Name="Psyche Pipes" ProgramChange="66" />
+      <Patch Number="324" Name="ChrchPipes S" ProgramChange="67" />
+      <Patch Number="325" Name="Organ&amp;Recdr" ProgramChange="68" />
+      <Patch Number="326" Name="Early Harmn" ProgramChange="69" />
+      <Patch Number="327" Name="CathedralSRX" ProgramChange="70" />
+      <Patch Number="328" Name="Harmonium" ProgramChange="71" />
+      <Patch Number="329" Name="ChurchOrgSRX" ProgramChange="72" />
+      <Patch Number="330" Name="OrganChrdSRX" ProgramChange="73" />
+      <Patch Number="331" Name="Musaccordion" ProgramChange="74" />
+      <Patch Number="332" Name="Mystery Pad" ProgramChange="75" />
+      <Patch Number="333" Name="Psychedelic1" ProgramChange="76" />
+      <Patch Number="334" Name="Psychedelic2" ProgramChange="77" />
+      <Patch Number="335" Name="Eylsium  m7^" ProgramChange="78" />
+      <Patch Number="336" Name="Eylsium 9th^" ProgramChange="79" />
+      <Patch Number="337" Name="Eylsium  +7^" ProgramChange="80" />
+      <Patch Number="338" Name="Eylsium  b9^" ProgramChange="81" />
+      <Patch Number="339" Name="Vln RunUp Mj" ProgramChange="82" />
+      <Patch Number="340" Name="Vln RunUp Mn" ProgramChange="83" />
+      <Patch Number="341" Name="Vln RunDn Mj" ProgramChange="84" />
+      <Patch Number="342" Name="Vln RunDn Mn" ProgramChange="85" />
+      <Patch Number="343" Name="Maj/MinHarps" ProgramChange="86" />
+      <Patch Number="344" Name="9th/b9 Harps" ProgramChange="87" />
+      <Patch Number="345" Name="Harp m7 SRX" ProgramChange="88" />
+      <Patch Number="346" Name="Harp 9th SRX" ProgramChange="89" />
+      <Patch Number="347" Name="Harp +7 SRX" ProgramChange="90" />
+      <Patch Number="348" Name="Harp b9 SRX" ProgramChange="91" />
+      <Patch Number="349" Name="Harpm7SclSRX" ProgramChange="92" />
+      <Patch Number="350" Name="Harp9thScrlS" ProgramChange="93" />
+      <Patch Number="351" Name="Harp+7SclSRX" ProgramChange="94" />
+      <Patch Number="352" Name="Harpb9SclSRX" ProgramChange="95" />
+      <Patch Number="353" Name="Cluster Gong" ProgramChange="96" />
+      <Patch Number="354" Name="Sus.Perc Hit" ProgramChange="97" />
+      <Patch Number="355" Name="Prc Ens6-Maj" ProgramChange="98" />
+      <Patch Number="356" Name="Prc Ens7-Min" ProgramChange="99" />
+      <Patch Number="357" Name="Prc Ens8-Dim" ProgramChange="100" />
+      <Patch Number="358" Name="Cluster SRX" ProgramChange="101" />
+      <Patch Number="359" Name="HorrorClustr" ProgramChange="102" />
+      <Patch Number="360" Name="Hell Section" ProgramChange="103" />
+      <Patch Number="361" Name="Legettimare" ProgramChange="104" />
+      <Patch Number="362" Name="Limbus SRX" ProgramChange="105" />
+      <Patch Number="363" Name="Backword" ProgramChange="106" />
+      <Patch Number="364" Name="Dreamseq SRX" ProgramChange="107" />
+      <Patch Number="365" Name="Midnight SRX" ProgramChange="108" />
+      <Patch Number="366" Name="Colombus SRX" ProgramChange="109" />
+      <Patch Number="367" Name="Once Upon A" ProgramChange="110" />
+      <Patch Number="368" Name="Desert Dream" ProgramChange="111" />
+      <Patch Number="369" Name="AncientTimes" ProgramChange="112" />
+      <Patch Number="370" Name="Tension SRX" ProgramChange="113" />
+      <Patch Number="371" Name="Wreck" ProgramChange="114" />
+      <Patch Number="372" Name="Eclipse SRX" ProgramChange="115" />
+      <Patch Number="373" Name="PulsingVox S" ProgramChange="116" />
+      <Patch Number="374" Name="SynthStr.Pad" ProgramChange="117" />
+      <Patch Number="375" Name="Meditate PAD" ProgramChange="118" />
+      <Patch Number="376" Name="Choir" ProgramChange="119" />
+      <Patch Number="377" Name="Angelic Pad" ProgramChange="120" />
+      <Patch Number="378" Name="BoysChoirSRX" ProgramChange="121" />
+      <Patch Number="379" Name="Sing! /Mod" ProgramChange="122" />
+      <Patch Number="380" Name="SmockyVoices" ProgramChange="123" />
+      <Patch Number="381" Name="Smooth Choir" ProgramChange="124" />
+      <Patch Number="382" Name="X.. Vox SRX" ProgramChange="125" />
+      <Patch Number="383" Name="RealChoirSRX" ProgramChange="126" />
+      <Patch Number="384" Name="StChrMm/Ah S" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX06) 384-449">
+      <Patch Number="385" Name="Mmms &amp; Aaahs" ProgramChange="0" />
+      <Patch Number="386" Name="Choir /Mod" ProgramChange="1" />
+      <Patch Number="387" Name="Close Mouths" ProgramChange="2" />
+      <Patch Number="388" Name="Voice Stax" ProgramChange="3" />
+      <Patch Number="389" Name="MorphieChoir" ProgramChange="4" />
+      <Patch Number="390" Name="Morph4Choir" ProgramChange="5" />
+      <Patch Number="391" Name="17th Movemnt" ProgramChange="6" />
+      <Patch Number="392" Name="Matins" ProgramChange="7" />
+      <Patch Number="393" Name="Quartet II 5" ProgramChange="8" />
+      <Patch Number="394" Name="Scat /" ProgramChange="9" />
+      <Patch Number="395" Name="Scatmen! SRX" ProgramChange="10" />
+      <Patch Number="396" Name="The Voices" ProgramChange="11" />
+      <Patch Number="397" Name="VocalCollect" ProgramChange="12" />
+      <Patch Number="398" Name="GregorianCho" ProgramChange="13" />
+      <Patch Number="399" Name="Soprano&amp;co." ProgramChange="14" />
+      <Patch Number="400" Name="Tenor solo" ProgramChange="15" />
+      <Patch Number="401" Name="ClarsahHarpS" ProgramChange="16" />
+      <Patch Number="402" Name="Heavens Harp" ProgramChange="17" />
+      <Patch Number="403" Name="C.Hrp/padSRX" ProgramChange="18" />
+      <Patch Number="404" Name="PhaseClarsah" ProgramChange="19" />
+      <Patch Number="405" Name="ClearHarpSRX" ProgramChange="20" />
+      <Patch Number="406" Name="Nails Harp" ProgramChange="21" />
+      <Patch Number="407" Name="Harp SRX" ProgramChange="22" />
+      <Patch Number="408" Name="Natural Harp" ProgramChange="23" />
+      <Patch Number="409" Name="Warm Harp" ProgramChange="24" />
+      <Patch Number="410" Name="Bousouk&amp;Harp" ProgramChange="25" />
+      <Patch Number="411" Name="Etheral Lute" ProgramChange="26" />
+      <Patch Number="412" Name="DelicateCOMB" ProgramChange="27" />
+      <Patch Number="413" Name="St.CymblnSRX" ProgramChange="28" />
+      <Patch Number="414" Name="CymblnDuoSRX" ProgramChange="29" />
+      <Patch Number="415" Name="Bohemian SRX" ProgramChange="30" />
+      <Patch Number="416" Name="Bousouki Pic" ProgramChange="31" />
+      <Patch Number="417" Name="Bousouki" ProgramChange="32" />
+      <Patch Number="418" Name="PulcinelaSRX" ProgramChange="33" />
+      <Patch Number="419" Name="SN Roll SRX/" ProgramChange="34" />
+      <Patch Number="420" Name="Perc Ens 1^" ProgramChange="35" />
+      <Patch Number="421" Name="Perc Ens 2^" ProgramChange="36" />
+      <Patch Number="422" Name="Perc Ens 3^" ProgramChange="37" />
+      <Patch Number="423" Name="Perc Ens 4^" ProgramChange="38" />
+      <Patch Number="424" Name="Perc Ens 5^" ProgramChange="39" />
+      <Patch Number="425" Name="Orch Percs" ProgramChange="40" />
+      <Patch Number="426" Name="BodhranSplit" ProgramChange="41" />
+      <Patch Number="427" Name="BodhranVel S" ProgramChange="42" />
+      <Patch Number="428" Name="CrazyBodhrnS" ProgramChange="43" />
+      <Patch Number="429" Name="BodhranMenuS" ProgramChange="44" />
+      <Patch Number="430" Name="Perc Mix SRX" ProgramChange="45" />
+      <Patch Number="431" Name="MassiveTimpa" ProgramChange="46" />
+      <Patch Number="432" Name="4-way Timps" ProgramChange="47" />
+      <Patch Number="433" Name="DynaTimpsSRX" ProgramChange="48" />
+      <Patch Number="434" Name="TimpaniRoll1" ProgramChange="49" />
+      <Patch Number="435" Name="TimpaniRoll2" ProgramChange="50" />
+      <Patch Number="436" Name="MultiTimpani" ProgramChange="51" />
+      <Patch Number="437" Name="Roll &gt; Klang" ProgramChange="52" />
+      <Patch Number="438" Name="Timpani /" ProgramChange="53" />
+      <Patch Number="439" Name="Big Orc.Perc" ProgramChange="54" />
+      <Patch Number="440" Name="WindChimeSRX" ProgramChange="55" />
+      <Patch Number="441" Name="FingerCymSRX" ProgramChange="56" />
+      <Patch Number="442" Name="ConcertBDSRX" ProgramChange="57" />
+      <Patch Number="443" Name="BD Roll SRX/" ProgramChange="58" />
+      <Patch Number="444" Name="Tam Tam SRX" ProgramChange="59" />
+      <Patch Number="445" Name="Piatti!! SRX" ProgramChange="60" />
+      <Patch Number="446" Name="SleighBellsS" ProgramChange="61" />
+      <Patch Number="447" Name="SlapstickS /" ProgramChange="62" />
+      <Patch Number="448" Name="TambourineS/" ProgramChange="63" />
+      <Patch Number="449" Name="CastanetsS /" ProgramChange="64" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX07) 1-128">
+      <Patch Number="001" Name="Stereo Piano" ProgramChange="0" />
+      <Patch Number="002" Name="Gran'Piano" ProgramChange="1" />
+      <Patch Number="003" Name="Easy Rocker" ProgramChange="2" />
+      <Patch Number="004" Name="Stage Grand" ProgramChange="3" />
+      <Patch Number="005" Name="SA Rocker" ProgramChange="4" />
+      <Patch Number="006" Name="Padded Pno" ProgramChange="5" />
+      <Patch Number="007" Name="Suitcase EP" ProgramChange="6" />
+      <Patch Number="008" Name="Real Thing" ProgramChange="7" />
+      <Patch Number="009" Name="Fusiontastic" ProgramChange="8" />
+      <Patch Number="010" Name="Inspiration" ProgramChange="9" />
+      <Patch Number="011" Name="Touch EP SRX" ProgramChange="10" />
+      <Patch Number="012" Name="Stage73 SRX" ProgramChange="11" />
+      <Patch Number="013" Name="Stage EP 2" ProgramChange="12" />
+      <Patch Number="014" Name="BalladPanner" ProgramChange="13" />
+      <Patch Number="015" Name="80's EP" ProgramChange="14" />
+      <Patch Number="016" Name="SweetStagePN" ProgramChange="15" />
+      <Patch Number="017" Name="Padded EP" ProgramChange="16" />
+      <Patch Number="018" Name="Nursery Tine" ProgramChange="17" />
+      <Patch Number="019" Name="Sine EP" ProgramChange="18" />
+      <Patch Number="020" Name="70s Ballad" ProgramChange="19" />
+      <Patch Number="021" Name="Church Mouse" ProgramChange="20" />
+      <Patch Number="022" Name="ClaviQ EP" ProgramChange="21" />
+      <Patch Number="023" Name="FlaredTrouzr" ProgramChange="22" />
+      <Patch Number="024" Name="70'EP Bs" ProgramChange="23" />
+      <Patch Number="025" Name="Swurly" ProgramChange="24" />
+      <Patch Number="026" Name="Dyno-Wurli" ProgramChange="25" />
+      <Patch Number="027" Name="60s Bros" ProgramChange="26" />
+      <Patch Number="028" Name="Pianohner" ProgramChange="27" />
+      <Patch Number="029" Name="Pianette 2K" ProgramChange="28" />
+      <Patch Number="030" Name="Cheapy Ep1" ProgramChange="29" />
+      <Patch Number="031" Name="Rox 668 St" ProgramChange="30" />
+      <Patch Number="032" Name="80's FM" ProgramChange="31" />
+      <Patch Number="033" Name="The 70'EP" ProgramChange="32" />
+      <Patch Number="034" Name="Heavens Tine" ProgramChange="33" />
+      <Patch Number="035" Name="Sparkle EPno" ProgramChange="34" />
+      <Patch Number="036" Name="FirstDigital" ProgramChange="35" />
+      <Patch Number="037" Name="Vox Harpsi" ProgramChange="36" />
+      <Patch Number="038" Name="Harpsiclav" ProgramChange="37" />
+      <Patch Number="039" Name="E.Harpsi" ProgramChange="38" />
+      <Patch Number="040" Name="Clav 1 SRX" ProgramChange="39" />
+      <Patch Number="041" Name="Clav 2 SRX" ProgramChange="40" />
+      <Patch Number="042" Name="VeloClav SRX" ProgramChange="41" />
+      <Patch Number="043" Name="Clav 3 SRX" ProgramChange="42" />
+      <Patch Number="044" Name="Generic Clav" ProgramChange="43" />
+      <Patch Number="045" Name="Clav Pluck" ProgramChange="44" />
+      <Patch Number="046" Name="Vintage Clav" ProgramChange="45" />
+      <Patch Number="047" Name="Dyno Clav" ProgramChange="46" />
+      <Patch Number="048" Name="PhaserClavi" ProgramChange="47" />
+      <Patch Number="049" Name="CompClav SRX" ProgramChange="48" />
+      <Patch Number="050" Name="MuteClv1 SRX" ProgramChange="49" />
+      <Patch Number="051" Name="MuteClv2 SRX" ProgramChange="50" />
+      <Patch Number="052" Name="Clav Supremo" ProgramChange="51" />
+      <Patch Number="053" Name="Clav By III" ProgramChange="52" />
+      <Patch Number="054" Name="Funk Synclav" ProgramChange="53" />
+      <Patch Number="055" Name="Quacky Clav" ProgramChange="54" />
+      <Patch Number="056" Name="GuitClav SRX" ProgramChange="55" />
+      <Patch Number="057" Name="Juno Clavi" ProgramChange="56" />
+      <Patch Number="058" Name="PhazynClvSRX" ProgramChange="57" />
+      <Patch Number="059" Name="Moogy Pulse" ProgramChange="58" />
+      <Patch Number="060" Name="JP8 Clav SRX" ProgramChange="59" />
+      <Patch Number="061" Name="HyperClv SRX" ProgramChange="60" />
+      <Patch Number="062" Name="Twinkle Bell" ProgramChange="61" />
+      <Patch Number="063" Name="Troika Ride" ProgramChange="62" />
+      <Patch Number="064" Name="Analog Bell" ProgramChange="63" />
+      <Patch Number="065" Name="Goodnite SRX" ProgramChange="64" />
+      <Patch Number="066" Name="2.2 SEQ SRX" ProgramChange="65" />
+      <Patch Number="067" Name="Vibraphone!" ProgramChange="66" />
+      <Patch Number="068" Name="SA Vibe  SRX" ProgramChange="67" />
+      <Patch Number="069" Name="Blue B  SRX" ProgramChange="68" />
+      <Patch Number="070" Name="FullPerc SRX" ProgramChange="69" />
+      <Patch Number="071" Name="NiceFeel SRX" ProgramChange="70" />
+      <Patch Number="072" Name="GreenB /Pdl" ProgramChange="71" />
+      <Patch Number="073" Name="Mello" ProgramChange="72" />
+      <Patch Number="074" Name="LA Blues SRX" ProgramChange="73" />
+      <Patch Number="075" Name="2BorNot2B3 2" ProgramChange="74" />
+      <Patch Number="076" Name="Gospel B SRX" ProgramChange="75" />
+      <Patch Number="077" Name="Bookin'B SRX" ProgramChange="76" />
+      <Patch Number="078" Name="Hush B3 SRX" ProgramChange="77" />
+      <Patch Number="079" Name="Real Organ" ProgramChange="78" />
+      <Patch Number="080" Name="Tenamos L100" ProgramChange="79" />
+      <Patch Number="081" Name="Harm.Organ" ProgramChange="80" />
+      <Patch Number="082" Name="Harm.Organ2" ProgramChange="81" />
+      <Patch Number="083" Name="Power B SRX" ProgramChange="82" />
+      <Patch Number="084" Name="AllStarB3SRX" ProgramChange="83" />
+      <Patch Number="085" Name="GoodLord/Mod" ProgramChange="84" />
+      <Patch Number="086" Name="CabnetSeries" ProgramChange="85" />
+      <Patch Number="087" Name="Absolute B3" ProgramChange="86" />
+      <Patch Number="088" Name="Rox368-B/Mod" ProgramChange="87" />
+      <Patch Number="089" Name="Suitcase B3" ProgramChange="88" />
+      <Patch Number="090" Name="BalladB /Mod" ProgramChange="89" />
+      <Patch Number="091" Name="70'sKeysMix" ProgramChange="90" />
+      <Patch Number="092" Name="Leslied B3" ProgramChange="91" />
+      <Patch Number="093" Name="Dyna Hammnd" ProgramChange="92" />
+      <Patch Number="094" Name="SaltyDog SRX" ProgramChange="93" />
+      <Patch Number="095" Name="Swt&amp;Mllw SRX" ProgramChange="94" />
+      <Patch Number="096" Name="Mellow 4'SRX" ProgramChange="95" />
+      <Patch Number="097" Name="ZomBee SRX" ProgramChange="96" />
+      <Patch Number="098" Name="Perky Twin B" ProgramChange="97" />
+      <Patch Number="099" Name="BluesPercSRX" ProgramChange="98" />
+      <Patch Number="100" Name="Club Organ" ProgramChange="99" />
+      <Patch Number="101" Name="888 +3rd SRX" ProgramChange="100" />
+      <Patch Number="102" Name="8888+3rd SRX" ProgramChange="101" />
+      <Patch Number="103" Name="Velo Perc" ProgramChange="102" />
+      <Patch Number="104" Name="Jazzy B" ProgramChange="103" />
+      <Patch Number="105" Name="Gutsy C3" ProgramChange="104" />
+      <Patch Number="106" Name="B3 888000004" ProgramChange="105" />
+      <Patch Number="107" Name="60s Brothers" ProgramChange="106" />
+      <Patch Number="108" Name="FirePerc SRX" ProgramChange="107" />
+      <Patch Number="109" Name="PercNorm3rd" ProgramChange="108" />
+      <Patch Number="110" Name="PercSoft3rd" ProgramChange="109" />
+      <Patch Number="111" Name="858808880SRX" ProgramChange="110" />
+      <Patch Number="112" Name="Mad Organ" ProgramChange="111" />
+      <Patch Number="113" Name="Touchy B Fst" ProgramChange="112" />
+      <Patch Number="114" Name="Souvenirs" ProgramChange="113" />
+      <Patch Number="115" Name="R&amp;R B3 SRX" ProgramChange="114" />
+      <Patch Number="116" Name="B3Sermon SRX" ProgramChange="115" />
+      <Patch Number="117" Name="AllSkate!SRX" ProgramChange="116" />
+      <Patch Number="118" Name="BalladB3 SRX" ProgramChange="117" />
+      <Patch Number="119" Name="Ultimate B 4" ProgramChange="118" />
+      <Patch Number="120" Name="Purple SRX" ProgramChange="119" />
+      <Patch Number="121" Name="GimmeSomeSRX" ProgramChange="120" />
+      <Patch Number="122" Name="Smoked Water" ProgramChange="121" />
+      <Patch Number="123" Name="HardPerc3rd" ProgramChange="122" />
+      <Patch Number="124" Name="FuzzheadSRX" ProgramChange="123" />
+      <Patch Number="125" Name="Tron B" ProgramChange="124" />
+      <Patch Number="126" Name="ShimmerOrgan" ProgramChange="125" />
+      <Patch Number="127" Name="AnimalModSRX" ProgramChange="126" />
+      <Patch Number="128" Name="SurfMnkysSRX" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX07) 129-256">
+      <Patch Number="129" Name="TelstarOrgan" ProgramChange="0" />
+      <Patch Number="130" Name="Continental" ProgramChange="1" />
+      <Patch Number="131" Name="Organfest'66" ProgramChange="2" />
+      <Patch Number="132" Name="PalisadesSRX" ProgramChange="3" />
+      <Patch Number="133" Name="New Riders" ProgramChange="4" />
+      <Patch Number="134" Name="The Sham SRX" ProgramChange="5" />
+      <Patch Number="135" Name="CrummyOrgSRX" ProgramChange="6" />
+      <Patch Number="136" Name="IronFarf SRX" ProgramChange="7" />
+      <Patch Number="137" Name="FarfComboSRX" ProgramChange="8" />
+      <Patch Number="138" Name="Farfisorium" ProgramChange="9" />
+      <Patch Number="139" Name="Farf 8' + 2'" ProgramChange="10" />
+      <Patch Number="140" Name="RoxOrgan SRX" ProgramChange="11" />
+      <Patch Number="141" Name="DittyDoo SRX" ProgramChange="12" />
+      <Patch Number="142" Name="Tranny Organ" ProgramChange="13" />
+      <Patch Number="143" Name="2.2 Organ" ProgramChange="14" />
+      <Patch Number="144" Name="VS Organ SRX" ProgramChange="15" />
+      <Patch Number="145" Name="D50 OrganSRX" ProgramChange="16" />
+      <Patch Number="146" Name="OrganbellSRX" ProgramChange="17" />
+      <Patch Number="147" Name="PhazedOrgSRX" ProgramChange="18" />
+      <Patch Number="148" Name="Das Limpet" ProgramChange="19" />
+      <Patch Number="149" Name="Spanish Gtr" ProgramChange="20" />
+      <Patch Number="150" Name="Nylon SoSoft" ProgramChange="21" />
+      <Patch Number="151" Name="Nylon on Pad" ProgramChange="22" />
+      <Patch Number="152" Name="Moody Nylon" ProgramChange="23" />
+      <Patch Number="153" Name="Conquest" ProgramChange="24" />
+      <Patch Number="154" Name="Heaven Nylon" ProgramChange="25" />
+      <Patch Number="155" Name="In Peace" ProgramChange="26" />
+      <Patch Number="156" Name="NashvilleSRX" ProgramChange="27" />
+      <Patch Number="157" Name="Caster Delay" ProgramChange="28" />
+      <Patch Number="158" Name="Ricken12stGT" ProgramChange="29" />
+      <Patch Number="159" Name="Narnia" ProgramChange="30" />
+      <Patch Number="160" Name="Gtr PopArps" ProgramChange="31" />
+      <Patch Number="161" Name="Touchy Mutes" ProgramChange="32" />
+      <Patch Number="162" Name="Disto-Chunky" ProgramChange="33" />
+      <Patch Number="163" Name="Rock Mute" ProgramChange="34" />
+      <Patch Number="164" Name="Telemaster" ProgramChange="35" />
+      <Patch Number="165" Name="Plugged!" ProgramChange="36" />
+      <Patch Number="166" Name="MutedDsBlief" ProgramChange="37" />
+      <Patch Number="167" Name="MM Bass /" ProgramChange="38" />
+      <Patch Number="168" Name="MMFatSlapSRX" ProgramChange="39" />
+      <Patch Number="169" Name="HyperFunkSRX" ProgramChange="40" />
+      <Patch Number="170" Name="MillerPopSRX" ProgramChange="41" />
+      <Patch Number="171" Name="Funk Bass" ProgramChange="42" />
+      <Patch Number="172" Name="Abe 4way SRX" ProgramChange="43" />
+      <Patch Number="173" Name="AL3way/NzSRX" ProgramChange="44" />
+      <Patch Number="174" Name="ALDarkSlpSRX" ProgramChange="45" />
+      <Patch Number="175" Name="John 4waySRX" ProgramChange="46" />
+      <Patch Number="176" Name="JPBritSlpSRX" ProgramChange="47" />
+      <Patch Number="177" Name="John w/NzSRX" ProgramChange="48" />
+      <Patch Number="178" Name="6strngBASS +" ProgramChange="49" />
+      <Patch Number="179" Name="Big Bad AL" ProgramChange="50" />
+      <Patch Number="180" Name="Comp 6tr Bas" ProgramChange="51" />
+      <Patch Number="181" Name="AbeLimitrSRX" ProgramChange="52" />
+      <Patch Number="182" Name="JP P.Bs 1SRX" ProgramChange="53" />
+      <Patch Number="183" Name="JP P.Bs 2SRX" ProgramChange="54" />
+      <Patch Number="184" Name="Abe'sP.BsSRX" ProgramChange="55" />
+      <Patch Number="185" Name="AL Solid SRX" ProgramChange="56" />
+      <Patch Number="186" Name="AL2wayFngSRX" ProgramChange="57" />
+      <Patch Number="187" Name="AL SoftBs/Nz" ProgramChange="58" />
+      <Patch Number="188" Name="MarcusJB SRX" ProgramChange="59" />
+      <Patch Number="189" Name="MM JB SRX" ProgramChange="60" />
+      <Patch Number="190" Name="Pick UP SRX" ProgramChange="61" />
+      <Patch Number="191" Name="JP Rock SRX" ProgramChange="62" />
+      <Patch Number="192" Name="PickedJzBass" ProgramChange="63" />
+      <Patch Number="193" Name="BritePickSRX" ProgramChange="64" />
+      <Patch Number="194" Name="PhsrMute SRX" ProgramChange="65" />
+      <Patch Number="195" Name="DarkPick SRX" ProgramChange="66" />
+      <Patch Number="196" Name="Country Mute" ProgramChange="67" />
+      <Patch Number="197" Name="FretlessBASS" ProgramChange="68" />
+      <Patch Number="198" Name="SoloFls SRX" ProgramChange="69" />
+      <Patch Number="199" Name="JP6StrFlsSRX" ProgramChange="70" />
+      <Patch Number="200" Name="MM OctFlsSRX" ProgramChange="71" />
+      <Patch Number="201" Name="MMSmthFlsSRX" ProgramChange="72" />
+      <Patch Number="202" Name="ALFlsSoloSRX" ProgramChange="73" />
+      <Patch Number="203" Name="JPSoloFlsSRX" ProgramChange="74" />
+      <Patch Number="204" Name="Contrabbasso" ProgramChange="75" />
+      <Patch Number="205" Name="InYerFaceBas" ProgramChange="76" />
+      <Patch Number="206" Name="BriteUpright" ProgramChange="77" />
+      <Patch Number="207" Name="Uplectric" ProgramChange="78" />
+      <Patch Number="208" Name="JPSoftAB SRX" ProgramChange="79" />
+      <Patch Number="209" Name="JPHardAB SRX" ProgramChange="80" />
+      <Patch Number="210" Name="Dry AcB SRX" ProgramChange="81" />
+      <Patch Number="211" Name="WildThangSRX" ProgramChange="82" />
+      <Patch Number="212" Name="Dist Bs SRX" ProgramChange="83" />
+      <Patch Number="213" Name="StickyBs SRX" ProgramChange="84" />
+      <Patch Number="214" Name="FunkinWahSRX" ProgramChange="85" />
+      <Patch Number="215" Name="Harm A#9 SRX" ProgramChange="86" />
+      <Patch Number="216" Name="Harm E69 SRX" ProgramChange="87" />
+      <Patch Number="217" Name="SlidesNz SRX" ProgramChange="88" />
+      <Patch Number="218" Name="AllSlidesSRX" ProgramChange="89" />
+      <Patch Number="219" Name="AllNoisesSRX" ProgramChange="90" />
+      <Patch Number="220" Name="Ac.Bs Nz SRX" ProgramChange="91" />
+      <Patch Number="221" Name="WildSynth101" ProgramChange="92" />
+      <Patch Number="222" Name="SH Dullbass" ProgramChange="93" />
+      <Patch Number="223" Name="101 Bass" ProgramChange="94" />
+      <Patch Number="224" Name="SH101 Bass" ProgramChange="95" />
+      <Patch Number="225" Name="SH-2 Bs SRX" ProgramChange="96" />
+      <Patch Number="226" Name="Bassic101SRX" ProgramChange="97" />
+      <Patch Number="227" Name="Fat Butt" ProgramChange="98" />
+      <Patch Number="228" Name="JP-4 Bs SRX" ProgramChange="99" />
+      <Patch Number="229" Name="Systm700 SRX" ProgramChange="100" />
+      <Patch Number="230" Name="BigSubBs SRX" ProgramChange="101" />
+      <Patch Number="231" Name="TickerBs SRX" ProgramChange="102" />
+      <Patch Number="232" Name="202 Bass" ProgramChange="103" />
+      <Patch Number="233" Name="101ZapBs SRX" ProgramChange="104" />
+      <Patch Number="234" Name="Housy Bass" ProgramChange="105" />
+      <Patch Number="235" Name="HousineBsSRX" ProgramChange="106" />
+      <Patch Number="236" Name="WooferBs SRX" ProgramChange="107" />
+      <Patch Number="237" Name="System100SRX" ProgramChange="108" />
+      <Patch Number="238" Name="Low Bass SRX" ProgramChange="109" />
+      <Patch Number="239" Name="TB3O3 Reso" ProgramChange="110" />
+      <Patch Number="240" Name="MeanderingBs" ProgramChange="111" />
+      <Patch Number="241" Name="Acid TB Bs" ProgramChange="112" />
+      <Patch Number="242" Name="MonsterMGSRX" ProgramChange="113" />
+      <Patch Number="243" Name="Rogue Bs SRX" ProgramChange="114" />
+      <Patch Number="244" Name="Classic Bs" ProgramChange="115" />
+      <Patch Number="245" Name="Fat Bass" ProgramChange="116" />
+      <Patch Number="246" Name="ResoMG BsSRX" ProgramChange="117" />
+      <Patch Number="247" Name="MG Punchbass" ProgramChange="118" />
+      <Patch Number="248" Name="Spike Bs SRX" ProgramChange="119" />
+      <Patch Number="249" Name="WetMG Bs SRX" ProgramChange="120" />
+      <Patch Number="250" Name="2-way Bass" ProgramChange="121" />
+      <Patch Number="251" Name="Oct stinger" ProgramChange="122" />
+      <Patch Number="252" Name="BsPedals SRX" ProgramChange="123" />
+      <Patch Number="253" Name="MG PedalsSRX" ProgramChange="124" />
+      <Patch Number="254" Name="OB Bass SRX" ProgramChange="125" />
+      <Patch Number="255" Name="8VCO Mono" ProgramChange="126" />
+      <Patch Number="256" Name="Thick OBass" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX07) 257-384">
+      <Patch Number="257" Name="The Synbass" ProgramChange="0" />
+      <Patch Number="258" Name="Dark~~~~BASS" ProgramChange="1" />
+      <Patch Number="259" Name="Valve5thBass" ProgramChange="2" />
+      <Patch Number="260" Name="Rezidence" ProgramChange="3" />
+      <Patch Number="261" Name="OrganSawBass" ProgramChange="4" />
+      <Patch Number="262" Name="Organ Bass" ProgramChange="5" />
+      <Patch Number="263" Name="SquareBs SRX" ProgramChange="6" />
+      <Patch Number="264" Name="SlobbryBsSRX" ProgramChange="7" />
+      <Patch Number="265" Name="Super Bs SRX" ProgramChange="8" />
+      <Patch Number="266" Name="STronSTringz" ProgramChange="9" />
+      <Patch Number="267" Name="TrnStrDrySRX" ProgramChange="10" />
+      <Patch Number="268" Name="Tron Vls SRX" ProgramChange="11" />
+      <Patch Number="269" Name="MelloVlnsSRX" ProgramChange="12" />
+      <Patch Number="270" Name="JP8 Str1 SRX" ProgramChange="13" />
+      <Patch Number="271" Name="JP8 Str2 SRX" ProgramChange="14" />
+      <Patch Number="272" Name="JP+OB StrSRX" ProgramChange="15" />
+      <Patch Number="273" Name="M12 Strings" ProgramChange="16" />
+      <Patch Number="274" Name="Wavestr SRX" ProgramChange="17" />
+      <Patch Number="275" Name="MemoryMG SRX" ProgramChange="18" />
+      <Patch Number="276" Name="Solina SRX" ProgramChange="19" />
+      <Patch Number="277" Name="Omni Strings" ProgramChange="20" />
+      <Patch Number="278" Name="Big Str SRX" ProgramChange="21" />
+      <Patch Number="279" Name="Solo Flute" ProgramChange="22" />
+      <Patch Number="280" Name="TouchFlt SRX" ProgramChange="23" />
+      <Patch Number="281" Name="StrawberTRON" ProgramChange="24" />
+      <Patch Number="282" Name="Flute School" ProgramChange="25" />
+      <Patch Number="283" Name="Calli SRX" ProgramChange="26" />
+      <Patch Number="284" Name="TpSoloistSRX" ProgramChange="27" />
+      <Patch Number="285" Name="Pop Fanfare" ProgramChange="28" />
+      <Patch Number="286" Name="Oct Brass" ProgramChange="29" />
+      <Patch Number="287" Name="SessnBrs SRX" ProgramChange="30" />
+      <Patch Number="288" Name="R&amp;R Bras SRX" ProgramChange="31" />
+      <Patch Number="289" Name="SuperTnr SRX" ProgramChange="32" />
+      <Patch Number="290" Name="T.Sax f SRX" ProgramChange="33" />
+      <Patch Number="291" Name="Cool Sax" ProgramChange="34" />
+      <Patch Number="292" Name="Duelin' Saxs" ProgramChange="35" />
+      <Patch Number="293" Name="SoftSaxesSRX" ProgramChange="36" />
+      <Patch Number="294" Name="AmazngEchSRX" ProgramChange="37" />
+      <Patch Number="295" Name="FlaxOstinato" ProgramChange="38" />
+      <Patch Number="296" Name="2voiceLd SRX" ProgramChange="39" />
+      <Patch Number="297" Name="Hollo Lead" ProgramChange="40" />
+      <Patch Number="298" Name="Sinusolo SRX" ProgramChange="41" />
+      <Patch Number="299" Name="Shmoog SRX" ProgramChange="42" />
+      <Patch Number="300" Name="Sine" ProgramChange="43" />
+      <Patch Number="301" Name="SH2000VoxSRX" ProgramChange="44" />
+      <Patch Number="302" Name="FM Lead SRX" ProgramChange="45" />
+      <Patch Number="303" Name="TrickTailEnd" ProgramChange="46" />
+      <Patch Number="304" Name="4 Old Saws" ProgramChange="47" />
+      <Patch Number="305" Name="Saw Bowed" ProgramChange="48" />
+      <Patch Number="306" Name="VoxSaws Lead" ProgramChange="49" />
+      <Patch Number="307" Name="GR500 Ld SRX" ProgramChange="50" />
+      <Patch Number="308" Name="LimonaireSRX" ProgramChange="51" />
+      <Patch Number="309" Name="NakdCheseSRX" ProgramChange="52" />
+      <Patch Number="310" Name="PromarsLdSRX" ProgramChange="53" />
+      <Patch Number="311" Name="Sweeze Lead" ProgramChange="54" />
+      <Patch Number="312" Name="Homey Lead" ProgramChange="55" />
+      <Patch Number="313" Name="MG Lead SRX" ProgramChange="56" />
+      <Patch Number="314" Name="Dreams Saw" ProgramChange="57" />
+      <Patch Number="315" Name="The Real Pat" ProgramChange="58" />
+      <Patch Number="316" Name="H 2 O" ProgramChange="59" />
+      <Patch Number="317" Name="PulseLd SRX" ProgramChange="60" />
+      <Patch Number="318" Name="Mono FM Lead" ProgramChange="61" />
+      <Patch Number="319" Name="VCO OctLdSRX" ProgramChange="62" />
+      <Patch Number="320" Name="Saws Lead" ProgramChange="63" />
+      <Patch Number="321" Name="Changes" ProgramChange="64" />
+      <Patch Number="322" Name="P5 Lead" ProgramChange="65" />
+      <Patch Number="323" Name="SH-2&amp;5 Sqr" ProgramChange="66" />
+      <Patch Number="324" Name="Cutting Solo" ProgramChange="67" />
+      <Patch Number="325" Name="Racy Lead" ProgramChange="68" />
+      <Patch Number="326" Name="Speedometer" ProgramChange="69" />
+      <Patch Number="327" Name="Rotary Lead" ProgramChange="70" />
+      <Patch Number="328" Name="BuzzzzzzzSRX" ProgramChange="71" />
+      <Patch Number="329" Name="Telstar Lead" ProgramChange="72" />
+      <Patch Number="330" Name="Pattern It" ProgramChange="73" />
+      <Patch Number="331" Name="Carbonite" ProgramChange="74" />
+      <Patch Number="332" Name="The Pipe 5th" ProgramChange="75" />
+      <Patch Number="333" Name="Buzzy Beez" ProgramChange="76" />
+      <Patch Number="334" Name="Look Back" ProgramChange="77" />
+      <Patch Number="335" Name="Razzert" ProgramChange="78" />
+      <Patch Number="336" Name="Raveferenz" ProgramChange="79" />
+      <Patch Number="337" Name="SupremeCheez" ProgramChange="80" />
+      <Patch Number="338" Name="Exit" ProgramChange="81" />
+      <Patch Number="339" Name="MousBoxesCat" ProgramChange="82" />
+      <Patch Number="340" Name="Riff the 5th" ProgramChange="83" />
+      <Patch Number="341" Name="Ice Man" ProgramChange="84" />
+      <Patch Number="342" Name="DncStack1SRX" ProgramChange="85" />
+      <Patch Number="343" Name="DncStack2SRX" ProgramChange="86" />
+      <Patch Number="344" Name="DncStack3SRX" ProgramChange="87" />
+      <Patch Number="345" Name="DncStack4SRX" ProgramChange="88" />
+      <Patch Number="346" Name="DncStack5SRX" ProgramChange="89" />
+      <Patch Number="347" Name="Euro BrsSRX" ProgramChange="90" />
+      <Patch Number="348" Name="ThipsBlipSRX" ProgramChange="91" />
+      <Patch Number="349" Name="FaveoravoSRX" ProgramChange="92" />
+      <Patch Number="350" Name="Cleanse" ProgramChange="93" />
+      <Patch Number="351" Name="Mer" ProgramChange="94" />
+      <Patch Number="352" Name="B-lieve" ProgramChange="95" />
+      <Patch Number="353" Name="Blue Light" ProgramChange="96" />
+      <Patch Number="354" Name="Progress" ProgramChange="97" />
+      <Patch Number="355" Name="Modularswirl" ProgramChange="98" />
+      <Patch Number="356" Name="Sparkly" ProgramChange="99" />
+      <Patch Number="357" Name="Undertones" ProgramChange="100" />
+      <Patch Number="358" Name="HappyLFOsSRX" ProgramChange="101" />
+      <Patch Number="359" Name="AeroInsctSRX" ProgramChange="102" />
+      <Patch Number="360" Name="MC8 Seq SRX" ProgramChange="103" />
+      <Patch Number="361" Name="Legato Rip" ProgramChange="104" />
+      <Patch Number="362" Name="Steam Valve" ProgramChange="105" />
+      <Patch Number="363" Name="Scanner7" ProgramChange="106" />
+      <Patch Number="364" Name="Haunted Tron" ProgramChange="107" />
+      <Patch Number="365" Name="Experimental" ProgramChange="108" />
+      <Patch Number="366" Name="Megatron" ProgramChange="109" />
+      <Patch Number="367" Name="Outer Spaces" ProgramChange="110" />
+      <Patch Number="368" Name="Martian Bell" ProgramChange="111" />
+      <Patch Number="369" Name="Ethereal SRX" ProgramChange="112" />
+      <Patch Number="370" Name="Meow 5thsSRX" ProgramChange="113" />
+      <Patch Number="371" Name="MantrawavSRX" ProgramChange="114" />
+      <Patch Number="372" Name="RSS SpinnerS" ProgramChange="115" />
+      <Patch Number="373" Name="Comp Net SRX" ProgramChange="116" />
+      <Patch Number="374" Name="SpitBrs SRX" ProgramChange="117" />
+      <Patch Number="375" Name="Pro-10BrsSRX" ProgramChange="118" />
+      <Patch Number="376" Name="OBStabBrsSRX" ProgramChange="119" />
+      <Patch Number="377" Name="Pro-5 BrsSRX" ProgramChange="120" />
+      <Patch Number="378" Name="Quack BrsSRX" ProgramChange="121" />
+      <Patch Number="379" Name="M.MG Brs SRX" ProgramChange="122" />
+      <Patch Number="380" Name="FM Brs SRX" ProgramChange="123" />
+      <Patch Number="381" Name="D50Belpd1SRX" ProgramChange="124" />
+      <Patch Number="382" Name="D50Belpd2SRX" ProgramChange="125" />
+      <Patch Number="383" Name="D50Belpd3SRX" ProgramChange="126" />
+      <Patch Number="384" Name="KlmbSynthSRX" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX07) 385-475">
+      <Patch Number="385" Name="B Higher" ProgramChange="0" />
+      <Patch Number="386" Name="Reflections" ProgramChange="1" />
+      <Patch Number="387" Name="VintagLayers" ProgramChange="2" />
+      <Patch Number="388" Name="HandleW/Care" ProgramChange="3" />
+      <Patch Number="389" Name="StaccHvn SRX" ProgramChange="4" />
+      <Patch Number="390" Name="TimefliesSRX" ProgramChange="5" />
+      <Patch Number="391" Name="JP6SqKeySRX" ProgramChange="6" />
+      <Patch Number="392" Name="CS Squared" ProgramChange="7" />
+      <Patch Number="393" Name="MawnlowerMan" ProgramChange="8" />
+      <Patch Number="394" Name="Glidiator" ProgramChange="9" />
+      <Patch Number="395" Name="Spit Synthie" ProgramChange="10" />
+      <Patch Number="396" Name="Raver One" ProgramChange="11" />
+      <Patch Number="397" Name="Slop-a-ramaS" ProgramChange="12" />
+      <Patch Number="398" Name="Big PWM SRX" ProgramChange="13" />
+      <Patch Number="399" Name="WavesyncSRX" ProgramChange="14" />
+      <Patch Number="400" Name="T8 Sync SRX" ProgramChange="15" />
+      <Patch Number="401" Name="SyncRush SRX" ProgramChange="16" />
+      <Patch Number="402" Name="DreaminOfJMJ" ProgramChange="17" />
+      <Patch Number="403" Name="Arp Saws SRX" ProgramChange="18" />
+      <Patch Number="404" Name="QuixelateSRX" ProgramChange="19" />
+      <Patch Number="405" Name="SpikedChzSRX" ProgramChange="20" />
+      <Patch Number="406" Name="Planet-S SRX" ProgramChange="21" />
+      <Patch Number="407" Name="Iceburg" ProgramChange="22" />
+      <Patch Number="408" Name="Old,Warm OBX" ProgramChange="23" />
+      <Patch Number="409" Name="Poly 3osc SH" ProgramChange="24" />
+      <Patch Number="410" Name="PortaSyn SRX" ProgramChange="25" />
+      <Patch Number="411" Name="RazrVCOs SRX" ProgramChange="26" />
+      <Patch Number="412" Name="Medusa SRX" ProgramChange="27" />
+      <Patch Number="413" Name="PhazeNRG SRX" ProgramChange="28" />
+      <Patch Number="414" Name="Build-Up SRX" ProgramChange="29" />
+      <Patch Number="415" Name="WavetableSRX" ProgramChange="30" />
+      <Patch Number="416" Name="DigiChoirSRX" ProgramChange="31" />
+      <Patch Number="417" Name="Rezidue SRX" ProgramChange="32" />
+      <Patch Number="418" Name="Combing SRX" ProgramChange="33" />
+      <Patch Number="419" Name="PhzslopadSRX" ProgramChange="34" />
+      <Patch Number="420" Name="OBThickPdSRX" ProgramChange="35" />
+      <Patch Number="421" Name="OBSftPad SRX" ProgramChange="36" />
+      <Patch Number="422" Name="RealStrSynth" ProgramChange="37" />
+      <Patch Number="423" Name="Rezonant Ens" ProgramChange="38" />
+      <Patch Number="424" Name="PG Phaser" ProgramChange="39" />
+      <Patch Number="425" Name="SynthOdyssey" ProgramChange="40" />
+      <Patch Number="426" Name="Liquid Lunch" ProgramChange="41" />
+      <Patch Number="427" Name="JP SquPadSRX" ProgramChange="42" />
+      <Patch Number="428" Name="Chewy Pad" ProgramChange="43" />
+      <Patch Number="429" Name="Hollow SRX" ProgramChange="44" />
+      <Patch Number="430" Name="Too Heaven" ProgramChange="45" />
+      <Patch Number="431" Name="Slow 3D Vox" ProgramChange="46" />
+      <Patch Number="432" Name="JP Spirit" ProgramChange="47" />
+      <Patch Number="433" Name="Classic OB" ProgramChange="48" />
+      <Patch Number="434" Name="Aulophony" ProgramChange="49" />
+      <Patch Number="435" Name="Dark Shadow" ProgramChange="50" />
+      <Patch Number="436" Name="Drawning Pad" ProgramChange="51" />
+      <Patch Number="437" Name="Sawed String" ProgramChange="52" />
+      <Patch Number="438" Name="R.I.P." ProgramChange="53" />
+      <Patch Number="439" Name="K World" ProgramChange="54" />
+      <Patch Number="440" Name="CanyonDreams" ProgramChange="55" />
+      <Patch Number="441" Name="Mysterioso" ProgramChange="56" />
+      <Patch Number="442" Name="S/HTexturSRX" ProgramChange="57" />
+      <Patch Number="443" Name="VP-330ChrSRX" ProgramChange="58" />
+      <Patch Number="444" Name="Mellorkestra" ProgramChange="59" />
+      <Patch Number="445" Name="Tron Mass" ProgramChange="60" />
+      <Patch Number="446" Name="PreSampleVox" ProgramChange="61" />
+      <Patch Number="447" Name="Gamma Girls" ProgramChange="62" />
+      <Patch Number="448" Name="Lo-Tek Choir" ProgramChange="63" />
+      <Patch Number="449" Name="Tron Vox SRX" ProgramChange="64" />
+      <Patch Number="450" Name="Vox JX8P SRX" ProgramChange="65" />
+      <Patch Number="451" Name="VP303 Arpeg" ProgramChange="66" />
+      <Patch Number="452" Name="DrumLP DemoS" ProgramChange="67" />
+      <Patch Number="453" Name="Pursuit 90" ProgramChange="68" />
+      <Patch Number="454" Name="Arcade 132" ProgramChange="69" />
+      <Patch Number="455" Name="SeventhHeavn" ProgramChange="70" />
+      <Patch Number="456" Name="TrollDrummin" ProgramChange="71" />
+      <Patch Number="457" Name="Chem Burn120" ProgramChange="72" />
+      <Patch Number="458" Name="Rockshow 126" ProgramChange="73" />
+      <Patch Number="459" Name="T-Pop 132" ProgramChange="74" />
+      <Patch Number="460" Name="Valentine 76" ProgramChange="75" />
+      <Patch Number="461" Name="Nocturne" ProgramChange="76" />
+      <Patch Number="462" Name="Cool At 102" ProgramChange="77" />
+      <Patch Number="463" Name="Circuit 112" ProgramChange="78" />
+      <Patch Number="464" Name="Hurt 90" ProgramChange="79" />
+      <Patch Number="465" Name="Orleans 90" ProgramChange="80" />
+      <Patch Number="466" Name="FunkyDrummer" ProgramChange="81" />
+      <Patch Number="467" Name="Circuit 90" ProgramChange="82" />
+      <Patch Number="468" Name="SweepingLP S" ProgramChange="83" />
+      <Patch Number="469" Name="Kick Menu" ProgramChange="84" />
+      <Patch Number="470" Name="Snare Menu 1" ProgramChange="85" />
+      <Patch Number="471" Name="Snare Menu 2" ProgramChange="86" />
+      <Patch Number="472" Name="Snare Menu 3" ProgramChange="87" />
+      <Patch Number="473" Name="Hi-Hat Menu" ProgramChange="88" />
+      <Patch Number="474" Name="Tom-Tom Menu" ProgramChange="89" />
+      <Patch Number="475" Name="Cymbals Menu" ProgramChange="90" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX08) 1-128">
+      <Patch Number="001" Name="Autopilot" ProgramChange="0" />
+      <Patch Number="002" Name="ElasticHouse" ProgramChange="1" />
+      <Patch Number="003" Name="Smash Beat" ProgramChange="2" />
+      <Patch Number="004" Name="SawPortaLead" ProgramChange="3" />
+      <Patch Number="005" Name="Pure Bass" ProgramChange="4" />
+      <Patch Number="006" Name="Jazz Parrotz" ProgramChange="5" />
+      <Patch Number="007" Name="Nicer Slicer" ProgramChange="6" />
+      <Patch Number="008" Name="Masssive" ProgramChange="7" />
+      <Patch Number="009" Name="Trance Line1" ProgramChange="8" />
+      <Patch Number="010" Name="Subtle Pads" ProgramChange="9" />
+      <Patch Number="011" Name="Look Back" ProgramChange="10" />
+      <Patch Number="012" Name="VesperTONE" ProgramChange="11" />
+      <Patch Number="013" Name="Hit&amp;FX Menu" ProgramChange="12" />
+      <Patch Number="014" Name="Crowd 84" ProgramChange="13" />
+      <Patch Number="015" Name="Hop Chop SRX" ProgramChange="14" />
+      <Patch Number="016" Name="Skid 92" ProgramChange="15" />
+      <Patch Number="017" Name="Predator 92" ProgramChange="16" />
+      <Patch Number="018" Name="Scream! SRX" ProgramChange="17" />
+      <Patch Number="019" Name="1978 116BPM" ProgramChange="18" />
+      <Patch Number="020" Name="X-Tronic SRX" ProgramChange="19" />
+      <Patch Number="021" Name="Trans SRX" ProgramChange="20" />
+      <Patch Number="022" Name="AcidRiff 125" ProgramChange="21" />
+      <Patch Number="023" Name="FullHous SRX" ProgramChange="22" />
+      <Patch Number="024" Name="Funk E 125" ProgramChange="23" />
+      <Patch Number="025" Name="Le Punk 125" ProgramChange="24" />
+      <Patch Number="026" Name="TekOp SRX" ProgramChange="25" />
+      <Patch Number="027" Name="Cauldron 138" ProgramChange="26" />
+      <Patch Number="028" Name="Punken 144" ProgramChange="27" />
+      <Patch Number="029" Name="Blitzkrieg" ProgramChange="28" />
+      <Patch Number="030" Name="Hauln 166" ProgramChange="29" />
+      <Patch Number="031" Name="Antenna 61" ProgramChange="30" />
+      <Patch Number="032" Name="Barry 76" ProgramChange="31" />
+      <Patch Number="033" Name="Slipn 80" ProgramChange="32" />
+      <Patch Number="034" Name="UndrTheStair" ProgramChange="33" />
+      <Patch Number="035" Name="Slam 86" ProgramChange="34" />
+      <Patch Number="036" Name="Only Human" ProgramChange="35" />
+      <Patch Number="037" Name="BAD 88" ProgramChange="36" />
+      <Patch Number="038" Name="Drama 89" ProgramChange="37" />
+      <Patch Number="039" Name="Mon 90" ProgramChange="38" />
+      <Patch Number="040" Name="McSick 90" ProgramChange="39" />
+      <Patch Number="041" Name="Meanstreet" ProgramChange="40" />
+      <Patch Number="042" Name="Meow 92" ProgramChange="41" />
+      <Patch Number="043" Name="Blvd 96" ProgramChange="42" />
+      <Patch Number="044" Name="Coder 98" ProgramChange="43" />
+      <Patch Number="045" Name="iROBOT 120" ProgramChange="44" />
+      <Patch Number="046" Name="Lifeform 120" ProgramChange="45" />
+      <Patch Number="047" Name="Haiti 120" ProgramChange="46" />
+      <Patch Number="048" Name="Hiphouse 125" ProgramChange="47" />
+      <Patch Number="049" Name="OW! 125" ProgramChange="48" />
+      <Patch Number="050" Name="CHI 125" ProgramChange="49" />
+      <Patch Number="051" Name="Miami 125" ProgramChange="50" />
+      <Patch Number="052" Name="Swing 125" ProgramChange="51" />
+      <Patch Number="053" Name="ObsessionSRX" ProgramChange="52" />
+      <Patch Number="054" Name="PJ 144" ProgramChange="53" />
+      <Patch Number="055" Name="Sky 160" ProgramChange="54" />
+      <Patch Number="056" Name="Aerosol Can" ProgramChange="55" />
+      <Patch Number="057" Name="Triggroove" ProgramChange="56" />
+      <Patch Number="058" Name="De Final CUT" ProgramChange="57" />
+      <Patch Number="059" Name="Chemiclspill" ProgramChange="58" />
+      <Patch Number="060" Name="DerangedBeat" ProgramChange="59" />
+      <Patch Number="061" Name="Cubit Dance" ProgramChange="60" />
+      <Patch Number="062" Name="Multi Level" ProgramChange="61" />
+      <Patch Number="063" Name="Random Beat" ProgramChange="62" />
+      <Patch Number="064" Name="Sonic Beat" ProgramChange="63" />
+      <Patch Number="065" Name="Fuzzy Wuzzy" ProgramChange="64" />
+      <Patch Number="066" Name="Cyclone 125" ProgramChange="65" />
+      <Patch Number="067" Name="Electrolux" ProgramChange="66" />
+      <Patch Number="068" Name="Bongo Congo" ProgramChange="67" />
+      <Patch Number="069" Name="Tricky Beat" ProgramChange="68" />
+      <Patch Number="070" Name="Windmill 132" ProgramChange="69" />
+      <Patch Number="071" Name="SlamSymphony" ProgramChange="70" />
+      <Patch Number="072" Name="Time Pulse" ProgramChange="71" />
+      <Patch Number="073" Name="TrainAComin" ProgramChange="72" />
+      <Patch Number="074" Name="House Rules" ProgramChange="73" />
+      <Patch Number="075" Name="Mother Ship" ProgramChange="74" />
+      <Patch Number="076" Name="YankyDoodlDo" ProgramChange="75" />
+      <Patch Number="077" Name="Elven Kbds" ProgramChange="76" />
+      <Patch Number="078" Name="DnB SRX" ProgramChange="77" />
+      <Patch Number="079" Name="Beat Menu 1" ProgramChange="78" />
+      <Patch Number="080" Name="Beat Menu 2" ProgramChange="79" />
+      <Patch Number="081" Name="TarzanBottom" ProgramChange="80" />
+      <Patch Number="082" Name="Subporter" ProgramChange="81" />
+      <Patch Number="083" Name="Subsonics" ProgramChange="82" />
+      <Patch Number="084" Name="Sub Bass" ProgramChange="83" />
+      <Patch Number="085" Name="HiLo303/Mod" ProgramChange="84" />
+      <Patch Number="086" Name="Bass Ment 1" ProgramChange="85" />
+      <Patch Number="087" Name="Bass Ment 2" ProgramChange="86" />
+      <Patch Number="088" Name="TB SawBs SRX" ProgramChange="87" />
+      <Patch Number="089" Name="TB OwBs SRX" ProgramChange="88" />
+      <Patch Number="090" Name="Acidic Testz" ProgramChange="89" />
+      <Patch Number="091" Name="Talk Bass" ProgramChange="90" />
+      <Patch Number="092" Name="VocoBass SRX" ProgramChange="91" />
+      <Patch Number="093" Name="Massive Bass" ProgramChange="92" />
+      <Patch Number="094" Name="TB Sqr SRX" ProgramChange="93" />
+      <Patch Number="095" Name="SQR Reso Bs" ProgramChange="94" />
+      <Patch Number="096" Name="SH-5 Synbass" ProgramChange="95" />
+      <Patch Number="097" Name="Juno Bs SRX" ProgramChange="96" />
+      <Patch Number="098" Name="SlippyBs SRX" ProgramChange="97" />
+      <Patch Number="099" Name="Arrpy Bs SRX" ProgramChange="98" />
+      <Patch Number="100" Name="TB / SRX" ProgramChange="99" />
+      <Patch Number="101" Name="TB-notTB SRX" ProgramChange="100" />
+      <Patch Number="102" Name="Si&lt;n&gt;ck Bass" ProgramChange="101" />
+      <Patch Number="103" Name="Deep Fat Bas" ProgramChange="102" />
+      <Patch Number="104" Name="7 bit bass" ProgramChange="103" />
+      <Patch Number="105" Name="DistortObass" ProgramChange="104" />
+      <Patch Number="106" Name="Double Bass" ProgramChange="105" />
+      <Patch Number="107" Name="Killer Bass" ProgramChange="106" />
+      <Patch Number="108" Name="Dancer Bass" ProgramChange="107" />
+      <Patch Number="109" Name="Rave Bass" ProgramChange="108" />
+      <Patch Number="110" Name="Big Bad Bass" ProgramChange="109" />
+      <Patch Number="111" Name="Fat FM Bass" ProgramChange="110" />
+      <Patch Number="112" Name="JackYourBody" ProgramChange="111" />
+      <Patch Number="113" Name="Solid Bs SRX" ProgramChange="112" />
+      <Patch Number="114" Name="Thick Bass" ProgramChange="113" />
+      <Patch Number="115" Name="Deep Bass 2" ProgramChange="114" />
+      <Patch Number="116" Name="Bassamatazz" ProgramChange="115" />
+      <Patch Number="117" Name="Juno 6 Bass" ProgramChange="116" />
+      <Patch Number="118" Name="Da JuBs SRX" ProgramChange="117" />
+      <Patch Number="119" Name="Fizzle Bass" ProgramChange="118" />
+      <Patch Number="120" Name="Ringin` bass" ProgramChange="119" />
+      <Patch Number="121" Name="No Rez 4 You" ProgramChange="120" />
+      <Patch Number="122" Name="Boomer" ProgramChange="121" />
+      <Patch Number="123" Name="OrgAtk Bass" ProgramChange="122" />
+      <Patch Number="124" Name="WahBassMod X" ProgramChange="123" />
+      <Patch Number="125" Name="LFO SqrBass" ProgramChange="124" />
+      <Patch Number="126" Name="FallBend Bs" ProgramChange="125" />
+      <Patch Number="127" Name="Hocket Bass" ProgramChange="126" />
+      <Patch Number="128" Name="FatBs / SRX" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX08) 129-256">
+      <Patch Number="129" Name="LoFi A.BsSRX" ProgramChange="0" />
+      <Patch Number="130" Name="ProcesBs SRX" ProgramChange="1" />
+      <Patch Number="131" Name="Solo flight" ProgramChange="2" />
+      <Patch Number="132" Name="Euro mix SRX" ProgramChange="3" />
+      <Patch Number="133" Name="Nitty Gritty" ProgramChange="4" />
+      <Patch Number="134" Name="Alias Lead" ProgramChange="5" />
+      <Patch Number="135" Name="Old Fi" ProgramChange="6" />
+      <Patch Number="136" Name="Dist-O-Matic" ProgramChange="7" />
+      <Patch Number="137" Name="Lead Dirt" ProgramChange="8" />
+      <Patch Number="138" Name="RetroRave" ProgramChange="9" />
+      <Patch Number="139" Name="Skreech Lead" ProgramChange="10" />
+      <Patch Number="140" Name="Outrage" ProgramChange="11" />
+      <Patch Number="141" Name="HipassTB SRX" ProgramChange="12" />
+      <Patch Number="142" Name="TB Squared" ProgramChange="13" />
+      <Patch Number="143" Name="TB Saw" ProgramChange="14" />
+      <Patch Number="144" Name="DistortedSaw" ProgramChange="15" />
+      <Patch Number="145" Name="Nail Driver" ProgramChange="16" />
+      <Patch Number="146" Name="Nasty 303" ProgramChange="17" />
+      <Patch Number="147" Name="Dance Baby" ProgramChange="18" />
+      <Patch Number="148" Name="5th Rave" ProgramChange="19" />
+      <Patch Number="149" Name="Auto 101" ProgramChange="20" />
+      <Patch Number="150" Name="Sine me in" ProgramChange="21" />
+      <Patch Number="151" Name="SoloSin SRX1" ProgramChange="22" />
+      <Patch Number="152" Name="SoloSin SRX2" ProgramChange="23" />
+      <Patch Number="153" Name="Piccolo solo" ProgramChange="24" />
+      <Patch Number="154" Name="Ana Flt SRX" ProgramChange="25" />
+      <Patch Number="155" Name="JUResLd SRX1" ProgramChange="26" />
+      <Patch Number="156" Name="Med Solo SRX" ProgramChange="27" />
+      <Patch Number="157" Name="MilkyWay SRX" ProgramChange="28" />
+      <Patch Number="158" Name="Shalot SRX" ProgramChange="29" />
+      <Patch Number="159" Name="3D Lead" ProgramChange="30" />
+      <Patch Number="160" Name="JUResLd SRX2" ProgramChange="31" />
+      <Patch Number="161" Name="Gringeley" ProgramChange="32" />
+      <Patch Number="162" Name="EuroSteroidz" ProgramChange="33" />
+      <Patch Number="163" Name="Operator" ProgramChange="34" />
+      <Patch Number="164" Name="NeverStopRvn" ProgramChange="35" />
+      <Patch Number="165" Name="TheSteamRoks" ProgramChange="36" />
+      <Patch Number="166" Name="TechnoAttack" ProgramChange="37" />
+      <Patch Number="167" Name="Formantz" ProgramChange="38" />
+      <Patch Number="168" Name="SRX Talker" ProgramChange="39" />
+      <Patch Number="169" Name="Nanite Pops" ProgramChange="40" />
+      <Patch Number="170" Name="TechnoAmbint" ProgramChange="41" />
+      <Patch Number="171" Name="Ringywig" ProgramChange="42" />
+      <Patch Number="172" Name="OrganOran" ProgramChange="43" />
+      <Patch Number="173" Name="Piddlee-Dee" ProgramChange="44" />
+      <Patch Number="174" Name="Cool Beam" ProgramChange="45" />
+      <Patch Number="175" Name="First Synth" ProgramChange="46" />
+      <Patch Number="176" Name="Santaz House" ProgramChange="47" />
+      <Patch Number="177" Name="Sub Melodic" ProgramChange="48" />
+      <Patch Number="178" Name="Landing Crew" ProgramChange="49" />
+      <Patch Number="179" Name="Chime Blocks" ProgramChange="50" />
+      <Patch Number="180" Name="Chordon Bleu" ProgramChange="51" />
+      <Patch Number="181" Name="Porter Rix" ProgramChange="52" />
+      <Patch Number="182" Name="PhenomenaSRX" ProgramChange="53" />
+      <Patch Number="183" Name="Club Hit" ProgramChange="54" />
+      <Patch Number="184" Name="ChrdMaj7 SRX" ProgramChange="55" />
+      <Patch Number="185" Name="ChrdMin7 SRX" ProgramChange="56" />
+      <Patch Number="186" Name="CordintheAct" ProgramChange="57" />
+      <Patch Number="187" Name="MetroPoly" ProgramChange="58" />
+      <Patch Number="188" Name="Lava Flow" ProgramChange="59" />
+      <Patch Number="189" Name="Panorama" ProgramChange="60" />
+      <Patch Number="190" Name="Nautilus" ProgramChange="61" />
+      <Patch Number="191" Name="Sliced Bread" ProgramChange="62" />
+      <Patch Number="192" Name="Time Machine" ProgramChange="63" />
+      <Patch Number="193" Name="Ana Logic" ProgramChange="64" />
+      <Patch Number="194" Name="Bass &amp; More" ProgramChange="65" />
+      <Patch Number="195" Name="In The Lab" ProgramChange="66" />
+      <Patch Number="196" Name="Galaxia" ProgramChange="67" />
+      <Patch Number="197" Name="Charmer" ProgramChange="68" />
+      <Patch Number="198" Name="BrainWaveSRX" ProgramChange="69" />
+      <Patch Number="199" Name="Replicants" ProgramChange="70" />
+      <Patch Number="200" Name="Speak Delay" ProgramChange="71" />
+      <Patch Number="201" Name="Location" ProgramChange="72" />
+      <Patch Number="202" Name="Cyber SRX" ProgramChange="73" />
+      <Patch Number="203" Name="EtheraltySRX" ProgramChange="74" />
+      <Patch Number="204" Name="IceDream SRX" ProgramChange="75" />
+      <Patch Number="205" Name="UpperStepper" ProgramChange="76" />
+      <Patch Number="206" Name="Padestrians" ProgramChange="77" />
+      <Patch Number="207" Name="Starlite XV" ProgramChange="78" />
+      <Patch Number="208" Name="Trance Line2" ProgramChange="79" />
+      <Patch Number="209" Name="Eurosynth" ProgramChange="80" />
+      <Patch Number="210" Name="Fat JP" ProgramChange="81" />
+      <Patch Number="211" Name="EuroDnc SRX1" ProgramChange="82" />
+      <Patch Number="212" Name="EuroDnc SRX2" ProgramChange="83" />
+      <Patch Number="213" Name="XpressiveSRX" ProgramChange="84" />
+      <Patch Number="214" Name="Organ-ized" ProgramChange="85" />
+      <Patch Number="215" Name="Juno Pluck" ProgramChange="86" />
+      <Patch Number="216" Name="Juno Plucked" ProgramChange="87" />
+      <Patch Number="217" Name="Rubberized" ProgramChange="88" />
+      <Patch Number="218" Name="Intense Vibe" ProgramChange="89" />
+      <Patch Number="219" Name="Intense Euro" ProgramChange="90" />
+      <Patch Number="220" Name="Generation e" ProgramChange="91" />
+      <Patch Number="221" Name="NewSkool 70s" ProgramChange="92" />
+      <Patch Number="222" Name="SyncDiffrent" ProgramChange="93" />
+      <Patch Number="223" Name="Kill Eyeopee" ProgramChange="94" />
+      <Patch Number="224" Name="FM Ringer" ProgramChange="95" />
+      <Patch Number="225" Name="Live at 5" ProgramChange="96" />
+      <Patch Number="226" Name="Octo" ProgramChange="97" />
+      <Patch Number="227" Name="Alpha Fizz" ProgramChange="98" />
+      <Patch Number="228" Name="FunkyJunoHrp" ProgramChange="99" />
+      <Patch Number="229" Name="Steel Piano" ProgramChange="100" />
+      <Patch Number="230" Name="Velorez 8000" ProgramChange="101" />
+      <Patch Number="231" Name="JU Keys SRX" ProgramChange="102" />
+      <Patch Number="232" Name="Euronal Syn" ProgramChange="103" />
+      <Patch Number="233" Name="Daft" ProgramChange="104" />
+      <Patch Number="234" Name="Neurotic Syn" ProgramChange="105" />
+      <Patch Number="235" Name="Deep Forest" ProgramChange="106" />
+      <Patch Number="236" Name="Pip Square" ProgramChange="107" />
+      <Patch Number="237" Name="Funky Pluck" ProgramChange="108" />
+      <Patch Number="238" Name="Tight TB" ProgramChange="109" />
+      <Patch Number="239" Name="Saw Yr Point" ProgramChange="110" />
+      <Patch Number="240" Name="Shortsawz" ProgramChange="111" />
+      <Patch Number="241" Name="Tropical Syn" ProgramChange="112" />
+      <Patch Number="242" Name="JU Pluck SRX" ProgramChange="113" />
+      <Patch Number="243" Name="TB AtkDst" ProgramChange="114" />
+      <Patch Number="244" Name="Amber" ProgramChange="115" />
+      <Patch Number="245" Name="Vox Switcher" ProgramChange="116" />
+      <Patch Number="246" Name="Juno Strings" ProgramChange="117" />
+      <Patch Number="247" Name="DetuneSawStr" ProgramChange="118" />
+      <Patch Number="248" Name="Wavebreaker" ProgramChange="119" />
+      <Patch Number="249" Name="Vintage Pad" ProgramChange="120" />
+      <Patch Number="250" Name="Glitz" ProgramChange="121" />
+      <Patch Number="251" Name="Discrete" ProgramChange="122" />
+      <Patch Number="252" Name="VntageRevSRX" ProgramChange="123" />
+      <Patch Number="253" Name="Explore SRX" ProgramChange="124" />
+      <Patch Number="254" Name="AfterPad SRX" ProgramChange="125" />
+      <Patch Number="255" Name="Euro Strings" ProgramChange="126" />
+      <Patch Number="256" Name="Powder" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX08) 257-384">
+      <Patch Number="257" Name="JU&amp;JP PhsSRX" ProgramChange="0" />
+      <Patch Number="258" Name="Lost In Time" ProgramChange="1" />
+      <Patch Number="259" Name="Europad" ProgramChange="2" />
+      <Patch Number="260" Name="Avalon SRX" ProgramChange="3" />
+      <Patch Number="261" Name="Dreames SRX" ProgramChange="4" />
+      <Patch Number="262" Name="SirenSng SRX" ProgramChange="5" />
+      <Patch Number="263" Name="CricketChoir" ProgramChange="6" />
+      <Patch Number="264" Name="TV Drama" ProgramChange="7" />
+      <Patch Number="265" Name="Elven Times" ProgramChange="8" />
+      <Patch Number="266" Name="TwilightPad" ProgramChange="9" />
+      <Patch Number="267" Name="WarmerPd SRX" ProgramChange="10" />
+      <Patch Number="268" Name="SoftStrngSRX" ProgramChange="11" />
+      <Patch Number="269" Name="AlphaWavePad" ProgramChange="12" />
+      <Patch Number="270" Name="Micromusic" ProgramChange="13" />
+      <Patch Number="271" Name="LitleDowners" ProgramChange="14" />
+      <Patch Number="272" Name="Fulcanelli03" ProgramChange="15" />
+      <Patch Number="273" Name="Galaxial" ProgramChange="16" />
+      <Patch Number="274" Name="It's Outside" ProgramChange="17" />
+      <Patch Number="275" Name="Alien Life" ProgramChange="18" />
+      <Patch Number="276" Name="Prey 160" ProgramChange="19" />
+      <Patch Number="277" Name="Transender" ProgramChange="20" />
+      <Patch Number="278" Name="Steel Drone" ProgramChange="21" />
+      <Patch Number="279" Name="Trissle" ProgramChange="22" />
+      <Patch Number="280" Name="Dimensions" ProgramChange="23" />
+      <Patch Number="281" Name="TuneBrethSRX" ProgramChange="24" />
+      <Patch Number="282" Name="Sonic Saucer" ProgramChange="25" />
+      <Patch Number="283" Name="Alter Native" ProgramChange="26" />
+      <Patch Number="284" Name="Evolution" ProgramChange="27" />
+      <Patch Number="285" Name="Outer Space" ProgramChange="28" />
+      <Patch Number="286" Name="Hyperspace" ProgramChange="29" />
+      <Patch Number="287" Name="WhaleUnitSRX" ProgramChange="30" />
+      <Patch Number="288" Name="Orcafreq SRX" ProgramChange="31" />
+      <Patch Number="289" Name="CrepedOutSRX" ProgramChange="32" />
+      <Patch Number="290" Name="Bombay Drone" ProgramChange="33" />
+      <Patch Number="291" Name="Fathoms SRX" ProgramChange="34" />
+      <Patch Number="292" Name="MothrshipSRX" ProgramChange="35" />
+      <Patch Number="293" Name="Cleansers" ProgramChange="36" />
+      <Patch Number="294" Name="Vinylprelude" ProgramChange="37" />
+      <Patch Number="295" Name="Turbine SRX" ProgramChange="38" />
+      <Patch Number="296" Name="Thrilling" ProgramChange="39" />
+      <Patch Number="297" Name="Bada Boing" ProgramChange="40" />
+      <Patch Number="298" Name="Confused" ProgramChange="41" />
+      <Patch Number="299" Name="Revolution#9" ProgramChange="42" />
+      <Patch Number="300" Name="Bugstep Noot" ProgramChange="43" />
+      <Patch Number="301" Name="Crotals" ProgramChange="44" />
+      <Patch Number="302" Name="Big Bang *" ProgramChange="45" />
+      <Patch Number="303" Name="South Sahara" ProgramChange="46" />
+      <Patch Number="304" Name="MunchiesPt12" ProgramChange="47" />
+      <Patch Number="305" Name="AlternSawSRX" ProgramChange="48" />
+      <Patch Number="306" Name="ElctroJamSRX" ProgramChange="49" />
+      <Patch Number="307" Name="Zaps" ProgramChange="50" />
+      <Patch Number="308" Name="B-Movie" ProgramChange="51" />
+      <Patch Number="309" Name="ScientistSRX" ProgramChange="52" />
+      <Patch Number="310" Name="Siren" ProgramChange="53" />
+      <Patch Number="311" Name="Sliderz SRX" ProgramChange="54" />
+      <Patch Number="312" Name="Krashead" ProgramChange="55" />
+      <Patch Number="313" Name="Iron Hit SRX" ProgramChange="56" />
+      <Patch Number="314" Name="DrumMeltDown" ProgramChange="57" />
+      <Patch Number="315" Name="TR Synhit" ProgramChange="58" />
+      <Patch Number="316" Name="Pit People" ProgramChange="59" />
+      <Patch Number="317" Name="Mad RHyThM" ProgramChange="60" />
+      <Patch Number="318" Name="ModrnLifeSRX" ProgramChange="61" />
+      <Patch Number="319" Name="BigBang SRX" ProgramChange="62" />
+      <Patch Number="320" Name="GateKeperSRX" ProgramChange="63" />
+      <Patch Number="321" Name="UndrWaterSRX" ProgramChange="64" />
+      <Patch Number="322" Name="TheWetSet" ProgramChange="65" />
+      <Patch Number="323" Name="DJ stuff SRX" ProgramChange="66" />
+      <Patch Number="324" Name="Skratchy SRX" ProgramChange="67" />
+      <Patch Number="325" Name="78 RPM SRX" ProgramChange="68" />
+      <Patch Number="326" Name="3D Turntable" ProgramChange="69" />
+      <Patch Number="327" Name="RadioBrekSRX" ProgramChange="70" />
+      <Patch Number="328" Name="Faze Gt&amp;Bass" ProgramChange="71" />
+      <Patch Number="329" Name="Hse Stb 125" ProgramChange="72" />
+      <Patch Number="330" Name="Full Force" ProgramChange="73" />
+      <Patch Number="331" Name="Soho Clubs" ProgramChange="74" />
+      <Patch Number="332" Name="GarageChdSRX" ProgramChange="75" />
+      <Patch Number="333" Name="Crap Stab" ProgramChange="76" />
+      <Patch Number="334" Name="2am-11am" ProgramChange="77" />
+      <Patch Number="335" Name="Hit&amp;Run SRX" ProgramChange="78" />
+      <Patch Number="336" Name="HIT in face" ProgramChange="79" />
+      <Patch Number="337" Name="LoFiHits SRX" ProgramChange="80" />
+      <Patch Number="338" Name="Next Stab" ProgramChange="81" />
+      <Patch Number="339" Name="Brazzer LoFi" ProgramChange="82" />
+      <Patch Number="340" Name="Big Stab SRX" ProgramChange="83" />
+      <Patch Number="341" Name="30's Tpt SRX" ProgramChange="84" />
+      <Patch Number="342" Name="BrsFall SRX" ProgramChange="85" />
+      <Patch Number="343" Name="Slammer" ProgramChange="86" />
+      <Patch Number="344" Name="Tribal Disco" ProgramChange="87" />
+      <Patch Number="345" Name="DiscoStr Hit" ProgramChange="88" />
+      <Patch Number="346" Name="Break HIT" ProgramChange="89" />
+      <Patch Number="347" Name="Cwisp SRX" ProgramChange="90" />
+      <Patch Number="348" Name="NYC Club SRX" ProgramChange="91" />
+      <Patch Number="349" Name="Tape Stops" ProgramChange="92" />
+      <Patch Number="350" Name="LoFi Subsine" ProgramChange="93" />
+      <Patch Number="351" Name="Maj/Min /" ProgramChange="94" />
+      <Patch Number="352" Name="Techno Logic" ProgramChange="95" />
+      <Patch Number="353" Name="Slam Hit" ProgramChange="96" />
+      <Patch Number="354" Name="Image BOOOM!" ProgramChange="97" />
+      <Patch Number="355" Name="Keep Clubing" ProgramChange="98" />
+      <Patch Number="356" Name="Techno Riff1" ProgramChange="99" />
+      <Patch Number="357" Name="MySweetHouse" ProgramChange="100" />
+      <Patch Number="358" Name="LateNiteTunz" ProgramChange="101" />
+      <Patch Number="359" Name="Moody Vibes" ProgramChange="102" />
+      <Patch Number="360" Name="Exit 2" ProgramChange="103" />
+      <Patch Number="361" Name="Massive" ProgramChange="104" />
+      <Patch Number="362" Name="Techno Riff2" ProgramChange="105" />
+      <Patch Number="363" Name="Metalsmith" ProgramChange="106" />
+      <Patch Number="364" Name="Meteor Pelt" ProgramChange="107" />
+      <Patch Number="365" Name="China White" ProgramChange="108" />
+      <Patch Number="366" Name="NewTech D&amp;B" ProgramChange="109" />
+      <Patch Number="367" Name="Water Plug" ProgramChange="110" />
+      <Patch Number="368" Name="Tribal Steel" ProgramChange="111" />
+      <Patch Number="369" Name="Tech Pno SRX" ProgramChange="112" />
+      <Patch Number="370" Name="LightPno SRX" ProgramChange="113" />
+      <Patch Number="371" Name="90s Pno SRX" ProgramChange="114" />
+      <Patch Number="372" Name="1FingrPnoSRX" ProgramChange="115" />
+      <Patch Number="373" Name="Pf/Key Menu" ProgramChange="116" />
+      <Patch Number="374" Name="Substitute" ProgramChange="117" />
+      <Patch Number="375" Name="HiphopEP SRX" ProgramChange="118" />
+      <Patch Number="376" Name="Assembled" ProgramChange="119" />
+      <Patch Number="377" Name="MelowTremSRX" ProgramChange="120" />
+      <Patch Number="378" Name="Echo EP SRX" ProgramChange="121" />
+      <Patch Number="379" Name="77GaragesSRX" ProgramChange="122" />
+      <Patch Number="380" Name="Wurlpool" ProgramChange="123" />
+      <Patch Number="381" Name="Lo Fi Wurli" ProgramChange="124" />
+      <Patch Number="382" Name="Dance Organ" ProgramChange="125" />
+      <Patch Number="383" Name="Juno Org SRX" ProgramChange="126" />
+      <Patch Number="384" Name="Clubed Organ" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX08) 385-448">
+      <Patch Number="385" Name="Pop B" ProgramChange="0" />
+      <Patch Number="386" Name="Vel Syn Org" ProgramChange="1" />
+      <Patch Number="387" Name="SpenderOrgan" ProgramChange="2" />
+      <Patch Number="388" Name="Tines&amp;Wheels" ProgramChange="3" />
+      <Patch Number="389" Name="Thick Organ" ProgramChange="4" />
+      <Patch Number="390" Name="1FingrOrgSRX" ProgramChange="5" />
+      <Patch Number="391" Name="Shorty Organ" ProgramChange="6" />
+      <Patch Number="392" Name="1FingrShrOrg" ProgramChange="7" />
+      <Patch Number="393" Name="Clav-ClubSRX" ProgramChange="8" />
+      <Patch Number="394" Name="DanceClavSRX" ProgramChange="9" />
+      <Patch Number="395" Name="CeremonyBell" ProgramChange="10" />
+      <Patch Number="396" Name="AnaBells SRX" ProgramChange="11" />
+      <Patch Number="397" Name="Guitar Stuff" ProgramChange="12" />
+      <Patch Number="398" Name="WahWahMelSRX" ProgramChange="13" />
+      <Patch Number="399" Name="GTRPowerSRX1" ProgramChange="14" />
+      <Patch Number="400" Name="GTRPowerSRX2" ProgramChange="15" />
+      <Patch Number="401" Name="FakeHead Hit" ProgramChange="16" />
+      <Patch Number="402" Name="Distinctive" ProgramChange="17" />
+      <Patch Number="403" Name="Gtr&amp;BassMenu" ProgramChange="18" />
+      <Patch Number="404" Name="Pizz Xpress" ProgramChange="19" />
+      <Patch Number="405" Name="Tek Pizz SRX" ProgramChange="20" />
+      <Patch Number="406" Name="Stringy Stab" ProgramChange="21" />
+      <Patch Number="407" Name="CS80Brass" ProgramChange="22" />
+      <Patch Number="408" Name="Fat Brass" ProgramChange="23" />
+      <Patch Number="409" Name="Talk Box SRX" ProgramChange="24" />
+      <Patch Number="410" Name="TekMusic SRX" ProgramChange="25" />
+      <Patch Number="411" Name="1.2.3.4. SRX" ProgramChange="26" />
+      <Patch Number="412" Name="1234 x4  SRX" ProgramChange="27" />
+      <Patch Number="413" Name="Baby...? SRX" ProgramChange="28" />
+      <Patch Number="414" Name="Vox Menu 1" ProgramChange="29" />
+      <Patch Number="415" Name="Vox Menu 2" ProgramChange="30" />
+      <Patch Number="416" Name="MelodicDrums" ProgramChange="31" />
+      <Patch Number="417" Name="Drumpeopled1" ProgramChange="32" />
+      <Patch Number="418" Name="Drumpeopled2" ProgramChange="33" />
+      <Patch Number="419" Name="Drumpeopled3" ProgramChange="34" />
+      <Patch Number="420" Name="KitTek.drmFX" ProgramChange="35" />
+      <Patch Number="421" Name="Hardcore Hit" ProgramChange="36" />
+      <Patch Number="422" Name="Kick Menu 1" ProgramChange="37" />
+      <Patch Number="423" Name="Kick Menu 2" ProgramChange="38" />
+      <Patch Number="424" Name="Kick Menu 3" ProgramChange="39" />
+      <Patch Number="425" Name="Snare Menu 1" ProgramChange="40" />
+      <Patch Number="426" Name="Snare Menu 2" ProgramChange="41" />
+      <Patch Number="427" Name="Snare Menu 3" ProgramChange="42" />
+      <Patch Number="428" Name="Snare Menu 4" ProgramChange="43" />
+      <Patch Number="429" Name="Snare Menu 5" ProgramChange="44" />
+      <Patch Number="430" Name="HiHat Menu 1" ProgramChange="45" />
+      <Patch Number="431" Name="HiHat Menu 2" ProgramChange="46" />
+      <Patch Number="432" Name="HH&amp;Cym Menu" ProgramChange="47" />
+      <Patch Number="433" Name="Cymbal Menu" ProgramChange="48" />
+      <Patch Number="434" Name="Tom Menu" ProgramChange="49" />
+      <Patch Number="435" Name="Clap Menu" ProgramChange="50" />
+      <Patch Number="436" Name="808 Chord" ProgramChange="51" />
+      <Patch Number="437" Name="808 Conga 3D" ProgramChange="52" />
+      <Patch Number="438" Name="Slow Chimes" ProgramChange="53" />
+      <Patch Number="439" Name="Dirty Sox" ProgramChange="54" />
+      <Patch Number="440" Name="ExtremPercus" ProgramChange="55" />
+      <Patch Number="441" Name="Pure Tribal" ProgramChange="56" />
+      <Patch Number="442" Name="TeknoTriangl" ProgramChange="57" />
+      <Patch Number="443" Name="Tamb&amp;SkrMenu" ProgramChange="58" />
+      <Patch Number="444" Name="Cow&amp;Rim Menu" ProgramChange="59" />
+      <Patch Number="445" Name="Perc. Menu 1" ProgramChange="60" />
+      <Patch Number="446" Name="Perc. Menu 2" ProgramChange="61" />
+      <Patch Number="447" Name="Perc. Menu 3" ProgramChange="62" />
+      <Patch Number="448" Name="Perc. Menu 4" ProgramChange="63" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX09) 1-128">
+      <Patch Number="001" Name="World Sounds" ProgramChange="0" />
+      <Patch Number="002" Name="Go2China /C2" ProgramChange="1" />
+      <Patch Number="003" Name="Go2India /C2" ProgramChange="2" />
+      <Patch Number="004" Name="The Great W" ProgramChange="3" />
+      <Patch Number="005" Name="Yuehchin+" ProgramChange="4" />
+      <Patch Number="006" Name="Sweet Nylon" ProgramChange="5" />
+      <Patch Number="007" Name="Tele R&amp;F" ProgramChange="6" />
+      <Patch Number="008" Name="Tubby Baby" ProgramChange="7" />
+      <Patch Number="009" Name="HeavenGender" ProgramChange="8" />
+      <Patch Number="010" Name="Gamelan Ems" ProgramChange="9" />
+      <Patch Number="011" Name="Childwood" ProgramChange="10" />
+      <Patch Number="012" Name="La Musette" ProgramChange="11" />
+      <Patch Number="013" Name="Essence" ProgramChange="12" />
+      <Patch Number="014" Name="Zampona /" ProgramChange="13" />
+      <Patch Number="015" Name="GipsyTrumpt/" ProgramChange="14" />
+      <Patch Number="016" Name="We Dream }{" ProgramChange="15" />
+      <Patch Number="017" Name="Fun WithPerc" ProgramChange="16" />
+      <Patch Number="018" Name="GuZheng arp" ProgramChange="17" />
+      <Patch Number="019" Name="Feets" ProgramChange="18" />
+      <Patch Number="020" Name="World Radio" ProgramChange="19" />
+      <Patch Number="021" Name="ClanAdvances" ProgramChange="20" />
+      <Patch Number="022" Name="Eastern Tour" ProgramChange="21" />
+      <Patch Number="023" Name="Enough!STOP!" ProgramChange="22" />
+      <Patch Number="024" Name="Banjo Phrs" ProgramChange="23" />
+      <Patch Number="025" Name="Guitar Phrs1" ProgramChange="24" />
+      <Patch Number="026" Name="Guitar Phrs2" ProgramChange="25" />
+      <Patch Number="027" Name="PdlStl Phrs" ProgramChange="26" />
+      <Patch Number="028" Name="Asia  UFO" ProgramChange="27" />
+      <Patch Number="029" Name="UBeenSoBaa" ProgramChange="28" />
+      <Patch Number="030" Name="Didgeri /" ProgramChange="29" />
+      <Patch Number="031" Name="WorldGroove" ProgramChange="30" />
+      <Patch Number="032" Name="LoopPhrase 1" ProgramChange="31" />
+      <Patch Number="033" Name="LoopPhrase 2" ProgramChange="32" />
+      <Patch Number="034" Name="TABLA groove" ProgramChange="33" />
+      <Patch Number="035" Name="JasonGoEast" ProgramChange="34" />
+      <Patch Number="036" Name="Flu&amp;AcompSRX" ProgramChange="35" />
+      <Patch Number="037" Name="Split Floot" ProgramChange="36" />
+      <Patch Number="038" Name="Hot Salsa" ProgramChange="37" />
+      <Patch Number="039" Name="TempBassSolo" ProgramChange="38" />
+      <Patch Number="040" Name="CherryFlower" ProgramChange="39" />
+      <Patch Number="041" Name="SplitThisSRX" ProgramChange="40" />
+      <Patch Number="042" Name="Crane Dance" ProgramChange="41" />
+      <Patch Number="043" Name="LostInMists" ProgramChange="42" />
+      <Patch Number="044" Name="Qu DiEnsembl" ProgramChange="43" />
+      <Patch Number="045" Name="NasalBlossom" ProgramChange="44" />
+      <Patch Number="046" Name="Meditation 1" ProgramChange="45" />
+      <Patch Number="047" Name="Art Of Feng" ProgramChange="46" />
+      <Patch Number="048" Name="Orient xPres" ProgramChange="47" />
+      <Patch Number="049" Name="Padded Sitar" ProgramChange="48" />
+      <Patch Number="050" Name="No Worries" ProgramChange="49" />
+      <Patch Number="051" Name="IntarMel SRX" ProgramChange="50" />
+      <Patch Number="052" Name="Ode 2 An Oud" ProgramChange="51" />
+      <Patch Number="053" Name="Fugi-man" ProgramChange="52" />
+      <Patch Number="054" Name="China pluck" ProgramChange="53" />
+      <Patch Number="055" Name="Yuehchin SRX" ProgramChange="54" />
+      <Patch Number="056" Name="Kayakeum" ProgramChange="55" />
+      <Patch Number="057" Name="Asian Pizz" ProgramChange="56" />
+      <Patch Number="058" Name="PiPa SRX" ProgramChange="57" />
+      <Patch Number="059" Name="Koto SRX" ProgramChange="58" />
+      <Patch Number="060" Name="Shamisen SRX" ProgramChange="59" />
+      <Patch Number="061" Name="Sanshin SRX" ProgramChange="60" />
+      <Patch Number="062" Name="Yang Qin trm" ProgramChange="61" />
+      <Patch Number="063" Name="Yang Qin/Mod" ProgramChange="62" />
+      <Patch Number="064" Name="SultanPalace" ProgramChange="63" />
+      <Patch Number="065" Name="Marco Polo" ProgramChange="64" />
+      <Patch Number="066" Name="Bandolim SRX" ProgramChange="65" />
+      <Patch Number="067" Name="K.Bandolim" ProgramChange="66" />
+      <Patch Number="068" Name="Afro Harp" ProgramChange="67" />
+      <Patch Number="069" Name="Ethnhit!" ProgramChange="68" />
+      <Patch Number="070" Name="OctaHarp+" ProgramChange="69" />
+      <Patch Number="071" Name="St.GuZhngSRX" ProgramChange="70" />
+      <Patch Number="072" Name="Zheng Zither" ProgramChange="71" />
+      <Patch Number="073" Name="Distance" ProgramChange="72" />
+      <Patch Number="074" Name="Mandolin/Mod" ProgramChange="73" />
+      <Patch Number="075" Name="Mandolin" ProgramChange="74" />
+      <Patch Number="076" Name="Mando Club" ProgramChange="75" />
+      <Patch Number="077" Name="MdlnTrmStSRX" ProgramChange="76" />
+      <Patch Number="078" Name="Drone Sitar" ProgramChange="77" />
+      <Patch Number="079" Name="Conch&amp;Sitar" ProgramChange="78" />
+      <Patch Number="080" Name="Punjab Rocks" ProgramChange="79" />
+      <Patch Number="081" Name="Pas2IndiaSRX" ProgramChange="80" />
+      <Patch Number="082" Name="Rain Drone" ProgramChange="81" />
+      <Patch Number="083" Name="SitarGlisSRX" ProgramChange="82" />
+      <Patch Number="084" Name="Tambura SRX" ProgramChange="83" />
+      <Patch Number="085" Name="TambDroneSRX" ProgramChange="84" />
+      <Patch Number="086" Name="St.SanturSRX" ProgramChange="85" />
+      <Patch Number="087" Name="SanturTrmSRX" ProgramChange="86" />
+      <Patch Number="088" Name="Santur /Mod" ProgramChange="87" />
+      <Patch Number="089" Name="Canton" ProgramChange="88" />
+      <Patch Number="090" Name="HamrDulcimer" ProgramChange="89" />
+      <Patch Number="091" Name="3D Dulcimer" ProgramChange="90" />
+      <Patch Number="092" Name="Zither" ProgramChange="91" />
+      <Patch Number="093" Name="Magic Pluck" ProgramChange="92" />
+      <Patch Number="094" Name="Biwa SRX" ProgramChange="93" />
+      <Patch Number="095" Name="Biwa Menu" ProgramChange="94" />
+      <Patch Number="096" Name="BerimbauMenu" ProgramChange="95" />
+      <Patch Number="097" Name="Berimbau" ProgramChange="96" />
+      <Patch Number="098" Name="JawHarp Menu" ProgramChange="97" />
+      <Patch Number="099" Name="Steel Rhythm" ProgramChange="98" />
+      <Patch Number="100" Name="SoloSteelGtr" ProgramChange="99" />
+      <Patch Number="101" Name="N'Ville Soft" ProgramChange="100" />
+      <Patch Number="102" Name="Spruce Top" ProgramChange="101" />
+      <Patch Number="103" Name="Procssd AGtr" ProgramChange="102" />
+      <Patch Number="104" Name="High Strung" ProgramChange="103" />
+      <Patch Number="105" Name="Compresd D18" ProgramChange="104" />
+      <Patch Number="106" Name="12 String" ProgramChange="105" />
+      <Patch Number="107" Name="Mixed 12Str1" ProgramChange="106" />
+      <Patch Number="108" Name="Mixed 12Str2" ProgramChange="107" />
+      <Patch Number="109" Name="Ac Gtr 12stg" ProgramChange="108" />
+      <Patch Number="110" Name="No Borders" ProgramChange="109" />
+      <Patch Number="111" Name="Loose 12Str" ProgramChange="110" />
+      <Patch Number="112" Name="Living R.Gtr" ProgramChange="111" />
+      <Patch Number="113" Name="Dobro Modro" ProgramChange="112" />
+      <Patch Number="114" Name="ResonatorGtr" ProgramChange="113" />
+      <Patch Number="115" Name="Ac.Gtrs SRX" ProgramChange="114" />
+      <Patch Number="116" Name="2 Players" ProgramChange="115" />
+      <Patch Number="117" Name="Solo RequGtr" ProgramChange="116" />
+      <Patch Number="118" Name="Loose Nylon" ProgramChange="117" />
+      <Patch Number="119" Name="AcousticBros" ProgramChange="118" />
+      <Patch Number="120" Name="So Sad Nylon" ProgramChange="119" />
+      <Patch Number="121" Name="Chinese Duo" ProgramChange="120" />
+      <Patch Number="122" Name="ChugRunTrSRX" ProgramChange="121" />
+      <Patch Number="123" Name="Chung Ruan" ProgramChange="122" />
+      <Patch Number="124" Name="ChungRuanSRX" ProgramChange="123" />
+      <Patch Number="125" Name="Bottom Ruan" ProgramChange="124" />
+      <Patch Number="126" Name="RuangGtr SRX" ProgramChange="125" />
+      <Patch Number="127" Name="Oud SRX" ProgramChange="126" />
+      <Patch Number="128" Name="BlugrsSldSRX" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX09) 129-256">
+      <Patch Number="129" Name="Guitaro SRX" ProgramChange="0" />
+      <Patch Number="130" Name="Natural Tele" ProgramChange="1" />
+      <Patch Number="131" Name="Psyche Tele" ProgramChange="2" />
+      <Patch Number="132" Name="Coral" ProgramChange="3" />
+      <Patch Number="133" Name="Chorus Twang" ProgramChange="4" />
+      <Patch Number="134" Name="Pick Licker" ProgramChange="5" />
+      <Patch Number="135" Name="CleanStrtSRX" ProgramChange="6" />
+      <Patch Number="136" Name="Velo 335 SRX" ProgramChange="7" />
+      <Patch Number="137" Name="Right Funky" ProgramChange="8" />
+      <Patch Number="138" Name="Comp Muted" ProgramChange="9" />
+      <Patch Number="139" Name="E.GtrMt SRX" ProgramChange="10" />
+      <Patch Number="140" Name="335VelMt SRX" ProgramChange="11" />
+      <Patch Number="141" Name="Wide Guitar" ProgramChange="12" />
+      <Patch Number="142" Name="Dob-Compress" ProgramChange="13" />
+      <Patch Number="143" Name="Nice Twelvey" ProgramChange="14" />
+      <Patch Number="144" Name="RotaryCrunch" ProgramChange="15" />
+      <Patch Number="145" Name="FastRotrySRX" ProgramChange="16" />
+      <Patch Number="146" Name="EGDynaPikSRX" ProgramChange="17" />
+      <Patch Number="147" Name="BackingEGSRX" ProgramChange="18" />
+      <Patch Number="148" Name="Room Slide" ProgramChange="19" />
+      <Patch Number="149" Name="Pedal Steel" ProgramChange="20" />
+      <Patch Number="150" Name="Phased P.Stl" ProgramChange="21" />
+      <Patch Number="151" Name="PureSteelSRX" ProgramChange="22" />
+      <Patch Number="152" Name="MutedAmbient" ProgramChange="23" />
+      <Patch Number="153" Name="GtrFX Menu" ProgramChange="24" />
+      <Patch Number="154" Name="LP Gtr SRX" ProgramChange="25" />
+      <Patch Number="155" Name="Tele-Funfken" ProgramChange="26" />
+      <Patch Number="156" Name="335 &amp;Cabinet" ProgramChange="27" />
+      <Patch Number="157" Name="Tele Licker" ProgramChange="28" />
+      <Patch Number="158" Name="Short &amp; Long" ProgramChange="29" />
+      <Patch Number="159" Name="NewBeginning" ProgramChange="30" />
+      <Patch Number="160" Name="Bouzouki" ProgramChange="31" />
+      <Patch Number="161" Name="Bousoukhit!" ProgramChange="32" />
+      <Patch Number="162" Name="3ChdStrumSRX" ProgramChange="33" />
+      <Patch Number="163" Name="Strum Poetic" ProgramChange="34" />
+      <Patch Number="164" Name="Strum Away" ProgramChange="35" />
+      <Patch Number="165" Name="Banjo-Mando" ProgramChange="36" />
+      <Patch Number="166" Name="5StringBanjo" ProgramChange="37" />
+      <Patch Number="167" Name="Banjo SRX 1" ProgramChange="38" />
+      <Patch Number="168" Name="Banjo SRX 2" ProgramChange="39" />
+      <Patch Number="169" Name="Banjo SRX 3" ProgramChange="40" />
+      <Patch Number="170" Name="Fiddle" ProgramChange="41" />
+      <Patch Number="171" Name="Fiddle 2002" ProgramChange="42" />
+      <Patch Number="172" Name="FiddleSwitch" ProgramChange="43" />
+      <Patch Number="173" Name="Fiddle Sect." ProgramChange="44" />
+      <Patch Number="174" Name="FiddleStacto" ProgramChange="45" />
+      <Patch Number="175" Name="AsianOrcPizz" ProgramChange="46" />
+      <Patch Number="176" Name="AJapaneseInn" ProgramChange="47" />
+      <Patch Number="177" Name="Deep Blue" ProgramChange="48" />
+      <Patch Number="178" Name="Ethnic Ens" ProgramChange="49" />
+      <Patch Number="179" Name="ChinesOrcSRX" ProgramChange="50" />
+      <Patch Number="180" Name="ErHu / SRX" ProgramChange="51" />
+      <Patch Number="181" Name="ErHuSolo SRX" ProgramChange="52" />
+      <Patch Number="182" Name="ErHu Ld SRX" ProgramChange="53" />
+      <Patch Number="183" Name="FiddleFXmenu" ProgramChange="54" />
+      <Patch Number="184" Name="ViolnSoloSRX" ProgramChange="55" />
+      <Patch Number="185" Name="Comp BabyBss" ProgramChange="56" />
+      <Patch Number="186" Name="Baby Bass" ProgramChange="57" />
+      <Patch Number="187" Name="Comp Fingerd" ProgramChange="58" />
+      <Patch Number="188" Name="Jazz Fing.BS" ProgramChange="59" />
+      <Patch Number="189" Name="Live Bass" ProgramChange="60" />
+      <Patch Number="190" Name="Flango Bass" ProgramChange="61" />
+      <Patch Number="191" Name="Bass Oddesy" ProgramChange="62" />
+      <Patch Number="192" Name="6Str Bs SRX1" ProgramChange="63" />
+      <Patch Number="193" Name="Muted Bass" ProgramChange="64" />
+      <Patch Number="194" Name="6Str/Mt SRX" ProgramChange="65" />
+      <Patch Number="195" Name="PickBsHd SRX" ProgramChange="66" />
+      <Patch Number="196" Name="PickedBs SRX" ProgramChange="67" />
+      <Patch Number="197" Name="Tub Bass" ProgramChange="68" />
+      <Patch Number="198" Name="GuitarnBsSRX" ProgramChange="69" />
+      <Patch Number="199" Name="GtrrnOct SRX" ProgramChange="70" />
+      <Patch Number="200" Name="PacificDream" ProgramChange="71" />
+      <Patch Number="201" Name="Meditation 2" ProgramChange="72" />
+      <Patch Number="202" Name="HybridKemong" ProgramChange="73" />
+      <Patch Number="203" Name="Purify" ProgramChange="74" />
+      <Patch Number="204" Name="Asia Bells" ProgramChange="75" />
+      <Patch Number="205" Name="Rama Cym SRX" ProgramChange="76" />
+      <Patch Number="206" Name="Bell Orchest" ProgramChange="77" />
+      <Patch Number="207" Name="Sacred Bells" ProgramChange="78" />
+      <Patch Number="208" Name="Spokes" ProgramChange="79" />
+      <Patch Number="209" Name="Winter Bells" ProgramChange="80" />
+      <Patch Number="210" Name="Wind Bells" ProgramChange="81" />
+      <Patch Number="211" Name="BelAngk SRX" ProgramChange="82" />
+      <Patch Number="212" Name="Tcheekolyna" ProgramChange="83" />
+      <Patch Number="213" Name="Wood EPiano" ProgramChange="84" />
+      <Patch Number="214" Name="Kalimba" ProgramChange="85" />
+      <Patch Number="215" Name="Kalimbatch" ProgramChange="86" />
+      <Patch Number="216" Name="VelAfro SRX1" ProgramChange="87" />
+      <Patch Number="217" Name="BsKalimbaSRX" ProgramChange="88" />
+      <Patch Number="218" Name="LogDetunrSRX" ProgramChange="89" />
+      <Patch Number="219" Name="Baateri SRX" ProgramChange="90" />
+      <Patch Number="220" Name="Balafon SRX" ProgramChange="91" />
+      <Patch Number="221" Name="Asian Wood" ProgramChange="92" />
+      <Patch Number="222" Name="Mellow tone" ProgramChange="93" />
+      <Patch Number="223" Name="Glas Mlt SRX" ProgramChange="94" />
+      <Patch Number="224" Name="SteelDr SRX1" ProgramChange="95" />
+      <Patch Number="225" Name="SteelDr SRX2" ProgramChange="96" />
+      <Patch Number="226" Name="Gendrous SRX" ProgramChange="97" />
+      <Patch Number="227" Name="BonangGamSRX" ProgramChange="98" />
+      <Patch Number="228" Name="VelAfro SRX2" ProgramChange="99" />
+      <Patch Number="229" Name="TemleMetlSRX" ProgramChange="100" />
+      <Patch Number="230" Name="Kemong / SRX" ProgramChange="101" />
+      <Patch Number="231" Name="Kane / SRX" ProgramChange="102" />
+      <Patch Number="232" Name="JeGong / SRX" ProgramChange="103" />
+      <Patch Number="233" Name="Jegogn / SRX" ProgramChange="104" />
+      <Patch Number="234" Name="Jublag / SRX" ProgramChange="105" />
+      <Patch Number="235" Name="Reyong / SRX" ProgramChange="106" />
+      <Patch Number="236" Name="Pemade / SRX" ProgramChange="107" />
+      <Patch Number="237" Name="Cajun" ProgramChange="108" />
+      <Patch Number="238" Name="D.Accordion" ProgramChange="109" />
+      <Patch Number="239" Name="SquezeBoxSRX" ProgramChange="110" />
+      <Patch Number="240" Name="Squeeze Box" ProgramChange="111" />
+      <Patch Number="241" Name="St.AcdOp SRX" ProgramChange="112" />
+      <Patch Number="242" Name="AcdionOp SRX" ProgramChange="113" />
+      <Patch Number="243" Name="Acd ffOp SRX" ProgramChange="114" />
+      <Patch Number="244" Name="St.AcdCl SRX" ProgramChange="115" />
+      <Patch Number="245" Name="Bluesy" ProgramChange="116" />
+      <Patch Number="246" Name="HarmonicaSRX" ProgramChange="117" />
+      <Patch Number="247" Name="CuntryHrpSRX" ProgramChange="118" />
+      <Patch Number="248" Name="Sessn HrpSRX" ProgramChange="119" />
+      <Patch Number="249" Name="Esraj&amp;Mizmar" ProgramChange="120" />
+      <Patch Number="250" Name="Before Time" ProgramChange="121" />
+      <Patch Number="251" Name="Gagaku Ems" ProgramChange="122" />
+      <Patch Number="252" Name="Mizmar solo" ProgramChange="123" />
+      <Patch Number="253" Name="PiriSolo SRX" ProgramChange="124" />
+      <Patch Number="254" Name="Shahnai SRX" ProgramChange="125" />
+      <Patch Number="255" Name="HichirikSRX" ProgramChange="126" />
+      <Patch Number="256" Name="Bagpipes SRX" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX09) 257-384">
+      <Patch Number="257" Name="Sheng / SRX" ProgramChange="0" />
+      <Patch Number="258" Name="Suona / SRX" ProgramChange="1" />
+      <Patch Number="259" Name="VillageDance" ProgramChange="2" />
+      <Patch Number="260" Name="Indian Ens" ProgramChange="3" />
+      <Patch Number="261" Name="Nature Loves" ProgramChange="4" />
+      <Patch Number="262" Name="PanPipes SRX" ProgramChange="5" />
+      <Patch Number="263" Name="Sad  Pipe" ProgramChange="6" />
+      <Patch Number="264" Name="Shell blow" ProgramChange="7" />
+      <Patch Number="265" Name="Desert Flute" ProgramChange="8" />
+      <Patch Number="266" Name="Zampona" ProgramChange="9" />
+      <Patch Number="267" Name="Isolation" ProgramChange="10" />
+      <Patch Number="268" Name="Ocarina" ProgramChange="11" />
+      <Patch Number="269" Name="New IndFlute" ProgramChange="12" />
+      <Patch Number="270" Name="Qu Di Vib" ProgramChange="13" />
+      <Patch Number="271" Name="Bang Di Vib" ProgramChange="14" />
+      <Patch Number="272" Name="New Kawala" ProgramChange="15" />
+      <Patch Number="273" Name="BreathyIndia" ProgramChange="16" />
+      <Patch Number="274" Name="New Shaku" ProgramChange="17" />
+      <Patch Number="275" Name="Shakuhachi" ProgramChange="18" />
+      <Patch Number="276" Name="DreamInColor" ProgramChange="19" />
+      <Patch Number="277" Name="TwinHillyLd" ProgramChange="20" />
+      <Patch Number="278" Name="Snake Eyes" ProgramChange="21" />
+      <Patch Number="279" Name="Latin Trumpt" ProgramChange="22" />
+      <Patch Number="280" Name="MariachiTpts" ProgramChange="23" />
+      <Patch Number="281" Name="Trumpets" ProgramChange="24" />
+      <Patch Number="282" Name="GrowlWah/Mod" ProgramChange="25" />
+      <Patch Number="283" Name="Muted-Grw /" ProgramChange="26" />
+      <Patch Number="284" Name="SoloTuba SRX" ProgramChange="27" />
+      <Patch Number="285" Name="LatinTubaSRX" ProgramChange="28" />
+      <Patch Number="286" Name="World Orch" ProgramChange="29" />
+      <Patch Number="287" Name="Stab&amp;Hold" ProgramChange="30" />
+      <Patch Number="288" Name="Indian Radio" ProgramChange="31" />
+      <Patch Number="289" Name="Wide Brass" ProgramChange="32" />
+      <Patch Number="290" Name="Trombones" ProgramChange="33" />
+      <Patch Number="291" Name="Brass Snapz" ProgramChange="34" />
+      <Patch Number="292" Name="Brass sfzzZZ" ProgramChange="35" />
+      <Patch Number="293" Name="2Tp+Tbn SRX" ProgramChange="36" />
+      <Patch Number="294" Name="MemphisHORNS" ProgramChange="37" />
+      <Patch Number="295" Name="SectStactSRX" ProgramChange="38" />
+      <Patch Number="296" Name="LatinBrasses" ProgramChange="39" />
+      <Patch Number="297" Name="Hit &amp; Fall" ProgramChange="40" />
+      <Patch Number="298" Name="BrsChd13 SRX" ProgramChange="41" />
+      <Patch Number="299" Name="BrsChdMi9SRX" ProgramChange="42" />
+      <Patch Number="300" Name="BrsChdMj9SRX" ProgramChange="43" />
+      <Patch Number="301" Name="Blow Pad" ProgramChange="44" />
+      <Patch Number="302" Name="Ceremony" ProgramChange="45" />
+      <Patch Number="303" Name="Glasses" ProgramChange="46" />
+      <Patch Number="304" Name="Ambiccordian" ProgramChange="47" />
+      <Patch Number="305" Name="DroneFlanger" ProgramChange="48" />
+      <Patch Number="306" Name="Rock Gods" ProgramChange="49" />
+      <Patch Number="307" Name="ScotlandLass" ProgramChange="50" />
+      <Patch Number="308" Name="Dry Fishes" ProgramChange="51" />
+      <Patch Number="309" Name="SteroidBrass" ProgramChange="52" />
+      <Patch Number="310" Name="Soul revived" ProgramChange="53" />
+      <Patch Number="311" Name="Rain Pad" ProgramChange="54" />
+      <Patch Number="312" Name="Rising Sun" ProgramChange="55" />
+      <Patch Number="313" Name="Ethnopad" ProgramChange="56" />
+      <Patch Number="314" Name="Ethno Strngs" ProgramChange="57" />
+      <Patch Number="315" Name="&amp; 40 Thieves" ProgramChange="58" />
+      <Patch Number="316" Name="TromboSynthy" ProgramChange="59" />
+      <Patch Number="317" Name="GrandExaltd1" ProgramChange="60" />
+      <Patch Number="318" Name="Sun Dog" ProgramChange="61" />
+      <Patch Number="319" Name="TechnoSpirit" ProgramChange="62" />
+      <Patch Number="320" Name="Play Softly" ProgramChange="63" />
+      <Patch Number="321" Name="WorkerBeetle" ProgramChange="64" />
+      <Patch Number="322" Name="Glass Cut" ProgramChange="65" />
+      <Patch Number="323" Name="GuruTronics" ProgramChange="66" />
+      <Patch Number="324" Name="DubJazz Trip" ProgramChange="67" />
+      <Patch Number="325" Name="Meditation 2" ProgramChange="68" />
+      <Patch Number="326" Name="Political" ProgramChange="69" />
+      <Patch Number="327" Name="G`day Mate" ProgramChange="70" />
+      <Patch Number="328" Name="Mission" ProgramChange="71" />
+      <Patch Number="329" Name="Jegorgan" ProgramChange="72" />
+      <Patch Number="330" Name="Dyno Conga 1" ProgramChange="73" />
+      <Patch Number="331" Name="Dyno Conga 2" ProgramChange="74" />
+      <Patch Number="332" Name="Congas+Bongo" ProgramChange="75" />
+      <Patch Number="333" Name="DynTimbale 1" ProgramChange="76" />
+      <Patch Number="334" Name="DynTimbale 2" ProgramChange="77" />
+      <Patch Number="335" Name="TimbaleCuica" ProgramChange="78" />
+      <Patch Number="336" Name="Dyno Surdo" ProgramChange="79" />
+      <Patch Number="337" Name="Rhythm Sect" ProgramChange="80" />
+      <Patch Number="338" Name="Rainstick" ProgramChange="81" />
+      <Patch Number="339" Name="Clap &amp; Snap" ProgramChange="82" />
+      <Patch Number="340" Name="CowbellRandm" ProgramChange="83" />
+      <Patch Number="341" Name="Karachi-Man" ProgramChange="84" />
+      <Patch Number="342" Name="That Was Zen" ProgramChange="85" />
+      <Patch Number="343" Name="StreetParade" ProgramChange="86" />
+      <Patch Number="344" Name="BUK" ProgramChange="87" />
+      <Patch Number="345" Name="Gongs" ProgramChange="88" />
+      <Patch Number="346" Name="Chenchen /" ProgramChange="89" />
+      <Patch Number="347" Name="WisdomWithin" ProgramChange="90" />
+      <Patch Number="348" Name="Tabla+" ProgramChange="91" />
+      <Patch Number="349" Name="DrumsScene" ProgramChange="92" />
+      <Patch Number="350" Name="Doholla Fun" ProgramChange="93" />
+      <Patch Number="351" Name="AfricanRhtms" ProgramChange="94" />
+      <Patch Number="352" Name="Big Logs SRX" ProgramChange="95" />
+      <Patch Number="353" Name="WarDrums SRX" ProgramChange="96" />
+      <Patch Number="354" Name="Samba Menu" ProgramChange="97" />
+      <Patch Number="355" Name="Shaker Menu" ProgramChange="98" />
+      <Patch Number="356" Name="Caixa  Menu" ProgramChange="99" />
+      <Patch Number="357" Name="Cowbell Menu" ProgramChange="100" />
+      <Patch Number="358" Name="JapanPrcMenu" ProgramChange="101" />
+      <Patch Number="359" Name="Kabuki Menu" ProgramChange="102" />
+      <Patch Number="360" Name="KwangwariSRX" ProgramChange="103" />
+      <Patch Number="361" Name="Tuzumi / SRX" ProgramChange="104" />
+      <Patch Number="362" Name="KoreaPrcMenu" ProgramChange="105" />
+      <Patch Number="363" Name="ChinaPrcMenu" ProgramChange="106" />
+      <Patch Number="364" Name="China Menu" ProgramChange="107" />
+      <Patch Number="365" Name="ChinaGongSRX" ProgramChange="108" />
+      <Patch Number="366" Name="Sanba /  SRX" ProgramChange="109" />
+      <Patch Number="367" Name="St.ShouBoSRX" ProgramChange="110" />
+      <Patch Number="368" Name="AsiaCym Menu" ProgramChange="111" />
+      <Patch Number="369" Name="Gong Menu" ProgramChange="112" />
+      <Patch Number="370" Name="Gamelan Menu" ProgramChange="113" />
+      <Patch Number="371" Name="GamlnPrcMenu" ProgramChange="114" />
+      <Patch Number="372" Name="BigBazar SRX" ProgramChange="115" />
+      <Patch Number="373" Name="Udu Pot Menu" ProgramChange="116" />
+      <Patch Number="374" Name="TablaBy Menu" ProgramChange="117" />
+      <Patch Number="375" Name="Rek Menu" ProgramChange="118" />
+      <Patch Number="376" Name="Dholak Menu1" ProgramChange="119" />
+      <Patch Number="377" Name="Dholak Menu2" ProgramChange="120" />
+      <Patch Number="378" Name="Dhol Menu" ProgramChange="121" />
+      <Patch Number="379" Name="Egypt Tablah" ProgramChange="122" />
+      <Patch Number="380" Name="Madal Menu" ProgramChange="123" />
+      <Patch Number="381" Name="AfropercMenu" ProgramChange="124" />
+      <Patch Number="382" Name="CommSatelite" ProgramChange="125" />
+      <Patch Number="383" Name="Amazone" ProgramChange="126" />
+      <Patch Number="384" Name="Tasman Sea" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX09) 385-414">
+      <Patch Number="385" Name="Ethnic FX 1" ProgramChange="0" />
+      <Patch Number="386" Name="Ethnic FX 2" ProgramChange="1" />
+      <Patch Number="387" Name="SpacetualBoy" ProgramChange="2" />
+      <Patch Number="388" Name="Crystal" ProgramChange="3" />
+      <Patch Number="389" Name="SpaceLuvSick" ProgramChange="4" />
+      <Patch Number="390" Name="HitAscension" ProgramChange="5" />
+      <Patch Number="391" Name="Nervous Man" ProgramChange="6" />
+      <Patch Number="392" Name="Silk Stream" ProgramChange="7" />
+      <Patch Number="393" Name="DerangedMind" ProgramChange="8" />
+      <Patch Number="394" Name="PolyDrone" ProgramChange="9" />
+      <Patch Number="395" Name="TequillaWorm" ProgramChange="10" />
+      <Patch Number="396" Name="GlistenToYou" ProgramChange="11" />
+      <Patch Number="397" Name="Dream Harp" ProgramChange="12" />
+      <Patch Number="398" Name="Waterfall" ProgramChange="13" />
+      <Patch Number="399" Name="Gender 3D" ProgramChange="14" />
+      <Patch Number="400" Name="Doom Drum" ProgramChange="15" />
+      <Patch Number="401" Name="Stalker" ProgramChange="16" />
+      <Patch Number="402" Name="PlasticBones" ProgramChange="17" />
+      <Patch Number="403" Name="PakistanVibe" ProgramChange="18" />
+      <Patch Number="404" Name="ThusSpokeZtr" ProgramChange="19" />
+      <Patch Number="405" Name="Kalissando" ProgramChange="20" />
+      <Patch Number="406" Name="Rain Forest" ProgramChange="21" />
+      <Patch Number="407" Name="AfropunchSRX" ProgramChange="22" />
+      <Patch Number="408" Name="Dance Tape" ProgramChange="23" />
+      <Patch Number="409" Name="Zaghruta SRX" ProgramChange="24" />
+      <Patch Number="410" Name="1,2,3,4! SRX" ProgramChange="25" />
+      <Patch Number="411" Name="Voices SRX" ProgramChange="26" />
+      <Patch Number="412" Name="Voice Menu 1" ProgramChange="27" />
+      <Patch Number="413" Name="Voice Menu 2" ProgramChange="28" />
+      <Patch Number="414" Name="Voice Menu 3" ProgramChange="29" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX10)">
+      <Patch Number="001" Name="Pop Brs Sect" ProgramChange="0" />
+      <Patch Number="002" Name="Pop Brs Stac" ProgramChange="1" />
+      <Patch Number="003" Name="Pop Brs Fall" ProgramChange="2" />
+      <Patch Number="004" Name="Trumpet Sect" ProgramChange="3" />
+      <Patch Number="005" Name="Tp Sect Stac" ProgramChange="4" />
+      <Patch Number="006" Name="Tp Sect Doit" ProgramChange="5" />
+      <Patch Number="007" Name="Mute Tp Sect" ProgramChange="6" />
+      <Patch Number="008" Name="MtTpSect Stc" ProgramChange="7" />
+      <Patch Number="009" Name="C Tp Section" ProgramChange="8" />
+      <Patch Number="010" Name="C TpSect Stc" ProgramChange="9" />
+      <Patch Number="011" Name="C TpSect Tri" ProgramChange="10" />
+      <Patch Number="012" Name="TromboneSect" ProgramChange="11" />
+      <Patch Number="013" Name="Tb Sect Stac" ProgramChange="12" />
+      <Patch Number="014" Name="Tb Sect Fall" ProgramChange="13" />
+      <Patch Number="015" Name="Horn Section" ProgramChange="14" />
+      <Patch Number="016" Name="HornSect Stc" ProgramChange="15" />
+      <Patch Number="017" Name="HornSect Rip" ProgramChange="16" />
+      <Patch Number="018" Name="Tuba /" ProgramChange="17" />
+      <Patch Number="019" Name="Tuba Stacc" ProgramChange="18" />
+      <Patch Number="020" Name="Mezzo Pop" ProgramChange="19" />
+      <Patch Number="021" Name="Mezzo Pop WS" ProgramChange="20" />
+      <Patch Number="022" Name="DynaBrass  M" ProgramChange="21" />
+      <Patch Number="023" Name="Smooth Brass" ProgramChange="22" />
+      <Patch Number="024" Name="Oct PopBrass" ProgramChange="23" />
+      <Patch Number="025" Name="PopBrass Sfz" ProgramChange="24" />
+      <Patch Number="026" Name="Stac PopSect" ProgramChange="25" />
+      <Patch Number="027" Name="PopBrs ShtFl" ProgramChange="26" />
+      <Patch Number="028" Name="PopBrs LngFl" ProgramChange="27" />
+      <Patch Number="029" Name="PopBrass Rip" ProgramChange="28" />
+      <Patch Number="030" Name="PopBrs /Fl 1" ProgramChange="29" />
+      <Patch Number="031" Name="PopBrs /Fl 2" ProgramChange="30" />
+      <Patch Number="032" Name="ShortBrs /Fl" ProgramChange="31" />
+      <Patch Number="033" Name="Smooth Tps" ProgramChange="32" />
+      <Patch Number="034" Name="Tpt Section" ProgramChange="33" />
+      <Patch Number="035" Name="Tpt Sect WS" ProgramChange="34" />
+      <Patch Number="036" Name="Tpt Sect M" ProgramChange="35" />
+      <Patch Number="037" Name="Mild Tp Sect" ProgramChange="36" />
+      <Patch Number="038" Name="Tp Sect Sfz" ProgramChange="37" />
+      <Patch Number="039" Name="Tp Sect Fall" ProgramChange="38" />
+      <Patch Number="040" Name="TpSect RipFl" ProgramChange="39" />
+      <Patch Number="041" Name="TpSect RipCp" ProgramChange="40" />
+      <Patch Number="042" Name="TpSect Shake" ProgramChange="41" />
+      <Patch Number="043" Name="Trumpets /Fl" ProgramChange="42" />
+      <Patch Number="044" Name="Trumpts/Shak" ProgramChange="43" />
+      <Patch Number="045" Name="Trumpts/Doit" ProgramChange="44" />
+      <Patch Number="046" Name="ShortTps /Fl" ProgramChange="45" />
+      <Patch Number="047" Name="..the Ripper" ProgramChange="46" />
+      <Patch Number="048" Name="Don't Doit!" ProgramChange="47" />
+      <Patch Number="049" Name="MuteTpSect S" ProgramChange="48" />
+      <Patch Number="050" Name="MuteTpSect M" ProgramChange="49" />
+      <Patch Number="051" Name="Mild MuteTps" ProgramChange="50" />
+      <Patch Number="052" Name="Smooth C-Tps" ProgramChange="51" />
+      <Patch Number="053" Name="C-Tps w/Vib" ProgramChange="52" />
+      <Patch Number="054" Name="C-Tp Sect" ProgramChange="53" />
+      <Patch Number="055" Name="C-Tp Sect WS" ProgramChange="54" />
+      <Patch Number="056" Name="C-Tp Sect M" ProgramChange="55" />
+      <Patch Number="057" Name="Mild CTpSect" ProgramChange="56" />
+      <Patch Number="058" Name="CTp Sect Sfz" ProgramChange="57" />
+      <Patch Number="059" Name="Tripoli" ProgramChange="58" />
+      <Patch Number="060" Name="Mainly Stacc" ProgramChange="59" />
+      <Patch Number="061" Name="C Tpts /Trit" ProgramChange="60" />
+      <Patch Number="062" Name="Smooth Tbs" ProgramChange="61" />
+      <Patch Number="063" Name="Mild Tb Sect" ProgramChange="62" />
+      <Patch Number="064" Name="Tb Sect" ProgramChange="63" />
+      <Patch Number="065" Name="Tb Sect WS" ProgramChange="64" />
+      <Patch Number="066" Name="Tb Sect M" ProgramChange="65" />
+      <Patch Number="067" Name="Tb Sect Sfz" ProgramChange="66" />
+      <Patch Number="068" Name="Tb Sect Rip" ProgramChange="67" />
+      <Patch Number="069" Name="Tb Sect /Fl" ProgramChange="68" />
+      <Patch Number="070" Name="ShortTbs /Fl" ProgramChange="69" />
+      <Patch Number="071" Name="ToodleAction" ProgramChange="70" />
+      <Patch Number="072" Name="Smooth Horns" ProgramChange="71" />
+      <Patch Number="073" Name="Horn Sect" ProgramChange="72" />
+      <Patch Number="074" Name="Horn Sect WS" ProgramChange="73" />
+      <Patch Number="075" Name="Horn Sect M" ProgramChange="74" />
+      <Patch Number="076" Name="EmotiveHorns" ProgramChange="75" />
+      <Patch Number="077" Name="Mild Horns" ProgramChange="76" />
+      <Patch Number="078" Name="HornSect Sfz" ProgramChange="77" />
+      <Patch Number="079" Name="HornSect/Rip" ProgramChange="78" />
+      <Patch Number="080" Name="HornSwitcher" ProgramChange="79" />
+      <Patch Number="081" Name="Mild Tuba" ProgramChange="80" />
+      <Patch Number="082" Name="Tuba Sect WS" ProgramChange="81" />
+      <Patch Number="083" Name="Tuba Sect M" ProgramChange="82" />
+      <Patch Number="084" Name="TubaSwitchOn" ProgramChange="83" />
+      <Patch Number="085" Name="Tp+Tb Sect /" ProgramChange="84" />
+      <Patch Number="086" Name="CTp+Tb Sect/" ProgramChange="85" />
+      <Patch Number="087" Name="LOUD OK?!" ProgramChange="86" />
+      <Patch Number="088" Name="Hey You Mute" ProgramChange="87" />
+      <Patch Number="089" Name="FullOnBrass" ProgramChange="88" />
+      <Patch Number="090" Name="Blend Brass" ProgramChange="89" />
+      <Patch Number="091" Name="LR Mix Stacc" ProgramChange="90" />
+      <Patch Number="092" Name="Warm Tp Sect" ProgramChange="91" />
+      <Patch Number="093" Name="Dyna Section" ProgramChange="92" />
+      <Patch Number="094" Name="Warm Horns" ProgramChange="93" />
+      <Patch Number="095" Name="Schizo Brass" ProgramChange="94" />
+      <Patch Number="096" Name="Don't hit me" ProgramChange="95" />
+      <Patch Number="097" Name="DiminerBrass" ProgramChange="96" />
+      <Patch Number="098" Name="Wild Niner" ProgramChange="97" />
+      <Patch Number="099" Name="Mid Thirties" ProgramChange="98" />
+      <Patch Number="100" Name="BrsStac Echo" ProgramChange="99" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX11)">
+      <Patch Number="001" Name="Superb Grand" ProgramChange="0" />
+      <Patch Number="002" Name="WideStereoGd" ProgramChange="1" />
+      <Patch Number="003" Name="ClassicGrand" ProgramChange="2" />
+      <Patch Number="004" Name="Rock Grand" ProgramChange="3" />
+      <Patch Number="005" Name="Superior Grd" ProgramChange="4" />
+      <Patch Number="006" Name="PerfectGrand" ProgramChange="5" />
+      <Patch Number="007" Name="SingUsASong" ProgramChange="6" />
+      <Patch Number="008" Name="Dynamic Grd" ProgramChange="7" />
+      <Patch Number="009" Name="BriteOnStage" ProgramChange="8" />
+      <Patch Number="010" Name="BrightPopV/S" ProgramChange="9" />
+      <Patch Number="011" Name="Grand P1" ProgramChange="10" />
+      <Patch Number="012" Name="BrighterSide" ProgramChange="11" />
+      <Patch Number="013" Name="Full Rock pF" ProgramChange="12" />
+      <Patch Number="014" Name="Dark Ballad" ProgramChange="13" />
+      <Patch Number="015" Name="Grand P2" ProgramChange="14" />
+      <Patch Number="016" Name="Darker Side" ProgramChange="15" />
+      <Patch Number="017" Name="VelocaverPno" ProgramChange="16" />
+      <Patch Number="018" Name="Warm Room pF" ProgramChange="17" />
+      <Patch Number="019" Name="AntiqueUprit" ProgramChange="18" />
+      <Patch Number="020" Name="SuperiorMono" ProgramChange="19" />
+      <Patch Number="021" Name="Ragtime Gd" ProgramChange="20" />
+      <Patch Number="022" Name="Gnu House pF" ProgramChange="21" />
+      <Patch Number="023" Name="Archive Pno" ProgramChange="22" />
+      <Patch Number="024" Name="Lil' Takker" ProgramChange="23" />
+      <Patch Number="025" Name="Grand n Str" ProgramChange="24" />
+      <Patch Number="026" Name="Superior Str" ProgramChange="25" />
+      <Patch Number="027" Name="Sad Farewell" ProgramChange="26" />
+      <Patch Number="028" Name="Mixed Layer" ProgramChange="27" />
+      <Patch Number="029" Name="SuperiorPd1" ProgramChange="28" />
+      <Patch Number="030" Name="SuperiorPd2" ProgramChange="29" />
+      <Patch Number="031" Name="First Star" ProgramChange="30" />
+      <Patch Number="032" Name="New Age Layr" ProgramChange="31" />
+      <Patch Number="033" Name="Deep Breath" ProgramChange="32" />
+      <Patch Number="034" Name="Mc Reverse" ProgramChange="33" />
+      <Patch Number="035" Name="Meditate" ProgramChange="34" />
+      <Patch Number="036" Name="Penta Duo" ProgramChange="35" />
+      <Patch Number="037" Name="D-lightful" ProgramChange="36" />
+      <Patch Number="038" Name="Custom Clav" ProgramChange="37" />
+      <Patch Number="039" Name="Barococo" ProgramChange="38" />
+      <Patch Number="040" Name="Pianolins" ProgramChange="39" />
+      <Patch Number="041" Name="RandoMeistro" ProgramChange="40" />
+      <Patch Number="042" Name="Spooky Dimin" ProgramChange="41" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (SRX12)">
+      <Patch Number="001" Name="Pure EP1" ProgramChange="0" />
+      <Patch Number="002" Name="Lo-Fi EP1" ProgramChange="1" />
+      <Patch Number="003" Name="Pure EP2" ProgramChange="2" />
+      <Patch Number="004" Name="Phaser EP1" ProgramChange="3" />
+      <Patch Number="005" Name="Soft Wurly" ProgramChange="4" />
+      <Patch Number="006" Name="Pure Wurly" ProgramChange="5" />
+      <Patch Number="007" Name="Pure Clav DB" ProgramChange="6" />
+      <Patch Number="008" Name="Pure Clav CB" ProgramChange="7" />
+      <Patch Number="009" Name="PhaseClav CB" ProgramChange="8" />
+      <Patch Number="010" Name="Wah Clav CB" ProgramChange="9" />
+      <Patch Number="011" Name="Comp Clav CB" ProgramChange="10" />
+      <Patch Number="012" Name="PureClavMtCB" ProgramChange="11" />
+      <Patch Number="013" Name="St.Trem EP1" ProgramChange="12" />
+      <Patch Number="014" Name="St.Trem EP2" ProgramChange="13" />
+      <Patch Number="015" Name="Chorus Wurly" ProgramChange="14" />
+      <Patch Number="016" Name="Chorus EP1" ProgramChange="15" />
+      <Patch Number="017" Name="Chorus EP2" ProgramChange="16" />
+      <Patch Number="018" Name="Dp-Cho EP1" ProgramChange="17" />
+      <Patch Number="019" Name="Dp-Cho EP2" ProgramChange="18" />
+      <Patch Number="020" Name="Soft EP1" ProgramChange="19" />
+      <Patch Number="021" Name="Soft EP2" ProgramChange="20" />
+      <Patch Number="022" Name="Phase Wurly" ProgramChange="21" />
+      <Patch Number="023" Name="Hard EP1" ProgramChange="22" />
+      <Patch Number="024" Name="Moving EP1" ProgramChange="23" />
+      <Patch Number="025" Name="EP1 w/FM" ProgramChange="24" />
+      <Patch Number="026" Name="EP1 w/VOX" ProgramChange="25" />
+      <Patch Number="027" Name="EP1 w/STR" ProgramChange="26" />
+      <Patch Number="028" Name="EP1 w/PAD" ProgramChange="27" />
+      <Patch Number="029" Name="Flanger EP1" ProgramChange="28" />
+      <Patch Number="030" Name="Flanger EP2" ProgramChange="29" />
+      <Patch Number="031" Name="FlangerWurly" ProgramChange="30" />
+      <Patch Number="032" Name="Melodic EP1" ProgramChange="31" />
+      <Patch Number="033" Name="Amped EP1" ProgramChange="32" />
+      <Patch Number="034" Name="Amped EP2" ProgramChange="33" />
+      <Patch Number="035" Name="Lo-Fi EP2" ProgramChange="34" />
+      <Patch Number="036" Name="Lo-Fi Wurly" ProgramChange="35" />
+      <Patch Number="037" Name="ModDly EP1" ProgramChange="36" />
+      <Patch Number="038" Name="ModDly EP2" ProgramChange="37" />
+      <Patch Number="039" Name="Dual EP1" ProgramChange="38" />
+      <Patch Number="040" Name="Dual Wurly" ProgramChange="39" />
+      <Patch Number="041" Name="Enhance Clav" ProgramChange="40" />
+      <Patch Number="042" Name="Peaking Clav" ProgramChange="41" />
+      <Patch Number="043" Name="Dual Clav DB" ProgramChange="42" />
+      <Patch Number="044" Name="Dual Clav DA" ProgramChange="43" />
+      <Patch Number="045" Name="Dual Clav CB" ProgramChange="44" />
+      <Patch Number="046" Name="Dual Clav CA" ProgramChange="45" />
+      <Patch Number="047" Name="DualClavMtDB" ProgramChange="46" />
+      <Patch Number="048" Name="DualClavMtCB" ProgramChange="47" />
+      <Patch Number="049" Name="PhaseClav DB" ProgramChange="48" />
+      <Patch Number="050" Name="PhaseClvMtCB" ProgramChange="49" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Synth Tone 1-128">
+      <Patch Number="001" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="002" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="003" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="004" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="005" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="006" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="007" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="008" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="009" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="010" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="011" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="012" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="013" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="014" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="015" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="016" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="017" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="018" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="019" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="020" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="021" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="022" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="023" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="024" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="025" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="026" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="027" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="028" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="029" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="030" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="031" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="032" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="033" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="034" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="035" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="036" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="037" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="038" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="039" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="040" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="041" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="042" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="043" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="044" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="045" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="046" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="047" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="048" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="049" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="050" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="051" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="052" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="053" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="054" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="055" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="056" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="057" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="058" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="059" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="060" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="061" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="062" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="063" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="064" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="065" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="066" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="067" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="068" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="069" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="070" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="071" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="072" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="073" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="074" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="075" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="076" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="077" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="078" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="079" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="080" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="081" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="082" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="083" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="084" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="085" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="086" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="087" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="088" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="089" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="090" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="091" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="092" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="093" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="094" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="095" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="096" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="097" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="098" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="099" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="100" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="101" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="102" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="103" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="104" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="105" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="106" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="107" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="108" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="109" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="110" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="111" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="112" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="113" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="114" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="115" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="116" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="117" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="118" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="119" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="120" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="121" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="122" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="123" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="124" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="125" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="126" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="127" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="128" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Synth Tone 129-256">
+      <Patch Number="129" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="130" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="131" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="132" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="133" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="134" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="135" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="136" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="137" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="138" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="139" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="140" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="141" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="142" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="143" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="144" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="145" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="146" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="147" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="148" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="149" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="150" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="151" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="152" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="153" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="154" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="155" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="156" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="157" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="158" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="159" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="160" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="161" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="162" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="163" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="164" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="165" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="166" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="167" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="168" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="169" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="170" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="171" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="172" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="173" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="174" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="175" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="176" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="177" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="178" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="179" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="180" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="181" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="182" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="183" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="184" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="185" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="186" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="187" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="188" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="189" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="190" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="191" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="192" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="193" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="194" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="195" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="196" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="197" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="198" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="199" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="200" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="201" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="202" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="203" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="204" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="205" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="206" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="207" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="208" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="209" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="210" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="211" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="212" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="213" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="214" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="215" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="216" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="217" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="218" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="219" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="220" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="221" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="222" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="223" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="224" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="225" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="226" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="227" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="228" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="229" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="230" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="231" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="232" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="233" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="234" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="235" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="236" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="237" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="238" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="239" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="240" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="241" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="242" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="243" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="244" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="245" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="246" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="247" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="248" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="249" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="250" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="251" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="252" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="253" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="254" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="255" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="256" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Synth Tone 257-384">
+      <Patch Number="257" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="258" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="259" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="260" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="261" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="262" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="263" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="264" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="265" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="266" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="267" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="268" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="269" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="270" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="271" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="272" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="273" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="274" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="275" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="276" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="277" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="278" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="279" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="280" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="281" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="282" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="283" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="284" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="285" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="286" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="287" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="288" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="289" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="290" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="291" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="292" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="293" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="294" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="295" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="296" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="297" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="298" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="299" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="300" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="301" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="302" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="303" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="304" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="305" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="306" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="307" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="308" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="309" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="310" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="311" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="312" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="313" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="314" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="315" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="316" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="317" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="318" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="319" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="320" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="321" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="322" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="323" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="324" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="325" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="326" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="327" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="328" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="329" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="330" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="331" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="332" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="333" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="334" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="335" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="336" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="337" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="338" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="339" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="340" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="341" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="342" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="343" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="344" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="345" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="346" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="347" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="348" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="349" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="350" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="351" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="352" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="353" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="354" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="355" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="356" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="357" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="358" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="359" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="360" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="361" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="362" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="363" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="364" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="365" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="366" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="367" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="368" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="369" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="370" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="371" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="372" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="373" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="374" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="375" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="376" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="377" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="378" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="379" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="380" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="381" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="382" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="383" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="384" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Synth Tone 385-512">
+      <Patch Number="385" Name="INIT TONE" ProgramChange="0" />
+      <Patch Number="386" Name="INIT TONE" ProgramChange="1" />
+      <Patch Number="387" Name="INIT TONE" ProgramChange="2" />
+      <Patch Number="388" Name="INIT TONE" ProgramChange="3" />
+      <Patch Number="389" Name="INIT TONE" ProgramChange="4" />
+      <Patch Number="390" Name="INIT TONE" ProgramChange="5" />
+      <Patch Number="391" Name="INIT TONE" ProgramChange="6" />
+      <Patch Number="392" Name="INIT TONE" ProgramChange="7" />
+      <Patch Number="393" Name="INIT TONE" ProgramChange="8" />
+      <Patch Number="394" Name="INIT TONE" ProgramChange="9" />
+      <Patch Number="395" Name="INIT TONE" ProgramChange="10" />
+      <Patch Number="396" Name="INIT TONE" ProgramChange="11" />
+      <Patch Number="397" Name="INIT TONE" ProgramChange="12" />
+      <Patch Number="398" Name="INIT TONE" ProgramChange="13" />
+      <Patch Number="399" Name="INIT TONE" ProgramChange="14" />
+      <Patch Number="400" Name="INIT TONE" ProgramChange="15" />
+      <Patch Number="401" Name="INIT TONE" ProgramChange="16" />
+      <Patch Number="402" Name="INIT TONE" ProgramChange="17" />
+      <Patch Number="403" Name="INIT TONE" ProgramChange="18" />
+      <Patch Number="404" Name="INIT TONE" ProgramChange="19" />
+      <Patch Number="405" Name="INIT TONE" ProgramChange="20" />
+      <Patch Number="406" Name="INIT TONE" ProgramChange="21" />
+      <Patch Number="407" Name="INIT TONE" ProgramChange="22" />
+      <Patch Number="408" Name="INIT TONE" ProgramChange="23" />
+      <Patch Number="409" Name="INIT TONE" ProgramChange="24" />
+      <Patch Number="410" Name="INIT TONE" ProgramChange="25" />
+      <Patch Number="411" Name="INIT TONE" ProgramChange="26" />
+      <Patch Number="412" Name="INIT TONE" ProgramChange="27" />
+      <Patch Number="413" Name="INIT TONE" ProgramChange="28" />
+      <Patch Number="414" Name="INIT TONE" ProgramChange="29" />
+      <Patch Number="415" Name="INIT TONE" ProgramChange="30" />
+      <Patch Number="416" Name="INIT TONE" ProgramChange="31" />
+      <Patch Number="417" Name="INIT TONE" ProgramChange="32" />
+      <Patch Number="418" Name="INIT TONE" ProgramChange="33" />
+      <Patch Number="419" Name="INIT TONE" ProgramChange="34" />
+      <Patch Number="420" Name="INIT TONE" ProgramChange="35" />
+      <Patch Number="421" Name="INIT TONE" ProgramChange="36" />
+      <Patch Number="422" Name="INIT TONE" ProgramChange="37" />
+      <Patch Number="423" Name="INIT TONE" ProgramChange="38" />
+      <Patch Number="424" Name="INIT TONE" ProgramChange="39" />
+      <Patch Number="425" Name="INIT TONE" ProgramChange="40" />
+      <Patch Number="426" Name="INIT TONE" ProgramChange="41" />
+      <Patch Number="427" Name="INIT TONE" ProgramChange="42" />
+      <Patch Number="428" Name="INIT TONE" ProgramChange="43" />
+      <Patch Number="429" Name="INIT TONE" ProgramChange="44" />
+      <Patch Number="430" Name="INIT TONE" ProgramChange="45" />
+      <Patch Number="431" Name="INIT TONE" ProgramChange="46" />
+      <Patch Number="432" Name="INIT TONE" ProgramChange="47" />
+      <Patch Number="433" Name="INIT TONE" ProgramChange="48" />
+      <Patch Number="434" Name="INIT TONE" ProgramChange="49" />
+      <Patch Number="435" Name="INIT TONE" ProgramChange="50" />
+      <Patch Number="436" Name="INIT TONE" ProgramChange="51" />
+      <Patch Number="437" Name="INIT TONE" ProgramChange="52" />
+      <Patch Number="438" Name="INIT TONE" ProgramChange="53" />
+      <Patch Number="439" Name="INIT TONE" ProgramChange="54" />
+      <Patch Number="440" Name="INIT TONE" ProgramChange="55" />
+      <Patch Number="441" Name="INIT TONE" ProgramChange="56" />
+      <Patch Number="442" Name="INIT TONE" ProgramChange="57" />
+      <Patch Number="443" Name="INIT TONE" ProgramChange="58" />
+      <Patch Number="444" Name="INIT TONE" ProgramChange="59" />
+      <Patch Number="445" Name="INIT TONE" ProgramChange="60" />
+      <Patch Number="446" Name="INIT TONE" ProgramChange="61" />
+      <Patch Number="447" Name="INIT TONE" ProgramChange="62" />
+      <Patch Number="448" Name="INIT TONE" ProgramChange="63" />
+      <Patch Number="449" Name="INIT TONE" ProgramChange="64" />
+      <Patch Number="450" Name="INIT TONE" ProgramChange="65" />
+      <Patch Number="451" Name="INIT TONE" ProgramChange="66" />
+      <Patch Number="452" Name="INIT TONE" ProgramChange="67" />
+      <Patch Number="453" Name="INIT TONE" ProgramChange="68" />
+      <Patch Number="454" Name="INIT TONE" ProgramChange="69" />
+      <Patch Number="455" Name="INIT TONE" ProgramChange="70" />
+      <Patch Number="456" Name="INIT TONE" ProgramChange="71" />
+      <Patch Number="457" Name="INIT TONE" ProgramChange="72" />
+      <Patch Number="458" Name="INIT TONE" ProgramChange="73" />
+      <Patch Number="459" Name="INIT TONE" ProgramChange="74" />
+      <Patch Number="460" Name="INIT TONE" ProgramChange="75" />
+      <Patch Number="461" Name="INIT TONE" ProgramChange="76" />
+      <Patch Number="462" Name="INIT TONE" ProgramChange="77" />
+      <Patch Number="463" Name="INIT TONE" ProgramChange="78" />
+      <Patch Number="464" Name="INIT TONE" ProgramChange="79" />
+      <Patch Number="465" Name="INIT TONE" ProgramChange="80" />
+      <Patch Number="466" Name="INIT TONE" ProgramChange="81" />
+      <Patch Number="467" Name="INIT TONE" ProgramChange="82" />
+      <Patch Number="468" Name="INIT TONE" ProgramChange="83" />
+      <Patch Number="469" Name="INIT TONE" ProgramChange="84" />
+      <Patch Number="470" Name="INIT TONE" ProgramChange="85" />
+      <Patch Number="471" Name="INIT TONE" ProgramChange="86" />
+      <Patch Number="472" Name="INIT TONE" ProgramChange="87" />
+      <Patch Number="473" Name="INIT TONE" ProgramChange="88" />
+      <Patch Number="474" Name="INIT TONE" ProgramChange="89" />
+      <Patch Number="475" Name="INIT TONE" ProgramChange="90" />
+      <Patch Number="476" Name="INIT TONE" ProgramChange="91" />
+      <Patch Number="477" Name="INIT TONE" ProgramChange="92" />
+      <Patch Number="478" Name="INIT TONE" ProgramChange="93" />
+      <Patch Number="479" Name="INIT TONE" ProgramChange="94" />
+      <Patch Number="480" Name="INIT TONE" ProgramChange="95" />
+      <Patch Number="481" Name="INIT TONE" ProgramChange="96" />
+      <Patch Number="482" Name="INIT TONE" ProgramChange="97" />
+      <Patch Number="483" Name="INIT TONE" ProgramChange="98" />
+      <Patch Number="484" Name="INIT TONE" ProgramChange="99" />
+      <Patch Number="485" Name="INIT TONE" ProgramChange="100" />
+      <Patch Number="486" Name="INIT TONE" ProgramChange="101" />
+      <Patch Number="487" Name="INIT TONE" ProgramChange="102" />
+      <Patch Number="488" Name="INIT TONE" ProgramChange="103" />
+      <Patch Number="489" Name="INIT TONE" ProgramChange="104" />
+      <Patch Number="490" Name="INIT TONE" ProgramChange="105" />
+      <Patch Number="491" Name="INIT TONE" ProgramChange="106" />
+      <Patch Number="492" Name="INIT TONE" ProgramChange="107" />
+      <Patch Number="493" Name="INIT TONE" ProgramChange="108" />
+      <Patch Number="494" Name="INIT TONE" ProgramChange="109" />
+      <Patch Number="495" Name="INIT TONE" ProgramChange="110" />
+      <Patch Number="496" Name="INIT TONE" ProgramChange="111" />
+      <Patch Number="497" Name="INIT TONE" ProgramChange="112" />
+      <Patch Number="498" Name="INIT TONE" ProgramChange="113" />
+      <Patch Number="499" Name="INIT TONE" ProgramChange="114" />
+      <Patch Number="500" Name="INIT TONE" ProgramChange="115" />
+      <Patch Number="501" Name="INIT TONE" ProgramChange="116" />
+      <Patch Number="502" Name="INIT TONE" ProgramChange="117" />
+      <Patch Number="503" Name="INIT TONE" ProgramChange="118" />
+      <Patch Number="504" Name="INIT TONE" ProgramChange="119" />
+      <Patch Number="505" Name="INIT TONE" ProgramChange="120" />
+      <Patch Number="506" Name="INIT TONE" ProgramChange="121" />
+      <Patch Number="507" Name="INIT TONE" ProgramChange="122" />
+      <Patch Number="508" Name="INIT TONE" ProgramChange="123" />
+      <Patch Number="509" Name="INIT TONE" ProgramChange="124" />
+      <Patch Number="510" Name="INIT TONE" ProgramChange="125" />
+      <Patch Number="511" Name="INIT TONE" ProgramChange="126" />
+      <Patch Number="512" Name="INIT TONE" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 1-128">
+      <Patch Number="001" Name="JP8 Strings1" ProgramChange="0" />
+      <Patch Number="002" Name="JP8 Strings2" ProgramChange="1" />
+      <Patch Number="003" Name="JP8 Strings3" ProgramChange="2" />
+      <Patch Number="004" Name="JP8 Strings4" ProgramChange="3" />
+      <Patch Number="005" Name="JP8 Strings5" ProgramChange="4" />
+      <Patch Number="006" Name="JP8 Strings6" ProgramChange="5" />
+      <Patch Number="007" Name="JP8 Strings7" ProgramChange="6" />
+      <Patch Number="008" Name="JP8 Strings8" ProgramChange="7" />
+      <Patch Number="009" Name="JP8 Strings9" ProgramChange="8" />
+      <Patch Number="010" Name="JP8Strings10" ProgramChange="9" />
+      <Patch Number="011" Name="JP8Strings11" ProgramChange="10" />
+      <Patch Number="012" Name="JP8Strings12" ProgramChange="11" />
+      <Patch Number="013" Name="JP8Strings13" ProgramChange="12" />
+      <Patch Number="014" Name="JP8Strings14" ProgramChange="13" />
+      <Patch Number="015" Name="JP8Strings15" ProgramChange="14" />
+      <Patch Number="016" Name="JP8Strings16" ProgramChange="15" />
+      <Patch Number="017" Name="JP-8 Pad 1" ProgramChange="16" />
+      <Patch Number="018" Name="JP-8 Pad 2" ProgramChange="17" />
+      <Patch Number="019" Name="JP-8 Pad 3" ProgramChange="18" />
+      <Patch Number="020" Name="JP-8 Pad 4" ProgramChange="19" />
+      <Patch Number="021" Name="JUNO Str 1" ProgramChange="20" />
+      <Patch Number="022" Name="JUNO Str 2" ProgramChange="21" />
+      <Patch Number="023" Name="JUNO Str 3" ProgramChange="22" />
+      <Patch Number="024" Name="JX Strings" ProgramChange="23" />
+      <Patch Number="025" Name="OB Strings 1" ProgramChange="24" />
+      <Patch Number="026" Name="OB Strings 2" ProgramChange="25" />
+      <Patch Number="027" Name="OB Strings 3" ProgramChange="26" />
+      <Patch Number="028" Name="OB Strings 4" ProgramChange="27" />
+      <Patch Number="029" Name="OB Strings 5" ProgramChange="28" />
+      <Patch Number="030" Name="OB Strings 6" ProgramChange="29" />
+      <Patch Number="031" Name="Vintage 1" ProgramChange="30" />
+      <Patch Number="032" Name="Vintage 2" ProgramChange="31" />
+      <Patch Number="033" Name="Vintage 3" ProgramChange="32" />
+      <Patch Number="034" Name="Vintage 4" ProgramChange="33" />
+      <Patch Number="035" Name="Vintage 5" ProgramChange="34" />
+      <Patch Number="036" Name="Vintage 6" ProgramChange="35" />
+      <Patch Number="037" Name="Vintage 7" ProgramChange="36" />
+      <Patch Number="038" Name="Vintage 8" ProgramChange="37" />
+      <Patch Number="039" Name="Vintage 9" ProgramChange="38" />
+      <Patch Number="040" Name="Vintage 10" ProgramChange="39" />
+      <Patch Number="041" Name="Vintage 11" ProgramChange="40" />
+      <Patch Number="042" Name="Soft Pad 1" ProgramChange="41" />
+      <Patch Number="043" Name="Soft Pad 2" ProgramChange="42" />
+      <Patch Number="044" Name="Soft Pad 3" ProgramChange="43" />
+      <Patch Number="045" Name="Soft Pad 4" ProgramChange="44" />
+      <Patch Number="046" Name="Soft Pad 5" ProgramChange="45" />
+      <Patch Number="047" Name="Soft Pad 6" ProgramChange="46" />
+      <Patch Number="048" Name="Soft Pad 7" ProgramChange="47" />
+      <Patch Number="049" Name="Soft Pad 8" ProgramChange="48" />
+      <Patch Number="050" Name="Soft Pad 9" ProgramChange="49" />
+      <Patch Number="051" Name="Soft Pad 10" ProgramChange="50" />
+      <Patch Number="052" Name="Soft Pad 11" ProgramChange="51" />
+      <Patch Number="053" Name="Soft Pad 12" ProgramChange="52" />
+      <Patch Number="054" Name="Soft Pad 13" ProgramChange="53" />
+      <Patch Number="055" Name="Soft Pad 14" ProgramChange="54" />
+      <Patch Number="056" Name="Soft Pad 15" ProgramChange="55" />
+      <Patch Number="057" Name="Soft Pad 16" ProgramChange="56" />
+      <Patch Number="058" Name="Soft Pad 17" ProgramChange="57" />
+      <Patch Number="059" Name="Oct Str 1" ProgramChange="58" />
+      <Patch Number="060" Name="Oct Str 2" ProgramChange="59" />
+      <Patch Number="061" Name="Oct Str 3" ProgramChange="60" />
+      <Patch Number="062" Name="Oct Str 4" ProgramChange="61" />
+      <Patch Number="063" Name="Oct Str 5" ProgramChange="62" />
+      <Patch Number="064" Name="Oct Str 6" ProgramChange="63" />
+      <Patch Number="065" Name="Oct Str 7" ProgramChange="64" />
+      <Patch Number="066" Name="Cloud Pad" ProgramChange="65" />
+      <Patch Number="067" Name="Slow Pad 1" ProgramChange="66" />
+      <Patch Number="068" Name="Slow Pad 2" ProgramChange="67" />
+      <Patch Number="069" Name="Brite Str 1" ProgramChange="68" />
+      <Patch Number="070" Name="Brite Str 2" ProgramChange="69" />
+      <Patch Number="071" Name="Brite Str 3" ProgramChange="70" />
+      <Patch Number="072" Name="Brite Str 4" ProgramChange="71" />
+      <Patch Number="073" Name="Boreal Pad" ProgramChange="72" />
+      <Patch Number="074" Name="Flange Str" ProgramChange="73" />
+      <Patch Number="075" Name="Organ Pad 1" ProgramChange="74" />
+      <Patch Number="076" Name="Organ Pad 2" ProgramChange="75" />
+      <Patch Number="077" Name="Organ Pad 3" ProgramChange="76" />
+      <Patch Number="078" Name="Organ Pad 4" ProgramChange="77" />
+      <Patch Number="079" Name="Digi Str 1" ProgramChange="78" />
+      <Patch Number="080" Name="Digi Str 2" ProgramChange="79" />
+      <Patch Number="081" Name="Digi Pad 1" ProgramChange="80" />
+      <Patch Number="082" Name="Digi Pad 2" ProgramChange="81" />
+      <Patch Number="083" Name="Digi Pad 3" ProgramChange="82" />
+      <Patch Number="084" Name="Digi Pad 4" ProgramChange="83" />
+      <Patch Number="085" Name="Heaven Pad 1" ProgramChange="84" />
+      <Patch Number="086" Name="Heaven Pad 2" ProgramChange="85" />
+      <Patch Number="087" Name="Heaven Pad 3" ProgramChange="86" />
+      <Patch Number="088" Name="Heaven Pad 4" ProgramChange="87" />
+      <Patch Number="089" Name="Voice Heaven" ProgramChange="88" />
+      <Patch Number="090" Name="ChordOfCnada" ProgramChange="89" />
+      <Patch Number="091" Name="Awakening" ProgramChange="90" />
+      <Patch Number="092" Name="JP8 Hollow 1" ProgramChange="91" />
+      <Patch Number="093" Name="JP8 Hollow 2" ProgramChange="92" />
+      <Patch Number="094" Name="JP8 Hollow 3" ProgramChange="93" />
+      <Patch Number="095" Name="Hollow Pad 1" ProgramChange="94" />
+      <Patch Number="096" Name="Hollow Pad 2" ProgramChange="95" />
+      <Patch Number="097" Name="Simple Air" ProgramChange="96" />
+      <Patch Number="098" Name="Air Pad" ProgramChange="97" />
+      <Patch Number="099" Name="Glass Pad" ProgramChange="98" />
+      <Patch Number="100" Name="Flute Pad" ProgramChange="99" />
+      <Patch Number="101" Name="Seek Flute" ProgramChange="100" />
+      <Patch Number="102" Name="Syn Pad 1" ProgramChange="101" />
+      <Patch Number="103" Name="Syn Pad 2" ProgramChange="102" />
+      <Patch Number="104" Name="Syn Pad 3" ProgramChange="103" />
+      <Patch Number="105" Name="Syn Pad 4" ProgramChange="104" />
+      <Patch Number="106" Name="Syn Pad 5" ProgramChange="105" />
+      <Patch Number="107" Name="Syn Pad 6" ProgramChange="106" />
+      <Patch Number="108" Name="Syn Pad 7" ProgramChange="107" />
+      <Patch Number="109" Name="Syn Pad 8" ProgramChange="108" />
+      <Patch Number="110" Name="Syn Pad 9" ProgramChange="109" />
+      <Patch Number="111" Name="Syn Pad 10" ProgramChange="110" />
+      <Patch Number="112" Name="Syn Pad 11" ProgramChange="111" />
+      <Patch Number="113" Name="Syn Pad 12" ProgramChange="112" />
+      <Patch Number="114" Name="Syn Pad 13" ProgramChange="113" />
+      <Patch Number="115" Name="Syn Pad 14" ProgramChange="114" />
+      <Patch Number="116" Name="Syn Pad 15" ProgramChange="115" />
+      <Patch Number="117" Name="Syn Pad 16" ProgramChange="116" />
+      <Patch Number="118" Name="Syn Pad 17" ProgramChange="117" />
+      <Patch Number="119" Name="Syn Pad 18" ProgramChange="118" />
+      <Patch Number="120" Name="Syn Pad 19" ProgramChange="119" />
+      <Patch Number="121" Name="Syn Pad 20" ProgramChange="120" />
+      <Patch Number="122" Name="Syn Pad 21" ProgramChange="121" />
+      <Patch Number="123" Name="Syn Pad 22" ProgramChange="122" />
+      <Patch Number="124" Name="Syn Pad 23" ProgramChange="123" />
+      <Patch Number="125" Name="Hybrid Str 1" ProgramChange="124" />
+      <Patch Number="126" Name="Hybrid Str 2" ProgramChange="125" />
+      <Patch Number="127" Name="Hybrid Str 3" ProgramChange="126" />
+      <Patch Number="128" Name="LFO Pad 1" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 129-256">
+      <Patch Number="129" Name="LFO Pad 2" ProgramChange="0" />
+      <Patch Number="130" Name="RETROX 139" ProgramChange="1" />
+      <Patch Number="131" Name="I Sync So" ProgramChange="2" />
+      <Patch Number="132" Name="Sea Waves" ProgramChange="3" />
+      <Patch Number="133" Name="FireFlies" ProgramChange="4" />
+      <Patch Number="134" Name="Particles" ProgramChange="5" />
+      <Patch Number="135" Name="Phr Str 1" ProgramChange="6" />
+      <Patch Number="136" Name="Phr Str 2" ProgramChange="7" />
+      <Patch Number="137" Name="Phr Str 3" ProgramChange="8" />
+      <Patch Number="138" Name="Phr Str 4" ProgramChange="9" />
+      <Patch Number="139" Name="Phr Str 5" ProgramChange="10" />
+      <Patch Number="140" Name="Phr Str 6" ProgramChange="11" />
+      <Patch Number="141" Name="Phr Str 7" ProgramChange="12" />
+      <Patch Number="142" Name="Phr Str 8" ProgramChange="13" />
+      <Patch Number="143" Name="Phr Str 9" ProgramChange="14" />
+      <Patch Number="144" Name="Phr Str 10" ProgramChange="15" />
+      <Patch Number="145" Name="Phr Str 11" ProgramChange="16" />
+      <Patch Number="146" Name="Stone Pad" ProgramChange="17" />
+      <Patch Number="147" Name="JP8 Stone 1" ProgramChange="18" />
+      <Patch Number="148" Name="JP8 Stone 2" ProgramChange="19" />
+      <Patch Number="149" Name="Sweep Pad 1" ProgramChange="20" />
+      <Patch Number="150" Name="Sweep Pad 2" ProgramChange="21" />
+      <Patch Number="151" Name="Sweep Pad 3" ProgramChange="22" />
+      <Patch Number="152" Name="Sweep Pad 4" ProgramChange="23" />
+      <Patch Number="153" Name="Sweep Pad 5" ProgramChange="24" />
+      <Patch Number="154" Name="Sweep Pad 6" ProgramChange="25" />
+      <Patch Number="155" Name="Sweep Pad 7" ProgramChange="26" />
+      <Patch Number="156" Name="Sweep Pad 8" ProgramChange="27" />
+      <Patch Number="157" Name="Sweep Pad 9" ProgramChange="28" />
+      <Patch Number="158" Name="Sweep Pad 10" ProgramChange="29" />
+      <Patch Number="159" Name="Sweep Pad 11" ProgramChange="30" />
+      <Patch Number="160" Name="Sweep Pad 12" ProgramChange="31" />
+      <Patch Number="161" Name="Sweep Pad 13" ProgramChange="32" />
+      <Patch Number="162" Name="Sweep Pad 14" ProgramChange="33" />
+      <Patch Number="163" Name="Sweep Pad 15" ProgramChange="34" />
+      <Patch Number="164" Name="Sweep Pad 16" ProgramChange="35" />
+      <Patch Number="165" Name="Sweep Pad 17" ProgramChange="36" />
+      <Patch Number="166" Name="Chronic Pad" ProgramChange="37" />
+      <Patch Number="167" Name="Sweep JD" ProgramChange="38" />
+      <Patch Number="168" Name="SweepNz Pad" ProgramChange="39" />
+      <Patch Number="169" Name="HPF Pad" ProgramChange="40" />
+      <Patch Number="170" Name="Iso Pad" ProgramChange="41" />
+      <Patch Number="171" Name="Reverie Pad" ProgramChange="42" />
+      <Patch Number="172" Name="PWM Pad 1" ProgramChange="43" />
+      <Patch Number="173" Name="PWM Pad 2" ProgramChange="44" />
+      <Patch Number="174" Name="Stack Pad" ProgramChange="45" />
+      <Patch Number="175" Name="Fanta Synth" ProgramChange="46" />
+      <Patch Number="176" Name="Deepity" ProgramChange="47" />
+      <Patch Number="177" Name="Fair Pad" ProgramChange="48" />
+      <Patch Number="178" Name="Revalation" ProgramChange="49" />
+      <Patch Number="179" Name="Trance Pad" ProgramChange="50" />
+      <Patch Number="180" Name="Alan's Pad" ProgramChange="51" />
+      <Patch Number="181" Name="Dreamwarp" ProgramChange="52" />
+      <Patch Number="182" Name="Emote String" ProgramChange="53" />
+      <Patch Number="183" Name="PortamentPad" ProgramChange="54" />
+      <Patch Number="184" Name="Cincosoft" ProgramChange="55" />
+      <Patch Number="185" Name="5th Pad 1" ProgramChange="56" />
+      <Patch Number="186" Name="5th Pad 2" ProgramChange="57" />
+      <Patch Number="187" Name="5th Pad 3" ProgramChange="58" />
+      <Patch Number="188" Name="Metal Pad" ProgramChange="59" />
+      <Patch Number="189" Name="Legend Pad" ProgramChange="60" />
+      <Patch Number="190" Name="GlassFx Pad" ProgramChange="61" />
+      <Patch Number="191" Name="Glass Forest" ProgramChange="62" />
+      <Patch Number="192" Name="Jungle-Pool" ProgramChange="63" />
+      <Patch Number="193" Name="Xadecimal" ProgramChange="64" />
+      <Patch Number="194" Name="HPF Strings" ProgramChange="65" />
+      <Patch Number="195" Name="Gate Game" ProgramChange="66" />
+      <Patch Number="196" Name="Horror Pad" ProgramChange="67" />
+      <Patch Number="197" Name="PLS Pad 1" ProgramChange="68" />
+      <Patch Number="198" Name="PLS Pad 2" ProgramChange="69" />
+      <Patch Number="199" Name="PLS Pad 3" ProgramChange="70" />
+      <Patch Number="200" Name="PLS Pad 4" ProgramChange="71" />
+      <Patch Number="201" Name="PLS Pad 5" ProgramChange="72" />
+      <Patch Number="202" Name="PLS Pad 6" ProgramChange="73" />
+      <Patch Number="203" Name="PLS Pad 7" ProgramChange="74" />
+      <Patch Number="204" Name="PLS Pad 8" ProgramChange="75" />
+      <Patch Number="205" Name="PLS Pad 9" ProgramChange="76" />
+      <Patch Number="206" Name="PLS Pad 10" ProgramChange="77" />
+      <Patch Number="207" Name="PLS Pad 11" ProgramChange="78" />
+      <Patch Number="208" Name="PLS Pad 12" ProgramChange="79" />
+      <Patch Number="209" Name="PLS Pad 13" ProgramChange="80" />
+      <Patch Number="210" Name="PLS Pad 14" ProgramChange="81" />
+      <Patch Number="211" Name="PLS Pad 15" ProgramChange="82" />
+      <Patch Number="212" Name="PLS Pad 16" ProgramChange="83" />
+      <Patch Number="213" Name="PLS Strings" ProgramChange="84" />
+      <Patch Number="214" Name="LFO Hollow" ProgramChange="85" />
+      <Patch Number="215" Name="Goes A Pad" ProgramChange="86" />
+      <Patch Number="216" Name="Metal PLS" ProgramChange="87" />
+      <Patch Number="217" Name="Trip 2 Mars" ProgramChange="88" />
+      <Patch Number="218" Name="Fist Pumper1" ProgramChange="89" />
+      <Patch Number="219" Name="Fist Pumper2" ProgramChange="90" />
+      <Patch Number="220" Name="Pulsatron" ProgramChange="91" />
+      <Patch Number="221" Name="LFO Poly" ProgramChange="92" />
+      <Patch Number="222" Name="LFO Saw 1" ProgramChange="93" />
+      <Patch Number="223" Name="LFO Saw 2" ProgramChange="94" />
+      <Patch Number="224" Name="Thick Pans" ProgramChange="95" />
+      <Patch Number="225" Name="LFO Ripple" ProgramChange="96" />
+      <Patch Number="226" Name="JayMeJay" ProgramChange="97" />
+      <Patch Number="227" Name="Karmalog" ProgramChange="98" />
+      <Patch Number="228" Name="MINIM-L" ProgramChange="99" />
+      <Patch Number="229" Name="Trance Staff" ProgramChange="100" />
+      <Patch Number="230" Name="Radanceky" ProgramChange="101" />
+      <Patch Number="231" Name="12303" ProgramChange="102" />
+      <Patch Number="232" Name="Experiment" ProgramChange="103" />
+      <Patch Number="233" Name="Pulserelay" ProgramChange="104" />
+      <Patch Number="234" Name="Jazz Bubbles" ProgramChange="105" />
+      <Patch Number="235" Name="Psychoscilo" ProgramChange="106" />
+      <Patch Number="236" Name="PXZoon" ProgramChange="107" />
+      <Patch Number="237" Name="Welding Bell" ProgramChange="108" />
+      <Patch Number="238" Name="Glassphemia" ProgramChange="109" />
+      <Patch Number="239" Name="Strobe Bell" ProgramChange="110" />
+      <Patch Number="240" Name="Sawflutter" ProgramChange="111" />
+      <Patch Number="241" Name="Dronified" ProgramChange="112" />
+      <Patch Number="242" Name="Tri-Vector" ProgramChange="113" />
+      <Patch Number="243" Name="Syn Vox 1" ProgramChange="114" />
+      <Patch Number="244" Name="Syn Vox 2" ProgramChange="115" />
+      <Patch Number="245" Name="Syn Vox 3" ProgramChange="116" />
+      <Patch Number="246" Name="JD80 SoftVox" ProgramChange="117" />
+      <Patch Number="247" Name="Valley Air" ProgramChange="118" />
+      <Patch Number="248" Name="Vox Pad 1" ProgramChange="119" />
+      <Patch Number="249" Name="Vox Pad 2" ProgramChange="120" />
+      <Patch Number="250" Name="Vox Pad 3" ProgramChange="121" />
+      <Patch Number="251" Name="Vox Pad 4" ProgramChange="122" />
+      <Patch Number="252" Name="Vox Pad 5" ProgramChange="123" />
+      <Patch Number="253" Name="5th Vox Pad" ProgramChange="124" />
+      <Patch Number="254" Name="Moving Chr" ProgramChange="125" />
+      <Patch Number="255" Name="VP-330 Chr" ProgramChange="126" />
+      <Patch Number="256" Name="HyperVentChr" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 257-384">
+      <Patch Number="257" Name="Vento Choir" ProgramChange="0" />
+      <Patch Number="258" Name="Scat Dow" ProgramChange="1" />
+      <Patch Number="259" Name="JP8 Brs 1" ProgramChange="2" />
+      <Patch Number="260" Name="JP8 Brs 2" ProgramChange="3" />
+      <Patch Number="261" Name="JP8 Brs 3" ProgramChange="4" />
+      <Patch Number="262" Name="JP8 Brs 4" ProgramChange="5" />
+      <Patch Number="263" Name="JP8 Brs 5" ProgramChange="6" />
+      <Patch Number="264" Name="JP8 Brs 6" ProgramChange="7" />
+      <Patch Number="265" Name="JUNO Brs 1" ProgramChange="8" />
+      <Patch Number="266" Name="JUNO Brs 2" ProgramChange="9" />
+      <Patch Number="267" Name="JUNO Brs 3" ProgramChange="10" />
+      <Patch Number="268" Name="JUNO Brs 4" ProgramChange="11" />
+      <Patch Number="269" Name="JUNO Brs 5" ProgramChange="12" />
+      <Patch Number="270" Name="JUNO Brs 6" ProgramChange="13" />
+      <Patch Number="271" Name="JUNO Brs 7" ProgramChange="14" />
+      <Patch Number="272" Name="JUNO Brs 8" ProgramChange="15" />
+      <Patch Number="273" Name="JUNO Brs 9" ProgramChange="16" />
+      <Patch Number="274" Name="JUNO Brs 10" ProgramChange="17" />
+      <Patch Number="275" Name="JP8000 Brs 1" ProgramChange="18" />
+      <Patch Number="276" Name="JP8000 Brs 2" ProgramChange="19" />
+      <Patch Number="277" Name="80s Brs 1" ProgramChange="20" />
+      <Patch Number="278" Name="80s Brs 2" ProgramChange="21" />
+      <Patch Number="279" Name="80s Brs 3" ProgramChange="22" />
+      <Patch Number="280" Name="80s Brs 4" ProgramChange="23" />
+      <Patch Number="281" Name="80s Brs 5" ProgramChange="24" />
+      <Patch Number="282" Name="80s Brs 6" ProgramChange="25" />
+      <Patch Number="283" Name="80s Brs 7" ProgramChange="26" />
+      <Patch Number="284" Name="80s Brs 8" ProgramChange="27" />
+      <Patch Number="285" Name="80s Brs 9" ProgramChange="28" />
+      <Patch Number="286" Name="80s Brs 10" ProgramChange="29" />
+      <Patch Number="287" Name="80s Brs 11" ProgramChange="30" />
+      <Patch Number="288" Name="SynBrs Str" ProgramChange="31" />
+      <Patch Number="289" Name="Analog Brs 1" ProgramChange="32" />
+      <Patch Number="290" Name="Analog Brs 2" ProgramChange="33" />
+      <Patch Number="291" Name="Analog Brs 3" ProgramChange="34" />
+      <Patch Number="292" Name="Analog Brs 4" ProgramChange="35" />
+      <Patch Number="293" Name="OB Brs" ProgramChange="36" />
+      <Patch Number="294" Name="Euro Express" ProgramChange="37" />
+      <Patch Number="295" Name="Syn Brs 1" ProgramChange="38" />
+      <Patch Number="296" Name="Syn Brs 2" ProgramChange="39" />
+      <Patch Number="297" Name="Syn Brs 3" ProgramChange="40" />
+      <Patch Number="298" Name="Syn Brs 4" ProgramChange="41" />
+      <Patch Number="299" Name="Syn Brs 5" ProgramChange="42" />
+      <Patch Number="300" Name="Syn Brs 6" ProgramChange="43" />
+      <Patch Number="301" Name="Syn Brs 7" ProgramChange="44" />
+      <Patch Number="302" Name="Syn Brs 8" ProgramChange="45" />
+      <Patch Number="303" Name="Syn Brs 9" ProgramChange="46" />
+      <Patch Number="304" Name="Syn Brs 10" ProgramChange="47" />
+      <Patch Number="305" Name="Syn Brs 11" ProgramChange="48" />
+      <Patch Number="306" Name="Syn Brs 12" ProgramChange="49" />
+      <Patch Number="307" Name="Syn Brs 13" ProgramChange="50" />
+      <Patch Number="308" Name="Soft SynBrs1" ProgramChange="51" />
+      <Patch Number="309" Name="Soft SynBrs2" ProgramChange="52" />
+      <Patch Number="310" Name="Soft SynBrs3" ProgramChange="53" />
+      <Patch Number="311" Name="Soft SynBrs4" ProgramChange="54" />
+      <Patch Number="312" Name="Soft SynBrs5" ProgramChange="55" />
+      <Patch Number="313" Name="Dyn SynBrs" ProgramChange="56" />
+      <Patch Number="314" Name="Quiet Brs" ProgramChange="57" />
+      <Patch Number="315" Name="Brassrub" ProgramChange="58" />
+      <Patch Number="316" Name="Poly Brass 1" ProgramChange="59" />
+      <Patch Number="317" Name="Poly Brass 2" ProgramChange="60" />
+      <Patch Number="318" Name="Poly Brass 3" ProgramChange="61" />
+      <Patch Number="319" Name="Poly Brass 4" ProgramChange="62" />
+      <Patch Number="320" Name="Poly Brass 5" ProgramChange="63" />
+      <Patch Number="321" Name="Octa Brass" ProgramChange="64" />
+      <Patch Number="322" Name="Reso Brs 1" ProgramChange="65" />
+      <Patch Number="323" Name="Reso Brs 2" ProgramChange="66" />
+      <Patch Number="324" Name="Slow Brs 1" ProgramChange="67" />
+      <Patch Number="325" Name="Slow Brs 2" ProgramChange="68" />
+      <Patch Number="326" Name="FM Brass" ProgramChange="69" />
+      <Patch Number="327" Name="Hybrid Brass" ProgramChange="70" />
+      <Patch Number="328" Name="Power JP" ProgramChange="71" />
+      <Patch Number="329" Name="Power SynBrs" ProgramChange="72" />
+      <Patch Number="330" Name="Love Brs" ProgramChange="73" />
+      <Patch Number="331" Name="LoveBrs Pad" ProgramChange="74" />
+      <Patch Number="332" Name="42 Brass" ProgramChange="75" />
+      <Patch Number="333" Name="80sBrsScoop1" ProgramChange="76" />
+      <Patch Number="334" Name="80sBrsScoop2" ProgramChange="77" />
+      <Patch Number="335" Name="ResoSweepBrs" ProgramChange="78" />
+      <Patch Number="336" Name="Porta Brs" ProgramChange="79" />
+      <Patch Number="337" Name="Xpand Brs 1" ProgramChange="80" />
+      <Patch Number="338" Name="Xpand Brs 2" ProgramChange="81" />
+      <Patch Number="339" Name="Saws Key 1" ProgramChange="82" />
+      <Patch Number="340" Name="Saws Key 2" ProgramChange="83" />
+      <Patch Number="341" Name="Saws Key 3" ProgramChange="84" />
+      <Patch Number="342" Name="Saws Key 4" ProgramChange="85" />
+      <Patch Number="343" Name="Saws Key 5" ProgramChange="86" />
+      <Patch Number="344" Name="Saws Key 6" ProgramChange="87" />
+      <Patch Number="345" Name="Saws Key 7" ProgramChange="88" />
+      <Patch Number="346" Name="Saws Key 8" ProgramChange="89" />
+      <Patch Number="347" Name="Saws Key 9" ProgramChange="90" />
+      <Patch Number="348" Name="Saws Key 10" ProgramChange="91" />
+      <Patch Number="349" Name="Laserthroat" ProgramChange="92" />
+      <Patch Number="350" Name="Poly Key 1" ProgramChange="93" />
+      <Patch Number="351" Name="Poly Key 2" ProgramChange="94" />
+      <Patch Number="352" Name="Poly Key 3" ProgramChange="95" />
+      <Patch Number="353" Name="Poly Key 4" ProgramChange="96" />
+      <Patch Number="354" Name="JP80 WaveSyn" ProgramChange="97" />
+      <Patch Number="355" Name="Poly Syn 1" ProgramChange="98" />
+      <Patch Number="356" Name="Poly Syn 2" ProgramChange="99" />
+      <Patch Number="357" Name="Poly Syn 3" ProgramChange="100" />
+      <Patch Number="358" Name="Poly Syn 4" ProgramChange="101" />
+      <Patch Number="359" Name="Poly Syn 5" ProgramChange="102" />
+      <Patch Number="360" Name="Poly Syn 6" ProgramChange="103" />
+      <Patch Number="361" Name="Poly Syn 7" ProgramChange="104" />
+      <Patch Number="362" Name="Poly Syn 8" ProgramChange="105" />
+      <Patch Number="363" Name="Poly Syn 9" ProgramChange="106" />
+      <Patch Number="364" Name="Poly Syn 10" ProgramChange="107" />
+      <Patch Number="365" Name="Poly Syn 11" ProgramChange="108" />
+      <Patch Number="366" Name="Poly Syn 12" ProgramChange="109" />
+      <Patch Number="367" Name="Poly Syn 13" ProgramChange="110" />
+      <Patch Number="368" Name="Poly Syn 14" ProgramChange="111" />
+      <Patch Number="369" Name="Poly Syn 15" ProgramChange="112" />
+      <Patch Number="370" Name="Poly Syn 16" ProgramChange="113" />
+      <Patch Number="371" Name="Poly Syn 17" ProgramChange="114" />
+      <Patch Number="372" Name="Poly Syn 18" ProgramChange="115" />
+      <Patch Number="373" Name="Poly Syn 19" ProgramChange="116" />
+      <Patch Number="374" Name="Poly Syn 20" ProgramChange="117" />
+      <Patch Number="375" Name="Poly Syn 21" ProgramChange="118" />
+      <Patch Number="376" Name="Poly Syn 22" ProgramChange="119" />
+      <Patch Number="377" Name="Poly Syn 23" ProgramChange="120" />
+      <Patch Number="378" Name="Poly Syn 24" ProgramChange="121" />
+      <Patch Number="379" Name="Poly Syn 25" ProgramChange="122" />
+      <Patch Number="380" Name="Poly Syn 26" ProgramChange="123" />
+      <Patch Number="381" Name="Saw Dtune" ProgramChange="124" />
+      <Patch Number="382" Name="Jester" ProgramChange="125" />
+      <Patch Number="383" Name="Fusion Decay" ProgramChange="126" />
+      <Patch Number="384" Name="Polysubito" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 385-512">
+      <Patch Number="385" Name="Wave Scan" ProgramChange="0" />
+      <Patch Number="386" Name="Wire String" ProgramChange="1" />
+      <Patch Number="387" Name="Brusky Key" ProgramChange="2" />
+      <Patch Number="388" Name="Cutter Key" ProgramChange="3" />
+      <Patch Number="389" Name="PolySyn Atk" ProgramChange="4" />
+      <Patch Number="390" Name="Harpsitone" ProgramChange="5" />
+      <Patch Number="391" Name="Digi Key 1" ProgramChange="6" />
+      <Patch Number="392" Name="Digi Key 2" ProgramChange="7" />
+      <Patch Number="393" Name="Digi Key 3" ProgramChange="8" />
+      <Patch Number="394" Name="Digi Key 4" ProgramChange="9" />
+      <Patch Number="395" Name="Digi Key 5" ProgramChange="10" />
+      <Patch Number="396" Name="Digi Key 6" ProgramChange="11" />
+      <Patch Number="397" Name="Digi Poly 1" ProgramChange="12" />
+      <Patch Number="398" Name="Digi Poly 2" ProgramChange="13" />
+      <Patch Number="399" Name="Bit Poly 1" ProgramChange="14" />
+      <Patch Number="400" Name="Bit Poly 2" ProgramChange="15" />
+      <Patch Number="401" Name="Bit Poly 3" ProgramChange="16" />
+      <Patch Number="402" Name="Bit Poly 4" ProgramChange="17" />
+      <Patch Number="403" Name="Bit Poly 5" ProgramChange="18" />
+      <Patch Number="404" Name="Bit Poly 6" ProgramChange="19" />
+      <Patch Number="405" Name="Bit Poly 7" ProgramChange="20" />
+      <Patch Number="406" Name="Bit Poly 8" ProgramChange="21" />
+      <Patch Number="407" Name="Bit Poly 9" ProgramChange="22" />
+      <Patch Number="408" Name="Bit Poly 10" ProgramChange="23" />
+      <Patch Number="409" Name="5th Poly 1" ProgramChange="24" />
+      <Patch Number="410" Name="5th Poly 2" ProgramChange="25" />
+      <Patch Number="411" Name="5th Poly 3" ProgramChange="26" />
+      <Patch Number="412" Name="Poly Aug 5th" ProgramChange="27" />
+      <Patch Number="413" Name="5th Key" ProgramChange="28" />
+      <Patch Number="414" Name="HPF Poly 1" ProgramChange="29" />
+      <Patch Number="415" Name="HPF Poly 2" ProgramChange="30" />
+      <Patch Number="416" Name="BPF Poly 1" ProgramChange="31" />
+      <Patch Number="417" Name="BPF Poly 2" ProgramChange="32" />
+      <Patch Number="418" Name="Sweep Poly 1" ProgramChange="33" />
+      <Patch Number="419" Name="Sweep Poly 2" ProgramChange="34" />
+      <Patch Number="420" Name="Sweep Poly 3" ProgramChange="35" />
+      <Patch Number="421" Name="Scoop Poly 1" ProgramChange="36" />
+      <Patch Number="422" Name="Scoop Poly 2" ProgramChange="37" />
+      <Patch Number="423" Name="Scoop Poly 3" ProgramChange="38" />
+      <Patch Number="424" Name="Scoop Poly 4" ProgramChange="39" />
+      <Patch Number="425" Name="Scoop Poly 5" ProgramChange="40" />
+      <Patch Number="426" Name="Scoop Poly 6" ProgramChange="41" />
+      <Patch Number="427" Name="Tekno Poly 1" ProgramChange="42" />
+      <Patch Number="428" Name="Tekno Poly 2" ProgramChange="43" />
+      <Patch Number="429" Name="Tekno Poly 3" ProgramChange="44" />
+      <Patch Number="430" Name="J-Pop Kira 1" ProgramChange="45" />
+      <Patch Number="431" Name="J-Pop Kira 2" ProgramChange="46" />
+      <Patch Number="432" Name="Square Poly" ProgramChange="47" />
+      <Patch Number="433" Name="Slow Poly" ProgramChange="48" />
+      <Patch Number="434" Name="Vox Poly" ProgramChange="49" />
+      <Patch Number="435" Name="S-SawPoly 1" ProgramChange="50" />
+      <Patch Number="436" Name="S-SawPoly 2" ProgramChange="51" />
+      <Patch Number="437" Name="S-SawPoly 3" ProgramChange="52" />
+      <Patch Number="438" Name="S-SawPoly 4" ProgramChange="53" />
+      <Patch Number="439" Name="S-SawPoly 5" ProgramChange="54" />
+      <Patch Number="440" Name="S-SawPoly 6" ProgramChange="55" />
+      <Patch Number="441" Name="S-SawPoly 7" ProgramChange="56" />
+      <Patch Number="442" Name="S-SawPoly 8" ProgramChange="57" />
+      <Patch Number="443" Name="S-SawPoly 9" ProgramChange="58" />
+      <Patch Number="444" Name="S-SawPoly 10" ProgramChange="59" />
+      <Patch Number="445" Name="S-SawPoly 11" ProgramChange="60" />
+      <Patch Number="446" Name="S-SawPoly 12" ProgramChange="61" />
+      <Patch Number="447" Name="S-SawPoly 13" ProgramChange="62" />
+      <Patch Number="448" Name="Trance Key 1" ProgramChange="63" />
+      <Patch Number="449" Name="Trance Key 2" ProgramChange="64" />
+      <Patch Number="450" Name="Trance Key 3" ProgramChange="65" />
+      <Patch Number="451" Name="Trance Key 4" ProgramChange="66" />
+      <Patch Number="452" Name="Trance Key 5" ProgramChange="67" />
+      <Patch Number="453" Name="Trance Key 6" ProgramChange="68" />
+      <Patch Number="454" Name="Delay Reso" ProgramChange="69" />
+      <Patch Number="455" Name="3Delay Poly" ProgramChange="70" />
+      <Patch Number="456" Name="JP80 FatPoly" ProgramChange="71" />
+      <Patch Number="457" Name="Poly Fat" ProgramChange="72" />
+      <Patch Number="458" Name="Trance Saw" ProgramChange="73" />
+      <Patch Number="459" Name="SoHo Lucky" ProgramChange="74" />
+      <Patch Number="460" Name="DLM SUM" ProgramChange="75" />
+      <Patch Number="461" Name="H@sWillFall" ProgramChange="76" />
+      <Patch Number="462" Name="A Log 4 Ana" ProgramChange="77" />
+      <Patch Number="463" Name="Log An A" ProgramChange="78" />
+      <Patch Number="464" Name="Androdrops" ProgramChange="79" />
+      <Patch Number="465" Name="Vntg Stack" ProgramChange="80" />
+      <Patch Number="466" Name="ANORMANALOG" ProgramChange="81" />
+      <Patch Number="467" Name="Don't you" ProgramChange="82" />
+      <Patch Number="468" Name="Nailbiter" ProgramChange="83" />
+      <Patch Number="469" Name="EinsZweiDry" ProgramChange="84" />
+      <Patch Number="470" Name="Analog Key 1" ProgramChange="85" />
+      <Patch Number="471" Name="Analog Key 2" ProgramChange="86" />
+      <Patch Number="472" Name="Paperclip" ProgramChange="87" />
+      <Patch Number="473" Name="Sqr Key" ProgramChange="88" />
+      <Patch Number="474" Name="Tri Key" ProgramChange="89" />
+      <Patch Number="475" Name="JP-8 PatchF2" ProgramChange="90" />
+      <Patch Number="476" Name="Fantasy 1" ProgramChange="91" />
+      <Patch Number="477" Name="Fantasy 2" ProgramChange="92" />
+      <Patch Number="478" Name="Fantasy 3" ProgramChange="93" />
+      <Patch Number="479" Name="Fantasy 4" ProgramChange="94" />
+      <Patch Number="480" Name="Fantasy 5" ProgramChange="95" />
+      <Patch Number="481" Name="Fantasy Pad" ProgramChange="96" />
+      <Patch Number="482" Name="What Key!" ProgramChange="97" />
+      <Patch Number="483" Name="EP-Cool Pad" ProgramChange="98" />
+      <Patch Number="484" Name="D50 Stack" ProgramChange="99" />
+      <Patch Number="485" Name="D-52 Babe" ProgramChange="100" />
+      <Patch Number="486" Name="Dreaming 1" ProgramChange="101" />
+      <Patch Number="487" Name="Dreaming 2" ProgramChange="102" />
+      <Patch Number="488" Name="Dreaming 3" ProgramChange="103" />
+      <Patch Number="489" Name="Dreaming 4" ProgramChange="104" />
+      <Patch Number="490" Name="Dreaming 5" ProgramChange="105" />
+      <Patch Number="491" Name="Dreaming 6" ProgramChange="106" />
+      <Patch Number="492" Name="Dreaming 7" ProgramChange="107" />
+      <Patch Number="493" Name="Dreambell" ProgramChange="108" />
+      <Patch Number="494" Name="DreamingBox" ProgramChange="109" />
+      <Patch Number="495" Name="New Jupiter" ProgramChange="110" />
+      <Patch Number="496" Name="Analog Dream" ProgramChange="111" />
+      <Patch Number="497" Name="Huge MIDI 1" ProgramChange="112" />
+      <Patch Number="498" Name="Huge MIDI 2" ProgramChange="113" />
+      <Patch Number="499" Name="Huge MIDI 3" ProgramChange="114" />
+      <Patch Number="500" Name="MIDI Key" ProgramChange="115" />
+      <Patch Number="501" Name="Pipe Key" ProgramChange="116" />
+      <Patch Number="502" Name="Vox Key" ProgramChange="117" />
+      <Patch Number="503" Name="Magichand" ProgramChange="118" />
+      <Patch Number="504" Name="AnalogBell 1" ProgramChange="119" />
+      <Patch Number="505" Name="AnalogBell 2" ProgramChange="120" />
+      <Patch Number="506" Name="AnalogBell 3" ProgramChange="121" />
+      <Patch Number="507" Name="AnalogBell 4" ProgramChange="122" />
+      <Patch Number="508" Name="Synth Sniper" ProgramChange="123" />
+      <Patch Number="509" Name="Temper Bell" ProgramChange="124" />
+      <Patch Number="510" Name="Icycle" ProgramChange="125" />
+      <Patch Number="511" Name="Pipe Chatter" ProgramChange="126" />
+      <Patch Number="512" Name="Spring Wind" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 513-640">
+      <Patch Number="513" Name="JP80 SynHarp" ProgramChange="0" />
+      <Patch Number="514" Name="Bell 1" ProgramChange="1" />
+      <Patch Number="515" Name="Bell 2" ProgramChange="2" />
+      <Patch Number="516" Name="Bell 3" ProgramChange="3" />
+      <Patch Number="517" Name="Bell 4" ProgramChange="4" />
+      <Patch Number="518" Name="Bell 5" ProgramChange="5" />
+      <Patch Number="519" Name="Bell 6" ProgramChange="6" />
+      <Patch Number="520" Name="Bell 7" ProgramChange="7" />
+      <Patch Number="521" Name="Bell 8" ProgramChange="8" />
+      <Patch Number="522" Name="Bell 9" ProgramChange="9" />
+      <Patch Number="523" Name="Bell 10" ProgramChange="10" />
+      <Patch Number="524" Name="Bell 11" ProgramChange="11" />
+      <Patch Number="525" Name="Bell 12" ProgramChange="12" />
+      <Patch Number="526" Name="Bell 13" ProgramChange="13" />
+      <Patch Number="527" Name="Bell 14" ProgramChange="14" />
+      <Patch Number="528" Name="Bell 15" ProgramChange="15" />
+      <Patch Number="529" Name="Bell 16" ProgramChange="16" />
+      <Patch Number="530" Name="Bell 17" ProgramChange="17" />
+      <Patch Number="531" Name="Bell 18" ProgramChange="18" />
+      <Patch Number="532" Name="Bell 19" ProgramChange="19" />
+      <Patch Number="533" Name="Bell 20" ProgramChange="20" />
+      <Patch Number="534" Name="Bell 21" ProgramChange="21" />
+      <Patch Number="535" Name="Bell 22" ProgramChange="22" />
+      <Patch Number="536" Name="Tower Bell" ProgramChange="23" />
+      <Patch Number="537" Name="Tubular Bell" ProgramChange="24" />
+      <Patch Number="538" Name="OrganBell 1" ProgramChange="25" />
+      <Patch Number="539" Name="OrganBell 2" ProgramChange="26" />
+      <Patch Number="540" Name="OrganBell 3" ProgramChange="27" />
+      <Patch Number="541" Name="Kalimbell" ProgramChange="28" />
+      <Patch Number="542" Name="JP80 Bell" ProgramChange="29" />
+      <Patch Number="543" Name="Glass Amb" ProgramChange="30" />
+      <Patch Number="544" Name="Digi Crystal" ProgramChange="31" />
+      <Patch Number="545" Name="Icy Keys" ProgramChange="32" />
+      <Patch Number="546" Name="JP-8 PatchH1" ProgramChange="33" />
+      <Patch Number="547" Name="SEQ 1" ProgramChange="34" />
+      <Patch Number="548" Name="SEQ 2" ProgramChange="35" />
+      <Patch Number="549" Name="SEQ 3" ProgramChange="36" />
+      <Patch Number="550" Name="SEQ 4" ProgramChange="37" />
+      <Patch Number="551" Name="SEQ 5" ProgramChange="38" />
+      <Patch Number="552" Name="SEQ 6" ProgramChange="39" />
+      <Patch Number="553" Name="SEQ 7" ProgramChange="40" />
+      <Patch Number="554" Name="SEQ 8" ProgramChange="41" />
+      <Patch Number="555" Name="SEQ 9" ProgramChange="42" />
+      <Patch Number="556" Name="SEQ 10" ProgramChange="43" />
+      <Patch Number="557" Name="SEQ 11" ProgramChange="44" />
+      <Patch Number="558" Name="SEQ 12" ProgramChange="45" />
+      <Patch Number="559" Name="SEQ 13" ProgramChange="46" />
+      <Patch Number="560" Name="SEQ 14" ProgramChange="47" />
+      <Patch Number="561" Name="SEQ 15" ProgramChange="48" />
+      <Patch Number="562" Name="SEQ 16" ProgramChange="49" />
+      <Patch Number="563" Name="SEQ 17" ProgramChange="50" />
+      <Patch Number="564" Name="SEQ 18" ProgramChange="51" />
+      <Patch Number="565" Name="SEQ 19" ProgramChange="52" />
+      <Patch Number="566" Name="SEQ 20" ProgramChange="53" />
+      <Patch Number="567" Name="SEQ 21" ProgramChange="54" />
+      <Patch Number="568" Name="SEQ 22" ProgramChange="55" />
+      <Patch Number="569" Name="SEQ 23" ProgramChange="56" />
+      <Patch Number="570" Name="SEQ 24" ProgramChange="57" />
+      <Patch Number="571" Name="SEQ 25" ProgramChange="58" />
+      <Patch Number="572" Name="SEQ 26" ProgramChange="59" />
+      <Patch Number="573" Name="SEQ 27" ProgramChange="60" />
+      <Patch Number="574" Name="SEQ 28" ProgramChange="61" />
+      <Patch Number="575" Name="SEQ 29" ProgramChange="62" />
+      <Patch Number="576" Name="SEQ 30" ProgramChange="63" />
+      <Patch Number="577" Name="SEQ 31" ProgramChange="64" />
+      <Patch Number="578" Name="SEQ 32" ProgramChange="65" />
+      <Patch Number="579" Name="SEQ 33" ProgramChange="66" />
+      <Patch Number="580" Name="SEQ 34" ProgramChange="67" />
+      <Patch Number="581" Name="SEQ 35" ProgramChange="68" />
+      <Patch Number="582" Name="SEQ 36" ProgramChange="69" />
+      <Patch Number="583" Name="SEQ 37" ProgramChange="70" />
+      <Patch Number="584" Name="SEQ 38" ProgramChange="71" />
+      <Patch Number="585" Name="SEQ 39" ProgramChange="72" />
+      <Patch Number="586" Name="Stubby Mono" ProgramChange="73" />
+      <Patch Number="587" Name="Scrt Decay" ProgramChange="74" />
+      <Patch Number="588" Name="R&amp;B Bs 1" ProgramChange="75" />
+      <Patch Number="589" Name="R&amp;B Bs 2" ProgramChange="76" />
+      <Patch Number="590" Name="R&amp;B Bs 3" ProgramChange="77" />
+      <Patch Number="591" Name="R&amp;B Bs 4" ProgramChange="78" />
+      <Patch Number="592" Name="R&amp;B Bs 5" ProgramChange="79" />
+      <Patch Number="593" Name="R&amp;B Bs 6" ProgramChange="80" />
+      <Patch Number="594" Name="R&amp;B Bs 7" ProgramChange="81" />
+      <Patch Number="595" Name="R&amp;B Bs 8" ProgramChange="82" />
+      <Patch Number="596" Name="R&amp;B Bs 9" ProgramChange="83" />
+      <Patch Number="597" Name="MG Bs 1" ProgramChange="84" />
+      <Patch Number="598" Name="MG Bs 2" ProgramChange="85" />
+      <Patch Number="599" Name="MG Bs 3" ProgramChange="86" />
+      <Patch Number="600" Name="MG Bs 4" ProgramChange="87" />
+      <Patch Number="601" Name="MG Bs 5" ProgramChange="88" />
+      <Patch Number="602" Name="MG Bs 6" ProgramChange="89" />
+      <Patch Number="603" Name="MG Bs 7" ProgramChange="90" />
+      <Patch Number="604" Name="MG Bs 8" ProgramChange="91" />
+      <Patch Number="605" Name="MG Bs 9" ProgramChange="92" />
+      <Patch Number="606" Name="MG Bs 10" ProgramChange="93" />
+      <Patch Number="607" Name="MG Bs 11" ProgramChange="94" />
+      <Patch Number="608" Name="MG Bs 12" ProgramChange="95" />
+      <Patch Number="609" Name="MG Bs 13" ProgramChange="96" />
+      <Patch Number="610" Name="MG Bs 14" ProgramChange="97" />
+      <Patch Number="611" Name="MG Bs 15" ProgramChange="98" />
+      <Patch Number="612" Name="MG Bs 16" ProgramChange="99" />
+      <Patch Number="613" Name="MG Bs 17" ProgramChange="100" />
+      <Patch Number="614" Name="MG Bs 18" ProgramChange="101" />
+      <Patch Number="615" Name="MG Bs 19" ProgramChange="102" />
+      <Patch Number="616" Name="MG Bs 20" ProgramChange="103" />
+      <Patch Number="617" Name="MG Bs 21" ProgramChange="104" />
+      <Patch Number="618" Name="MG Bs 22" ProgramChange="105" />
+      <Patch Number="619" Name="MG Bs 23" ProgramChange="106" />
+      <Patch Number="620" Name="MG Bs 24" ProgramChange="107" />
+      <Patch Number="621" Name="MG Bs 25" ProgramChange="108" />
+      <Patch Number="622" Name="MG Bs 26" ProgramChange="109" />
+      <Patch Number="623" Name="Thickness Bs" ProgramChange="110" />
+      <Patch Number="624" Name="Plastic Bs" ProgramChange="111" />
+      <Patch Number="625" Name="Alpha Bs 1" ProgramChange="112" />
+      <Patch Number="626" Name="Alpha Bs 2" ProgramChange="113" />
+      <Patch Number="627" Name="Alpha Bs 3" ProgramChange="114" />
+      <Patch Number="628" Name="Flat6Bs" ProgramChange="115" />
+      <Patch Number="629" Name="Decay Bs 1" ProgramChange="116" />
+      <Patch Number="630" Name="Decay Bs 2" ProgramChange="117" />
+      <Patch Number="631" Name="Decay Bs 3" ProgramChange="118" />
+      <Patch Number="632" Name="Decay Bs 4" ProgramChange="119" />
+      <Patch Number="633" Name="106 Bass 1" ProgramChange="120" />
+      <Patch Number="634" Name="106 Bass 2" ProgramChange="121" />
+      <Patch Number="635" Name="106 Bass 3" ProgramChange="122" />
+      <Patch Number="636" Name="106 Bass 4" ProgramChange="123" />
+      <Patch Number="637" Name="106 Bass 5" ProgramChange="124" />
+      <Patch Number="638" Name="Breakdown Bs" ProgramChange="125" />
+      <Patch Number="639" Name="Dopebass" ProgramChange="126" />
+      <Patch Number="640" Name="MC202 Bs 1" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 641-768">
+      <Patch Number="641" Name="MC202 Bs 2" ProgramChange="0" />
+      <Patch Number="642" Name="Pulse Bs 1" ProgramChange="1" />
+      <Patch Number="643" Name="Pulse Bs 2" ProgramChange="2" />
+      <Patch Number="644" Name="Pulse Bs 3" ProgramChange="3" />
+      <Patch Number="645" Name="Pulse Bs 4" ProgramChange="4" />
+      <Patch Number="646" Name="FM Bs 1" ProgramChange="5" />
+      <Patch Number="647" Name="FM Bs 2" ProgramChange="6" />
+      <Patch Number="648" Name="JP Bs" ProgramChange="7" />
+      <Patch Number="649" Name="Compu Bass 1" ProgramChange="8" />
+      <Patch Number="650" Name="Compu Bass 2" ProgramChange="9" />
+      <Patch Number="651" Name="Detune Bs 1" ProgramChange="10" />
+      <Patch Number="652" Name="Detune Bs 2" ProgramChange="11" />
+      <Patch Number="653" Name="Detune Bs 3" ProgramChange="12" />
+      <Patch Number="654" Name="Detune Bs 4" ProgramChange="13" />
+      <Patch Number="655" Name="Intrusive Bs" ProgramChange="14" />
+      <Patch Number="656" Name="SH-101 Bs 1" ProgramChange="15" />
+      <Patch Number="657" Name="SH-101 Bs 2" ProgramChange="16" />
+      <Patch Number="658" Name="Sweep Bs 1" ProgramChange="17" />
+      <Patch Number="659" Name="Sweep Bs 2" ProgramChange="18" />
+      <Patch Number="660" Name="Sweep Bs 3" ProgramChange="19" />
+      <Patch Number="661" Name="Sweep Bs 4" ProgramChange="20" />
+      <Patch Number="662" Name="Sweep Bs 5" ProgramChange="21" />
+      <Patch Number="663" Name="Sweep Bs 6" ProgramChange="22" />
+      <Patch Number="664" Name="Sweep Bs 7" ProgramChange="23" />
+      <Patch Number="665" Name="Rubbertouch" ProgramChange="24" />
+      <Patch Number="666" Name="P5 Bs 1" ProgramChange="25" />
+      <Patch Number="667" Name="P5 Bs 2" ProgramChange="26" />
+      <Patch Number="668" Name="P5 Bs 3" ProgramChange="27" />
+      <Patch Number="669" Name="P5 Bs 4" ProgramChange="28" />
+      <Patch Number="670" Name="P5 Bs 5" ProgramChange="29" />
+      <Patch Number="671" Name="Juno60 Bs" ProgramChange="30" />
+      <Patch Number="672" Name="D-50 Bs" ProgramChange="31" />
+      <Patch Number="673" Name="MKS-50 Bs" ProgramChange="32" />
+      <Patch Number="674" Name="Wide Bs 1" ProgramChange="33" />
+      <Patch Number="675" Name="Wide Bs 2" ProgramChange="34" />
+      <Patch Number="676" Name="Wide Bs 3" ProgramChange="35" />
+      <Patch Number="677" Name="Wide Bs 4" ProgramChange="36" />
+      <Patch Number="678" Name="BASSH 10" ProgramChange="37" />
+      <Patch Number="679" Name="Chow Bs 1" ProgramChange="38" />
+      <Patch Number="680" Name="Chow Bs 2" ProgramChange="39" />
+      <Patch Number="681" Name="House Bs" ProgramChange="40" />
+      <Patch Number="682" Name="JP-4 Bs" ProgramChange="41" />
+      <Patch Number="683" Name="SH Square Bs" ProgramChange="42" />
+      <Patch Number="684" Name="JunoSqr Bs 1" ProgramChange="43" />
+      <Patch Number="685" Name="JunoSqr Bs 2" ProgramChange="44" />
+      <Patch Number="686" Name="TB Bass 1" ProgramChange="45" />
+      <Patch Number="687" Name="TB Bass 2" ProgramChange="46" />
+      <Patch Number="688" Name="TB Dist Bs 1" ProgramChange="47" />
+      <Patch Number="689" Name="TB Dist Bs 2" ProgramChange="48" />
+      <Patch Number="690" Name="Agresso Bass" ProgramChange="49" />
+      <Patch Number="691" Name="Show Me Low" ProgramChange="50" />
+      <Patch Number="692" Name="Organ Bs" ProgramChange="51" />
+      <Patch Number="693" Name="Muffled Bass" ProgramChange="52" />
+      <Patch Number="694" Name="Garage Bs 1" ProgramChange="53" />
+      <Patch Number="695" Name="Garage Bs 2" ProgramChange="54" />
+      <Patch Number="696" Name="Low Bs 1" ProgramChange="55" />
+      <Patch Number="697" Name="Low Bs 2" ProgramChange="56" />
+      <Patch Number="698" Name="Low Bs 3" ProgramChange="57" />
+      <Patch Number="699" Name="Low Bs 4" ProgramChange="58" />
+      <Patch Number="700" Name="Low Bs 5" ProgramChange="59" />
+      <Patch Number="701" Name="Low Bs 6" ProgramChange="60" />
+      <Patch Number="702" Name="Tri Bass 1" ProgramChange="61" />
+      <Patch Number="703" Name="Tri Bass 2" ProgramChange="62" />
+      <Patch Number="704" Name="Fat Analog 1" ProgramChange="63" />
+      <Patch Number="705" Name="Fat Analog 2" ProgramChange="64" />
+      <Patch Number="706" Name="Reso Bs 1" ProgramChange="65" />
+      <Patch Number="707" Name="Reso Bs 2" ProgramChange="66" />
+      <Patch Number="708" Name="Reso Bs 3" ProgramChange="67" />
+      <Patch Number="709" Name="Reso Bs 4" ProgramChange="68" />
+      <Patch Number="710" Name="Reso Bs 5" ProgramChange="69" />
+      <Patch Number="711" Name="Reso Bs 6" ProgramChange="70" />
+      <Patch Number="712" Name="Reso Bs 7" ProgramChange="71" />
+      <Patch Number="713" Name="Reso Bs 8" ProgramChange="72" />
+      <Patch Number="714" Name="Reso Bs 9" ProgramChange="73" />
+      <Patch Number="715" Name="Reso Bs 10" ProgramChange="74" />
+      <Patch Number="716" Name="Reso Bs 11" ProgramChange="75" />
+      <Patch Number="717" Name="Reso Bs 12" ProgramChange="76" />
+      <Patch Number="718" Name="Reso Bs 13" ProgramChange="77" />
+      <Patch Number="719" Name="Reso Bs 14" ProgramChange="78" />
+      <Patch Number="720" Name="Reso Bs 15" ProgramChange="79" />
+      <Patch Number="721" Name="Reso Bs 16" ProgramChange="80" />
+      <Patch Number="722" Name="Reso Bs 17" ProgramChange="81" />
+      <Patch Number="723" Name="Reso Bs 18" ProgramChange="82" />
+      <Patch Number="724" Name="Reso Bs 19" ProgramChange="83" />
+      <Patch Number="725" Name="Reso Bs 20" ProgramChange="84" />
+      <Patch Number="726" Name="Reso Bs 21" ProgramChange="85" />
+      <Patch Number="727" Name="Reso Bs 22" ProgramChange="86" />
+      <Patch Number="728" Name="Reso Bs 23" ProgramChange="87" />
+      <Patch Number="729" Name="Reso Bs 24" ProgramChange="88" />
+      <Patch Number="730" Name="Camblast" ProgramChange="89" />
+      <Patch Number="731" Name="LA SynBs" ProgramChange="90" />
+      <Patch Number="732" Name="Fat SynBs" ProgramChange="91" />
+      <Patch Number="733" Name="Syn Bs 1" ProgramChange="92" />
+      <Patch Number="734" Name="Syn Bs 2" ProgramChange="93" />
+      <Patch Number="735" Name="Syn Bs 3" ProgramChange="94" />
+      <Patch Number="736" Name="Rubber Bs 1" ProgramChange="95" />
+      <Patch Number="737" Name="Rubber Bs 2" ProgramChange="96" />
+      <Patch Number="738" Name="Dynamic Bs 1" ProgramChange="97" />
+      <Patch Number="739" Name="Dynamic Bs 2" ProgramChange="98" />
+      <Patch Number="740" Name="Round Bs" ProgramChange="99" />
+      <Patch Number="741" Name="Acid Bs 1" ProgramChange="100" />
+      <Patch Number="742" Name="Acid Bs 2" ProgramChange="101" />
+      <Patch Number="743" Name="Acid Bs 3" ProgramChange="102" />
+      <Patch Number="744" Name="Acid Bs 4" ProgramChange="103" />
+      <Patch Number="745" Name="Acid Bs 5" ProgramChange="104" />
+      <Patch Number="746" Name="Acid Bs 6" ProgramChange="105" />
+      <Patch Number="747" Name="Spike Bs 1" ProgramChange="106" />
+      <Patch Number="748" Name="Spike Bs 2" ProgramChange="107" />
+      <Patch Number="749" Name="H&amp;S Bass" ProgramChange="108" />
+      <Patch Number="750" Name="Short Bs 1" ProgramChange="109" />
+      <Patch Number="751" Name="Short Bs 2" ProgramChange="110" />
+      <Patch Number="752" Name="Short Bs 3" ProgramChange="111" />
+      <Patch Number="753" Name="HH Bs 1" ProgramChange="112" />
+      <Patch Number="754" Name="HH Bs 2" ProgramChange="113" />
+      <Patch Number="755" Name="HH Bs 3" ProgramChange="114" />
+      <Patch Number="756" Name="HH Bs 4" ProgramChange="115" />
+      <Patch Number="757" Name="HH Bs 5" ProgramChange="116" />
+      <Patch Number="758" Name="HH Bs 6" ProgramChange="117" />
+      <Patch Number="759" Name="Arpaccio" ProgramChange="118" />
+      <Patch Number="760" Name="Carmelcorn" ProgramChange="119" />
+      <Patch Number="761" Name="NoiseBs" ProgramChange="120" />
+      <Patch Number="762" Name="Soft Bs" ProgramChange="121" />
+      <Patch Number="763" Name="Slow Bs" ProgramChange="122" />
+      <Patch Number="764" Name="Square Bs 1" ProgramChange="123" />
+      <Patch Number="765" Name="Square Bs 2" ProgramChange="124" />
+      <Patch Number="766" Name="Square Bs 3" ProgramChange="125" />
+      <Patch Number="767" Name="Square Bs 4" ProgramChange="126" />
+      <Patch Number="768" Name="Squaresville" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 769-896">
+      <Patch Number="769" Name="PWM Bass 1" ProgramChange="0" />
+      <Patch Number="770" Name="PWM Bass 2" ProgramChange="1" />
+      <Patch Number="771" Name="Modular Bs 1" ProgramChange="2" />
+      <Patch Number="772" Name="Modular Bs 2" ProgramChange="3" />
+      <Patch Number="773" Name="Modular Bs 3" ProgramChange="4" />
+      <Patch Number="774" Name="Modular Bs 4" ProgramChange="5" />
+      <Patch Number="775" Name="Modular Bs 5" ProgramChange="6" />
+      <Patch Number="776" Name="Modular Bs 6" ProgramChange="7" />
+      <Patch Number="777" Name="Unison Bs 1" ProgramChange="8" />
+      <Patch Number="778" Name="Unison Bs 2" ProgramChange="9" />
+      <Patch Number="779" Name="Unison Bs 3" ProgramChange="10" />
+      <Patch Number="780" Name="Unison Bs 4" ProgramChange="11" />
+      <Patch Number="781" Name="Monster Bs 1" ProgramChange="12" />
+      <Patch Number="782" Name="Monster Bs 2" ProgramChange="13" />
+      <Patch Number="783" Name="Monster Bs 3" ProgramChange="14" />
+      <Patch Number="784" Name="Monster Bs 4" ProgramChange="15" />
+      <Patch Number="785" Name="Monster Bs 5" ProgramChange="16" />
+      <Patch Number="786" Name="Monster Bs 6" ProgramChange="17" />
+      <Patch Number="787" Name="Monster Bs 7" ProgramChange="18" />
+      <Patch Number="788" Name="Monster Bs 8" ProgramChange="19" />
+      <Patch Number="789" Name="Bit Bs 1" ProgramChange="20" />
+      <Patch Number="790" Name="Bit Bs 2" ProgramChange="21" />
+      <Patch Number="791" Name="Bit Bs 3" ProgramChange="22" />
+      <Patch Number="792" Name="Bit Bs 4" ProgramChange="23" />
+      <Patch Number="793" Name="SuperSawBs 1" ProgramChange="24" />
+      <Patch Number="794" Name="SuperSawBs 2" ProgramChange="25" />
+      <Patch Number="795" Name="SuperSawBs 3" ProgramChange="26" />
+      <Patch Number="796" Name="SuperSawBs 4" ProgramChange="27" />
+      <Patch Number="797" Name="SuperSawBs 5" ProgramChange="28" />
+      <Patch Number="798" Name="Sync Bs 1" ProgramChange="29" />
+      <Patch Number="799" Name="Sync Bs 2" ProgramChange="30" />
+      <Patch Number="800" Name="Sync Bs 3" ProgramChange="31" />
+      <Patch Number="801" Name="Sync Bs 4" ProgramChange="32" />
+      <Patch Number="802" Name="SubOSC Bs 1" ProgramChange="33" />
+      <Patch Number="803" Name="SubOSC Bs 2" ProgramChange="34" />
+      <Patch Number="804" Name="Ramp Bs" ProgramChange="35" />
+      <Patch Number="805" Name="LFO Bs 1" ProgramChange="36" />
+      <Patch Number="806" Name="LFO Bs 2" ProgramChange="37" />
+      <Patch Number="807" Name="LFO Bs 3" ProgramChange="38" />
+      <Patch Number="808" Name="LFO Bs 4" ProgramChange="39" />
+      <Patch Number="809" Name="Crackbass" ProgramChange="40" />
+      <Patch Number="810" Name="Basschunk" ProgramChange="41" />
+      <Patch Number="811" Name="Hi-Energy Bs" ProgramChange="42" />
+      <Patch Number="812" Name="Saw Lead 1" ProgramChange="43" />
+      <Patch Number="813" Name="Saw Lead 2" ProgramChange="44" />
+      <Patch Number="814" Name="Saw Lead 3" ProgramChange="45" />
+      <Patch Number="815" Name="Saw Lead 4" ProgramChange="46" />
+      <Patch Number="816" Name="Saw Lead 5" ProgramChange="47" />
+      <Patch Number="817" Name="Saw Lead 6" ProgramChange="48" />
+      <Patch Number="818" Name="Saw Lead 7" ProgramChange="49" />
+      <Patch Number="819" Name="Saw Lead 8" ProgramChange="50" />
+      <Patch Number="820" Name="Saw Lead 9" ProgramChange="51" />
+      <Patch Number="821" Name="Saw Lead 10" ProgramChange="52" />
+      <Patch Number="822" Name="Saw Lead 11" ProgramChange="53" />
+      <Patch Number="823" Name="Saw Lead 12" ProgramChange="54" />
+      <Patch Number="824" Name="Saw Lead 13" ProgramChange="55" />
+      <Patch Number="825" Name="Saw Lead 14" ProgramChange="56" />
+      <Patch Number="826" Name="Saw Lead 15" ProgramChange="57" />
+      <Patch Number="827" Name="Saw Lead 16" ProgramChange="58" />
+      <Patch Number="828" Name="Saw Lead 17" ProgramChange="59" />
+      <Patch Number="829" Name="Saw Lead 18" ProgramChange="60" />
+      <Patch Number="830" Name="Saw Lead 19" ProgramChange="61" />
+      <Patch Number="831" Name="Saw Lead 20" ProgramChange="62" />
+      <Patch Number="832" Name="Saw Lead 21" ProgramChange="63" />
+      <Patch Number="833" Name="Saw Lead 22" ProgramChange="64" />
+      <Patch Number="834" Name="Saw Lead 23" ProgramChange="65" />
+      <Patch Number="835" Name="Saw Lead 24" ProgramChange="66" />
+      <Patch Number="836" Name="Saw Lead 25" ProgramChange="67" />
+      <Patch Number="837" Name="Saw Lead 26" ProgramChange="68" />
+      <Patch Number="838" Name="Saw Lead 27" ProgramChange="69" />
+      <Patch Number="839" Name="Saw Lead 28" ProgramChange="70" />
+      <Patch Number="840" Name="Saw Lead 29" ProgramChange="71" />
+      <Patch Number="841" Name="Saw Lead 30" ProgramChange="72" />
+      <Patch Number="842" Name="Saw Lead 31" ProgramChange="73" />
+      <Patch Number="843" Name="Saw Lead 32" ProgramChange="74" />
+      <Patch Number="844" Name="Saw Lead 33" ProgramChange="75" />
+      <Patch Number="845" Name="Saw Lead 34" ProgramChange="76" />
+      <Patch Number="846" Name="Saw Lead 35" ProgramChange="77" />
+      <Patch Number="847" Name="Saw Lead 36" ProgramChange="78" />
+      <Patch Number="848" Name="Saw Lead 37" ProgramChange="79" />
+      <Patch Number="849" Name="Saw Lead 38" ProgramChange="80" />
+      <Patch Number="850" Name="Saw Lead 39" ProgramChange="81" />
+      <Patch Number="851" Name="Saw Lead 40" ProgramChange="82" />
+      <Patch Number="852" Name="Saw Lead 41" ProgramChange="83" />
+      <Patch Number="853" Name="Saw Lead 42" ProgramChange="84" />
+      <Patch Number="854" Name="Saw Lead 43" ProgramChange="85" />
+      <Patch Number="855" Name="Saw Lead 44" ProgramChange="86" />
+      <Patch Number="856" Name="Saw Lead 45" ProgramChange="87" />
+      <Patch Number="857" Name="CC Saw Ld 1" ProgramChange="88" />
+      <Patch Number="858" Name="CC Saw Ld 2" ProgramChange="89" />
+      <Patch Number="859" Name="CC Saw Ld 3" ProgramChange="90" />
+      <Patch Number="860" Name="CC Saw Ld 4" ProgramChange="91" />
+      <Patch Number="861" Name="CC Saw Ld 5" ProgramChange="92" />
+      <Patch Number="862" Name="Bad Axe" ProgramChange="93" />
+      <Patch Number="863" Name="Buzz Cut" ProgramChange="94" />
+      <Patch Number="864" Name="Cutting Lead" ProgramChange="95" />
+      <Patch Number="865" Name="Fat GR Lead" ProgramChange="96" />
+      <Patch Number="866" Name="Bright Pls" ProgramChange="97" />
+      <Patch Number="867" Name="Juicy JP" ProgramChange="98" />
+      <Patch Number="868" Name="Abakababra" ProgramChange="99" />
+      <Patch Number="869" Name="Crossfire" ProgramChange="100" />
+      <Patch Number="870" Name="Borrowed" ProgramChange="101" />
+      <Patch Number="871" Name="PulstarLd 1" ProgramChange="102" />
+      <Patch Number="872" Name="PulstarLd 2" ProgramChange="103" />
+      <Patch Number="873" Name="Dirty Saw Ld" ProgramChange="104" />
+      <Patch Number="874" Name="Leadership" ProgramChange="105" />
+      <Patch Number="875" Name="Ripping Mini" ProgramChange="106" />
+      <Patch Number="876" Name="Love Lead" ProgramChange="107" />
+      <Patch Number="877" Name="EQ Lead 1" ProgramChange="108" />
+      <Patch Number="878" Name="EQ Lead 2" ProgramChange="109" />
+      <Patch Number="879" Name="Stn MG Lead" ProgramChange="110" />
+      <Patch Number="880" Name="Octa Juice" ProgramChange="111" />
+      <Patch Number="881" Name="CR Lead" ProgramChange="112" />
+      <Patch Number="882" Name="Hip Lead" ProgramChange="113" />
+      <Patch Number="883" Name="Chubby Lead" ProgramChange="114" />
+      <Patch Number="884" Name="Super Saws" ProgramChange="115" />
+      <Patch Number="885" Name="NuWave" ProgramChange="116" />
+      <Patch Number="886" Name="Flangepig" ProgramChange="117" />
+      <Patch Number="887" Name="Bodyart" ProgramChange="118" />
+      <Patch Number="888" Name="Buzz Synth" ProgramChange="119" />
+      <Patch Number="889" Name="Hard Synth" ProgramChange="120" />
+      <Patch Number="890" Name="Dance Saw 1" ProgramChange="121" />
+      <Patch Number="891" Name="Dance Saw 2" ProgramChange="122" />
+      <Patch Number="892" Name="Funky Lead" ProgramChange="123" />
+      <Patch Number="893" Name="WaveShape Ld" ProgramChange="124" />
+      <Patch Number="894" Name="Synchro Lead" ProgramChange="125" />
+      <Patch Number="895" Name="LFO Saw Ld" ProgramChange="126" />
+      <Patch Number="896" Name="Juno Soft Ld" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 897-1024">
+      <Patch Number="897" Name="Oct Lead" ProgramChange="0" />
+      <Patch Number="898" Name="Slow Lead 1" ProgramChange="1" />
+      <Patch Number="899" Name="Slow Lead 2" ProgramChange="2" />
+      <Patch Number="900" Name="Slow Lead 3" ProgramChange="3" />
+      <Patch Number="901" Name="Slow Lead 4" ProgramChange="4" />
+      <Patch Number="902" Name="Slow Lead 5" ProgramChange="5" />
+      <Patch Number="903" Name="Slow Lead 6" ProgramChange="6" />
+      <Patch Number="904" Name="Slow Lead 7" ProgramChange="7" />
+      <Patch Number="905" Name="Slow Lead 8" ProgramChange="8" />
+      <Patch Number="906" Name="Slow Lead 9" ProgramChange="9" />
+      <Patch Number="907" Name="Slow Lead 10" ProgramChange="10" />
+      <Patch Number="908" Name="Slow Lead 11" ProgramChange="11" />
+      <Patch Number="909" Name="Slow Lead 12" ProgramChange="12" />
+      <Patch Number="910" Name="AnaVox Ld 1" ProgramChange="13" />
+      <Patch Number="911" Name="AnaVox Ld 2" ProgramChange="14" />
+      <Patch Number="912" Name="AnaVox Ld 3" ProgramChange="15" />
+      <Patch Number="913" Name="AnaVox Ld 4" ProgramChange="16" />
+      <Patch Number="914" Name="Pulse Lead 1" ProgramChange="17" />
+      <Patch Number="915" Name="Pulse Lead 2" ProgramChange="18" />
+      <Patch Number="916" Name="Pulse Lead 3" ProgramChange="19" />
+      <Patch Number="917" Name="BellSaw Ld 1" ProgramChange="20" />
+      <Patch Number="918" Name="BellSaw Ld 2" ProgramChange="21" />
+      <Patch Number="919" Name="Bell Lead 1" ProgramChange="22" />
+      <Patch Number="920" Name="Bell Lead 2" ProgramChange="23" />
+      <Patch Number="921" Name="Bell Lead 3" ProgramChange="24" />
+      <Patch Number="922" Name="Dig n D" ProgramChange="25" />
+      <Patch Number="923" Name="Juicy Lead 1" ProgramChange="26" />
+      <Patch Number="924" Name="Juicy Lead 2" ProgramChange="27" />
+      <Patch Number="925" Name="Portament Ld" ProgramChange="28" />
+      <Patch Number="926" Name="Reso Juno" ProgramChange="29" />
+      <Patch Number="927" Name="Air Lead 1" ProgramChange="30" />
+      <Patch Number="928" Name="Air Lead 2" ProgramChange="31" />
+      <Patch Number="929" Name="Reso Pulser" ProgramChange="32" />
+      <Patch Number="930" Name="Growl Lead" ProgramChange="33" />
+      <Patch Number="931" Name="Vintager 1" ProgramChange="34" />
+      <Patch Number="932" Name="Vintager 2" ProgramChange="35" />
+      <Patch Number="933" Name="Vintager 3" ProgramChange="36" />
+      <Patch Number="934" Name="SuperSaw Ld" ProgramChange="37" />
+      <Patch Number="935" Name="5th SawLead1" ProgramChange="38" />
+      <Patch Number="936" Name="5th SawLead2" ProgramChange="39" />
+      <Patch Number="937" Name="Simple Sqr" ProgramChange="40" />
+      <Patch Number="938" Name="Round Sqr 1" ProgramChange="41" />
+      <Patch Number="939" Name="Round Sqr 2" ProgramChange="42" />
+      <Patch Number="940" Name="Square Ld 1" ProgramChange="43" />
+      <Patch Number="941" Name="Square Ld 2" ProgramChange="44" />
+      <Patch Number="942" Name="Square Ld 3" ProgramChange="45" />
+      <Patch Number="943" Name="Square Ld 4" ProgramChange="46" />
+      <Patch Number="944" Name="Square Ld 5" ProgramChange="47" />
+      <Patch Number="945" Name="Square Ld 6" ProgramChange="48" />
+      <Patch Number="946" Name="Square Ld 7" ProgramChange="49" />
+      <Patch Number="947" Name="Square Ld 8" ProgramChange="50" />
+      <Patch Number="948" Name="Square Ld 9" ProgramChange="51" />
+      <Patch Number="949" Name="Square Ld 10" ProgramChange="52" />
+      <Patch Number="950" Name="Square Ld 11" ProgramChange="53" />
+      <Patch Number="951" Name="Square Ld 12" ProgramChange="54" />
+      <Patch Number="952" Name="Square Ld 13" ProgramChange="55" />
+      <Patch Number="953" Name="Square Ld 14" ProgramChange="56" />
+      <Patch Number="954" Name="Square Ld 15" ProgramChange="57" />
+      <Patch Number="955" Name="Squareoff" ProgramChange="58" />
+      <Patch Number="956" Name="Brite Sqr 1" ProgramChange="59" />
+      <Patch Number="957" Name="Brite Sqr 2" ProgramChange="60" />
+      <Patch Number="958" Name="Brite Sqr 3" ProgramChange="61" />
+      <Patch Number="959" Name="Cpt McSquare" ProgramChange="62" />
+      <Patch Number="960" Name="Tekno Sqr" ProgramChange="63" />
+      <Patch Number="961" Name="Octa Square" ProgramChange="64" />
+      <Patch Number="962" Name="Pure Square" ProgramChange="65" />
+      <Patch Number="963" Name="SynOcarina 1" ProgramChange="66" />
+      <Patch Number="964" Name="SynOcarina 2" ProgramChange="67" />
+      <Patch Number="965" Name="SynOcarina 3" ProgramChange="68" />
+      <Patch Number="966" Name="Crawler" ProgramChange="69" />
+      <Patch Number="967" Name="OB Lead 1" ProgramChange="70" />
+      <Patch Number="968" Name="OB Lead 2" ProgramChange="71" />
+      <Patch Number="969" Name="Tri Lead 1" ProgramChange="72" />
+      <Patch Number="970" Name="Tri Lead 2" ProgramChange="73" />
+      <Patch Number="971" Name="Tri Lead 3" ProgramChange="74" />
+      <Patch Number="972" Name="Tri Lead 4" ProgramChange="75" />
+      <Patch Number="973" Name="Softy Lead" ProgramChange="76" />
+      <Patch Number="974" Name="Sine Lead 1" ProgramChange="77" />
+      <Patch Number="975" Name="Sine Lead 2" ProgramChange="78" />
+      <Patch Number="976" Name="Sine Lead 3" ProgramChange="79" />
+      <Patch Number="977" Name="Sine Lead 4" ProgramChange="80" />
+      <Patch Number="978" Name="Sine Lead 5" ProgramChange="81" />
+      <Patch Number="979" Name="OSC-SyncLd 1" ProgramChange="82" />
+      <Patch Number="980" Name="OSC-SyncLd 2" ProgramChange="83" />
+      <Patch Number="981" Name="OSC-SyncLd 3" ProgramChange="84" />
+      <Patch Number="982" Name="OSC-SyncLd 4" ProgramChange="85" />
+      <Patch Number="983" Name="OSC-SyncLd 5" ProgramChange="86" />
+      <Patch Number="984" Name="OSC-SyncLd 6" ProgramChange="87" />
+      <Patch Number="985" Name="OSC-SyncLd 7" ProgramChange="88" />
+      <Patch Number="986" Name="OSC-SyncLd 8" ProgramChange="89" />
+      <Patch Number="987" Name="Disturb Sync" ProgramChange="90" />
+      <Patch Number="988" Name="Digi Lead 1" ProgramChange="91" />
+      <Patch Number="989" Name="Digi Lead 2" ProgramChange="92" />
+      <Patch Number="990" Name="Waspy Lead" ProgramChange="93" />
+      <Patch Number="991" Name="Stitcher" ProgramChange="94" />
+      <Patch Number="992" Name="Sweet 5th 1" ProgramChange="95" />
+      <Patch Number="993" Name="Sweet 5th 2" ProgramChange="96" />
+      <Patch Number="994" Name="SoloNzPeaker" ProgramChange="97" />
+      <Patch Number="995" Name="Release Ld" ProgramChange="98" />
+      <Patch Number="996" Name="Syn Lead 1" ProgramChange="99" />
+      <Patch Number="997" Name="Syn Lead 2" ProgramChange="100" />
+      <Patch Number="998" Name="Syn Lead 3" ProgramChange="101" />
+      <Patch Number="999" Name="Syn Lead 4" ProgramChange="102" />
+      <Patch Number="1000" Name="Syn Lead 5" ProgramChange="103" />
+      <Patch Number="1001" Name="Syn Lead 6" ProgramChange="104" />
+      <Patch Number="1002" Name="Syn Lead 7" ProgramChange="105" />
+      <Patch Number="1003" Name="Syn Lead 8" ProgramChange="106" />
+      <Patch Number="1004" Name="Syn Lead 9" ProgramChange="107" />
+      <Patch Number="1005" Name="Syn Lead 10" ProgramChange="108" />
+      <Patch Number="1006" Name="Syn Lead 11" ProgramChange="109" />
+      <Patch Number="1007" Name="Tekno Ld 1" ProgramChange="110" />
+      <Patch Number="1008" Name="Tekno Ld 2" ProgramChange="111" />
+      <Patch Number="1009" Name="Tekno Ld 3" ProgramChange="112" />
+      <Patch Number="1010" Name="Tekno Ld 4" ProgramChange="113" />
+      <Patch Number="1011" Name="Tekno Ld 5" ProgramChange="114" />
+      <Patch Number="1012" Name="Tekno Ld 6" ProgramChange="115" />
+      <Patch Number="1013" Name="Tekno Ld 7" ProgramChange="116" />
+      <Patch Number="1014" Name="Tekno Ld 8" ProgramChange="117" />
+      <Patch Number="1015" Name="Tekno Ld 9" ProgramChange="118" />
+      <Patch Number="1016" Name="Tekno Ld 10" ProgramChange="119" />
+      <Patch Number="1017" Name="Tekno Ld 11" ProgramChange="120" />
+      <Patch Number="1018" Name="Tekno Ld 12" ProgramChange="121" />
+      <Patch Number="1019" Name="Tekno Ld 13" ProgramChange="122" />
+      <Patch Number="1020" Name="Tekno Ld 14" ProgramChange="123" />
+      <Patch Number="1021" Name="Tekno Ld 15" ProgramChange="124" />
+      <Patch Number="1022" Name="Tekno Ld 16" ProgramChange="125" />
+      <Patch Number="1023" Name="Tekno Ld 17" ProgramChange="126" />
+      <Patch Number="1024" Name="Tekno Ld 18" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Synth Tone 1025-1109">
+      <Patch Number="1025" Name="Tekno Ld 19" ProgramChange="0" />
+      <Patch Number="1026" Name="Tekno Ld 20" ProgramChange="1" />
+      <Patch Number="1027" Name="Tekno Ld 21" ProgramChange="2" />
+      <Patch Number="1028" Name="Tekno Ld 22" ProgramChange="3" />
+      <Patch Number="1029" Name="Tekno Ld 23" ProgramChange="4" />
+      <Patch Number="1030" Name="Tekno Ld 24" ProgramChange="5" />
+      <Patch Number="1031" Name="Tekno Ld 25" ProgramChange="6" />
+      <Patch Number="1032" Name="Tekno Ld 26" ProgramChange="7" />
+      <Patch Number="1033" Name="Tekno Ld 27" ProgramChange="8" />
+      <Patch Number="1034" Name="Tekno Ld 28" ProgramChange="9" />
+      <Patch Number="1035" Name="Tekno Ld 29" ProgramChange="10" />
+      <Patch Number="1036" Name="Tekno Ld 30" ProgramChange="11" />
+      <Patch Number="1037" Name="Tekno Ld 31" ProgramChange="12" />
+      <Patch Number="1038" Name="Tekno Ld 32" ProgramChange="13" />
+      <Patch Number="1039" Name="Tekno Ld 33" ProgramChange="14" />
+      <Patch Number="1040" Name="Tekno Ld 34" ProgramChange="15" />
+      <Patch Number="1041" Name="Tekno Ld 35" ProgramChange="16" />
+      <Patch Number="1042" Name="Tekno Ld 36" ProgramChange="17" />
+      <Patch Number="1043" Name="JP80 Ring-80" ProgramChange="18" />
+      <Patch Number="1044" Name="Distroubled" ProgramChange="19" />
+      <Patch Number="1045" Name="Hover Dive 1" ProgramChange="20" />
+      <Patch Number="1046" Name="Hover Dive 2" ProgramChange="21" />
+      <Patch Number="1047" Name="OhWowWow" ProgramChange="22" />
+      <Patch Number="1048" Name="Broken Lead" ProgramChange="23" />
+      <Patch Number="1049" Name="FX 1" ProgramChange="24" />
+      <Patch Number="1050" Name="FX 2" ProgramChange="25" />
+      <Patch Number="1051" Name="FX 3" ProgramChange="26" />
+      <Patch Number="1052" Name="FX 4" ProgramChange="27" />
+      <Patch Number="1053" Name="FX 5" ProgramChange="28" />
+      <Patch Number="1054" Name="FX 6" ProgramChange="29" />
+      <Patch Number="1055" Name="FX 7" ProgramChange="30" />
+      <Patch Number="1056" Name="FX 8" ProgramChange="31" />
+      <Patch Number="1057" Name="FX 9" ProgramChange="32" />
+      <Patch Number="1058" Name="FX 10" ProgramChange="33" />
+      <Patch Number="1059" Name="FX 11" ProgramChange="34" />
+      <Patch Number="1060" Name="FX 12" ProgramChange="35" />
+      <Patch Number="1061" Name="FX 13" ProgramChange="36" />
+      <Patch Number="1062" Name="FX 14" ProgramChange="37" />
+      <Patch Number="1063" Name="FX 15" ProgramChange="38" />
+      <Patch Number="1064" Name="FX 16" ProgramChange="39" />
+      <Patch Number="1065" Name="FX 17" ProgramChange="40" />
+      <Patch Number="1066" Name="FX 18" ProgramChange="41" />
+      <Patch Number="1067" Name="FX 19" ProgramChange="42" />
+      <Patch Number="1068" Name="FX 20" ProgramChange="43" />
+      <Patch Number="1069" Name="FX 21" ProgramChange="44" />
+      <Patch Number="1070" Name="FX 22" ProgramChange="45" />
+      <Patch Number="1071" Name="FX 23" ProgramChange="46" />
+      <Patch Number="1072" Name="FX 24" ProgramChange="47" />
+      <Patch Number="1073" Name="FX 25" ProgramChange="48" />
+      <Patch Number="1074" Name="Zapper" ProgramChange="49" />
+      <Patch Number="1075" Name="Sci-Fi Sweep" ProgramChange="50" />
+      <Patch Number="1076" Name="War Drum" ProgramChange="51" />
+      <Patch Number="1077" Name="Vox FX" ProgramChange="52" />
+      <Patch Number="1078" Name="Atomspheric" ProgramChange="53" />
+      <Patch Number="1079" Name="Angry Words" ProgramChange="54" />
+      <Patch Number="1080" Name="F6 = Critter" ProgramChange="55" />
+      <Patch Number="1081" Name="FreeJazz" ProgramChange="56" />
+      <Patch Number="1082" Name="FM EP 1" ProgramChange="57" />
+      <Patch Number="1083" Name="FM EP 2" ProgramChange="58" />
+      <Patch Number="1084" Name="FM EP 3" ProgramChange="59" />
+      <Patch Number="1085" Name="FM EP 4" ProgramChange="60" />
+      <Patch Number="1086" Name="FM EP 5" ProgramChange="61" />
+      <Patch Number="1087" Name="FM EP 6" ProgramChange="62" />
+      <Patch Number="1088" Name="FM EPhaser" ProgramChange="63" />
+      <Patch Number="1089" Name="EP Belle" ProgramChange="64" />
+      <Patch Number="1090" Name="80's EP" ProgramChange="65" />
+      <Patch Number="1091" Name="Spirit Tine" ProgramChange="66" />
+      <Patch Number="1092" Name="70's E.Org 1" ProgramChange="67" />
+      <Patch Number="1093" Name="70's E.Org 2" ProgramChange="68" />
+      <Patch Number="1094" Name="Theater 1" ProgramChange="69" />
+      <Patch Number="1095" Name="Theater 2" ProgramChange="70" />
+      <Patch Number="1096" Name="Theater 3" ProgramChange="71" />
+      <Patch Number="1097" Name="Pulse Clav" ProgramChange="72" />
+      <Patch Number="1098" Name="Toy Box 1" ProgramChange="73" />
+      <Patch Number="1099" Name="Toy Box 2" ProgramChange="74" />
+      <Patch Number="1100" Name="Ethno Keys" ProgramChange="75" />
+      <Patch Number="1101" Name="Mood String" ProgramChange="76" />
+      <Patch Number="1102" Name="Orch Hit" ProgramChange="77" />
+      <Patch Number="1103" Name="Philly Hit 1" ProgramChange="78" />
+      <Patch Number="1104" Name="Philly Hit 2" ProgramChange="79" />
+      <Patch Number="1105" Name="Philly Hit 3" ProgramChange="80" />
+      <Patch Number="1106" Name="Philly Hit 4" ProgramChange="81" />
+      <Patch Number="1107" Name="House Hit 1" ProgramChange="82" />
+      <Patch Number="1108" Name="House Hit 2" ProgramChange="83" />
+      <Patch Number="1109" Name="LoFi Hit" ProgramChange="84" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (ExPCM) 1-128">
+      <Patch Number="001" Name="St.Piano 1" ProgramChange="0" />
+      <Patch Number="002" Name="St.Piano 2" ProgramChange="1" />
+      <Patch Number="003" Name="St.Piano 3" ProgramChange="2" />
+      <Patch Number="004" Name="St.Piano 4" ProgramChange="3" />
+      <Patch Number="005" Name="St.Piano 5" ProgramChange="4" />
+      <Patch Number="006" Name="St.Piano 6" ProgramChange="5" />
+      <Patch Number="007" Name="JD Piano" ProgramChange="6" />
+      <Patch Number="008" Name="Stage Piano" ProgramChange="7" />
+      <Patch Number="009" Name="Honky-tonk 2" ProgramChange="8" />
+      <Patch Number="010" Name="Pop Piano 1" ProgramChange="9" />
+      <Patch Number="011" Name="Pop Piano 2" ProgramChange="10" />
+      <Patch Number="012" Name="Pop Piano 3" ProgramChange="11" />
+      <Patch Number="013" Name="Stage EP 1" ProgramChange="12" />
+      <Patch Number="014" Name="Stage EP 2" ProgramChange="13" />
+      <Patch Number="015" Name="Stage EP Trm" ProgramChange="14" />
+      <Patch Number="016" Name="Tremolo EP 1" ProgramChange="15" />
+      <Patch Number="017" Name="E.Piano 3" ProgramChange="16" />
+      <Patch Number="018" Name="E.Piano 4" ProgramChange="17" />
+      <Patch Number="019" Name="E.Piano 5" ProgramChange="18" />
+      <Patch Number="020" Name="E.Piano 6" ProgramChange="19" />
+      <Patch Number="021" Name="E.Piano 7" ProgramChange="20" />
+      <Patch Number="022" Name="E.Piano 8" ProgramChange="21" />
+      <Patch Number="023" Name="Dyno EP" ProgramChange="22" />
+      <Patch Number="024" Name="Dyno EP Trm" ProgramChange="23" />
+      <Patch Number="025" Name="Tremolo EP 2" ProgramChange="24" />
+      <Patch Number="026" Name="Back2the60s" ProgramChange="25" />
+      <Patch Number="027" Name="Tine EP" ProgramChange="26" />
+      <Patch Number="028" Name="SA EP 1" ProgramChange="27" />
+      <Patch Number="029" Name="SA EP 2" ProgramChange="28" />
+      <Patch Number="030" Name="Psy EP" ProgramChange="29" />
+      <Patch Number="031" Name="Wurly EP" ProgramChange="30" />
+      <Patch Number="032" Name="Wurly EP Trm" ProgramChange="31" />
+      <Patch Number="033" Name="Curly Wurly" ProgramChange="32" />
+      <Patch Number="034" Name="Super Wurly" ProgramChange="33" />
+      <Patch Number="035" Name="EP Legend 3" ProgramChange="34" />
+      <Patch Number="036" Name="EP Belle" ProgramChange="35" />
+      <Patch Number="037" Name="80's EP" ProgramChange="36" />
+      <Patch Number="038" Name="FM EP 1" ProgramChange="37" />
+      <Patch Number="039" Name="FM EP 2" ProgramChange="38" />
+      <Patch Number="040" Name="Sinus EP" ProgramChange="39" />
+      <Patch Number="041" Name="Spirit Tines" ProgramChange="40" />
+      <Patch Number="042" Name="Harpsichord2" ProgramChange="41" />
+      <Patch Number="043" Name="Clav 2" ProgramChange="42" />
+      <Patch Number="044" Name="Pulse Clav 2" ProgramChange="43" />
+      <Patch Number="045" Name="Pulse Clav 3" ProgramChange="44" />
+      <Patch Number="046" Name="Sweepin Clav" ProgramChange="45" />
+      <Patch Number="047" Name="Analog Clav" ProgramChange="46" />
+      <Patch Number="048" Name="Biting Clav" ProgramChange="47" />
+      <Patch Number="049" Name="Pulse Clv St" ProgramChange="48" />
+      <Patch Number="050" Name="Bell 1" ProgramChange="49" />
+      <Patch Number="051" Name="Bell 2" ProgramChange="50" />
+      <Patch Number="052" Name="Fantasy 1" ProgramChange="51" />
+      <Patch Number="053" Name="Fantasy 2" ProgramChange="52" />
+      <Patch Number="054" Name="D50 Fantasy" ProgramChange="53" />
+      <Patch Number="055" Name="D50 Bell" ProgramChange="54" />
+      <Patch Number="056" Name="Dreambell" ProgramChange="55" />
+      <Patch Number="057" Name="Dreaming Box" ProgramChange="56" />
+      <Patch Number="058" Name="Dreaming Bel" ProgramChange="57" />
+      <Patch Number="059" Name="Music Box 2" ProgramChange="58" />
+      <Patch Number="060" Name="Bell 3" ProgramChange="59" />
+      <Patch Number="061" Name="Bell 4" ProgramChange="60" />
+      <Patch Number="062" Name="Music Bells" ProgramChange="61" />
+      <Patch Number="063" Name="Kalimbells" ProgramChange="62" />
+      <Patch Number="064" Name="Org Bell" ProgramChange="63" />
+      <Patch Number="065" Name="Toy Box" ProgramChange="64" />
+      <Patch Number="066" Name="Soft Bell" ProgramChange="65" />
+      <Patch Number="067" Name="Analog Bell" ProgramChange="66" />
+      <Patch Number="068" Name="Carillon 2" ProgramChange="67" />
+      <Patch Number="069" Name="Tower Bell" ProgramChange="68" />
+      <Patch Number="070" Name="Bell Ring" ProgramChange="69" />
+      <Patch Number="071" Name="TubularBell2" ProgramChange="70" />
+      <Patch Number="072" Name="Vibraphone 2" ProgramChange="71" />
+      <Patch Number="073" Name="VibraphoneTr" ProgramChange="72" />
+      <Patch Number="074" Name="Jazz Vib" ProgramChange="73" />
+      <Patch Number="075" Name="BsMarimba 1" ProgramChange="74" />
+      <Patch Number="076" Name="BsMarimba 2" ProgramChange="75" />
+      <Patch Number="077" Name="Xylophone 2" ProgramChange="76" />
+      <Patch Number="078" Name="Xylophone 3" ProgramChange="77" />
+      <Patch Number="079" Name="Ethno Keys" ProgramChange="78" />
+      <Patch Number="080" Name="Steel Drums2" ProgramChange="79" />
+      <Patch Number="081" Name="Soft StlDrm" ProgramChange="80" />
+      <Patch Number="082" Name="Sine Mallet" ProgramChange="81" />
+      <Patch Number="083" Name="Rock Organ 1" ProgramChange="82" />
+      <Patch Number="084" Name="Rock Organ 2" ProgramChange="83" />
+      <Patch Number="085" Name="Rock Organ 3" ProgramChange="84" />
+      <Patch Number="086" Name="Rock Organ 4" ProgramChange="85" />
+      <Patch Number="087" Name="Rock Organ 5" ProgramChange="86" />
+      <Patch Number="088" Name="RotaryOrgan1" ProgramChange="87" />
+      <Patch Number="089" Name="RotaryOrgan2" ProgramChange="88" />
+      <Patch Number="090" Name="Perc.Organ 2" ProgramChange="89" />
+      <Patch Number="091" Name="Perc.Organ 3" ProgramChange="90" />
+      <Patch Number="092" Name="Perc.Organ 4" ProgramChange="91" />
+      <Patch Number="093" Name="E.Organ 1" ProgramChange="92" />
+      <Patch Number="094" Name="E.Organ 2" ProgramChange="93" />
+      <Patch Number="095" Name="E.Organ 3" ProgramChange="94" />
+      <Patch Number="096" Name="E.Organ 4" ProgramChange="95" />
+      <Patch Number="097" Name="E.Organ 5" ProgramChange="96" />
+      <Patch Number="098" Name="E.Organ 6" ProgramChange="97" />
+      <Patch Number="099" Name="E.Organ 7" ProgramChange="98" />
+      <Patch Number="100" Name="70's E.Org 1" ProgramChange="99" />
+      <Patch Number="101" Name="70's E.Org 2" ProgramChange="100" />
+      <Patch Number="102" Name="Grand Pipes" ProgramChange="101" />
+      <Patch Number="103" Name="Ana Organ 1" ProgramChange="102" />
+      <Patch Number="104" Name="Ana Organ 2" ProgramChange="103" />
+      <Patch Number="105" Name="Ana Organ 3" ProgramChange="104" />
+      <Patch Number="106" Name="Ana Organ 4" ProgramChange="105" />
+      <Patch Number="107" Name="Ana Organ 5" ProgramChange="106" />
+      <Patch Number="108" Name="AccordionIt2" ProgramChange="107" />
+      <Patch Number="109" Name="Musette" ProgramChange="108" />
+      <Patch Number="110" Name="Vodkakordion" ProgramChange="109" />
+      <Patch Number="111" Name="Nylon Gtr 3" ProgramChange="110" />
+      <Patch Number="112" Name="Nylon Gtr 4" ProgramChange="111" />
+      <Patch Number="113" Name="Folk Gtr 1" ProgramChange="112" />
+      <Patch Number="114" Name="Folk Gtr 2" ProgramChange="113" />
+      <Patch Number="115" Name="Folk Gtr 3" ProgramChange="114" />
+      <Patch Number="116" Name="Latin Gtr" ProgramChange="115" />
+      <Patch Number="117" Name="Aerial Harp" ProgramChange="116" />
+      <Patch Number="118" Name="LostParadise" ProgramChange="117" />
+      <Patch Number="119" Name="Indian Frtls" ProgramChange="118" />
+      <Patch Number="120" Name="Sitar 3" ProgramChange="119" />
+      <Patch Number="121" Name="Santur 2" ProgramChange="120" />
+      <Patch Number="122" Name="Santur 3" ProgramChange="121" />
+      <Patch Number="123" Name="Clean Gtr 2" ProgramChange="122" />
+      <Patch Number="124" Name="Clean Gtr 3" ProgramChange="123" />
+      <Patch Number="125" Name="Clean Gtr 4" ProgramChange="124" />
+      <Patch Number="126" Name="Jazz Guitar2" ProgramChange="125" />
+      <Patch Number="127" Name="Pick E.Gtr" ProgramChange="126" />
+      <Patch Number="128" Name="Funk Guitar2" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (ExPCM) 129-256">
+      <Patch Number="129" Name="Wet E.Gtr" ProgramChange="0" />
+      <Patch Number="130" Name="Pedal Steel2" ProgramChange="1" />
+      <Patch Number="131" Name="OverdriveGt2" ProgramChange="2" />
+      <Patch Number="132" Name="Dist Gtr 1" ProgramChange="3" />
+      <Patch Number="133" Name="Dist Gtr 2" ProgramChange="4" />
+      <Patch Number="134" Name="Dist Gtr 3" ProgramChange="5" />
+      <Patch Number="135" Name="Acoustic Bs2" ProgramChange="6" />
+      <Patch Number="136" Name="Fretless Bs2" ProgramChange="7" />
+      <Patch Number="137" Name="Finger Slap2" ProgramChange="8" />
+      <Patch Number="138" Name="Return2Base!" ProgramChange="9" />
+      <Patch Number="139" Name="R&amp;B Bass 1" ProgramChange="10" />
+      <Patch Number="140" Name="R&amp;B Bass 2" ProgramChange="11" />
+      <Patch Number="141" Name="R&amp;B Bass 3" ProgramChange="12" />
+      <Patch Number="142" Name="R&amp;B Bass 4" ProgramChange="13" />
+      <Patch Number="143" Name="R&amp;B Bass 5" ProgramChange="14" />
+      <Patch Number="144" Name="R&amp;B Bass 6" ProgramChange="15" />
+      <Patch Number="145" Name="MG Bass 1" ProgramChange="16" />
+      <Patch Number="146" Name="MG Bass 2" ProgramChange="17" />
+      <Patch Number="147" Name="MG Bass 3" ProgramChange="18" />
+      <Patch Number="148" Name="MG Bass 4" ProgramChange="19" />
+      <Patch Number="149" Name="MG Bass 5" ProgramChange="20" />
+      <Patch Number="150" Name="MG Bass 6" ProgramChange="21" />
+      <Patch Number="151" Name="MG Bass 7" ProgramChange="22" />
+      <Patch Number="152" Name="106 Bass 1" ProgramChange="23" />
+      <Patch Number="153" Name="Synth Bass 3" ProgramChange="24" />
+      <Patch Number="154" Name="Synth Bass 4" ProgramChange="25" />
+      <Patch Number="155" Name="MC202 Bass" ProgramChange="26" />
+      <Patch Number="156" Name="Pulse Bass" ProgramChange="27" />
+      <Patch Number="157" Name="Pedal Bass 1" ProgramChange="28" />
+      <Patch Number="158" Name="Pedal Bass 2" ProgramChange="29" />
+      <Patch Number="159" Name="Alpha Bass 1" ProgramChange="30" />
+      <Patch Number="160" Name="P5 Bass" ProgramChange="31" />
+      <Patch Number="161" Name="Modular Bs 1" ProgramChange="32" />
+      <Patch Number="162" Name="Modular Bs 2" ProgramChange="33" />
+      <Patch Number="163" Name="Modular Bs 3" ProgramChange="34" />
+      <Patch Number="164" Name="Synth Bass 5" ProgramChange="35" />
+      <Patch Number="165" Name="Intrusive Bs" ProgramChange="36" />
+      <Patch Number="166" Name="Reso Bass 1" ProgramChange="37" />
+      <Patch Number="167" Name="Reso Bass 2" ProgramChange="38" />
+      <Patch Number="168" Name="Reso Bass 3" ProgramChange="39" />
+      <Patch Number="169" Name="Reso Bass 4" ProgramChange="40" />
+      <Patch Number="170" Name="Reso Bass 5" ProgramChange="41" />
+      <Patch Number="171" Name="Rubber Bass2" ProgramChange="42" />
+      <Patch Number="172" Name="Reso Bass 6" ProgramChange="43" />
+      <Patch Number="173" Name="Reso Bass 7" ProgramChange="44" />
+      <Patch Number="174" Name="Reso Bass 8" ProgramChange="45" />
+      <Patch Number="175" Name="TB Bass 3" ProgramChange="46" />
+      <Patch Number="176" Name="Acid Bass 2" ProgramChange="47" />
+      <Patch Number="177" Name="Acid Bass 3" ProgramChange="48" />
+      <Patch Number="178" Name="Acid Bass 4" ProgramChange="49" />
+      <Patch Number="179" Name="Alpha Bass 2" ProgramChange="50" />
+      <Patch Number="180" Name="Alpha ResoBs" ProgramChange="51" />
+      <Patch Number="181" Name="Monster Bs 1" ProgramChange="52" />
+      <Patch Number="182" Name="Nu Saw Bass" ProgramChange="53" />
+      <Patch Number="183" Name="Nu RnB SawBs" ProgramChange="54" />
+      <Patch Number="184" Name="Monster Bs 2" ProgramChange="55" />
+      <Patch Number="185" Name="JunoSqr Bs 1" ProgramChange="56" />
+      <Patch Number="186" Name="JunoSqr Bs 2" ProgramChange="57" />
+      <Patch Number="187" Name="106 Bass 2" ProgramChange="58" />
+      <Patch Number="188" Name="Compu Bass 1" ProgramChange="59" />
+      <Patch Number="189" Name="Compu Bass 2" ProgramChange="60" />
+      <Patch Number="190" Name="Muffled Bass" ProgramChange="61" />
+      <Patch Number="191" Name="Garage Bass" ProgramChange="62" />
+      <Patch Number="192" Name="Sub Bass" ProgramChange="63" />
+      <Patch Number="193" Name="Flat Bass" ProgramChange="64" />
+      <Patch Number="194" Name="Brite Bass" ProgramChange="65" />
+      <Patch Number="195" Name="Pedal Bass 3" ProgramChange="66" />
+      <Patch Number="196" Name="Reso Bass 9" ProgramChange="67" />
+      <Patch Number="197" Name="Reso Bass10" ProgramChange="68" />
+      <Patch Number="198" Name="Ramp Bass" ProgramChange="69" />
+      <Patch Number="199" Name="Fat Bass" ProgramChange="70" />
+      <Patch Number="200" Name="80's Bass" ProgramChange="71" />
+      <Patch Number="201" Name="TB Bass 1" ProgramChange="72" />
+      <Patch Number="202" Name="TB Bass 2" ProgramChange="73" />
+      <Patch Number="203" Name="Mood Strings" ProgramChange="74" />
+      <Patch Number="204" Name="Hall Strings" ProgramChange="75" />
+      <Patch Number="205" Name="Strings 2" ProgramChange="76" />
+      <Patch Number="206" Name="Strings 3" ProgramChange="77" />
+      <Patch Number="207" Name="Strings 4" ProgramChange="78" />
+      <Patch Number="208" Name="Strings 5" ProgramChange="79" />
+      <Patch Number="209" Name="Strings 6" ProgramChange="80" />
+      <Patch Number="210" Name="Stage Str 1" ProgramChange="81" />
+      <Patch Number="211" Name="Stage Str 2" ProgramChange="82" />
+      <Patch Number="212" Name="Pop Strings" ProgramChange="83" />
+      <Patch Number="213" Name="Hybrid Str" ProgramChange="84" />
+      <Patch Number="214" Name="Marc.Str" ProgramChange="85" />
+      <Patch Number="215" Name="StringsStacc" ProgramChange="86" />
+      <Patch Number="216" Name="Pizz 1" ProgramChange="87" />
+      <Patch Number="217" Name="Pizz 2" ProgramChange="88" />
+      <Patch Number="218" Name="TapeStrings1" ProgramChange="89" />
+      <Patch Number="219" Name="TapeStrings2" ProgramChange="90" />
+      <Patch Number="220" Name="VintageStr 8" ProgramChange="91" />
+      <Patch Number="221" Name="Orc.Unison 1" ProgramChange="92" />
+      <Patch Number="222" Name="Orc.Unison 2" ProgramChange="93" />
+      <Patch Number="223" Name="Full Orc" ProgramChange="94" />
+      <Patch Number="224" Name="Cheezy Movie" ProgramChange="95" />
+      <Patch Number="225" Name="Housechord" ProgramChange="96" />
+      <Patch Number="226" Name="Pan Flute 2" ProgramChange="97" />
+      <Patch Number="227" Name="Pan Pipes" ProgramChange="98" />
+      <Patch Number="228" Name="Ocarina 2" ProgramChange="99" />
+      <Patch Number="229" Name="Trumpet 2" ProgramChange="100" />
+      <Patch Number="230" Name="Romantic Tp" ProgramChange="101" />
+      <Patch Number="231" Name="Soprano Sax2" ProgramChange="102" />
+      <Patch Number="232" Name="BreathyTenor" ProgramChange="103" />
+      <Patch Number="233" Name="Tenor Sax 2" ProgramChange="104" />
+      <Patch Number="234" Name="Brass 3" ProgramChange="105" />
+      <Patch Number="235" Name="Brass 4" ProgramChange="106" />
+      <Patch Number="236" Name="Brass 5" ProgramChange="107" />
+      <Patch Number="237" Name="Brass 6" ProgramChange="108" />
+      <Patch Number="238" Name="JP8 Brass 1" ProgramChange="109" />
+      <Patch Number="239" Name="JP8 Brass 2" ProgramChange="110" />
+      <Patch Number="240" Name="JP8 Brass 3" ProgramChange="111" />
+      <Patch Number="241" Name="JP8 Brass 4" ProgramChange="112" />
+      <Patch Number="242" Name="80's Brass 1" ProgramChange="113" />
+      <Patch Number="243" Name="80's Brass 2" ProgramChange="114" />
+      <Patch Number="244" Name="JP8 Brass 5" ProgramChange="115" />
+      <Patch Number="245" Name="Soft SynBrs1" ProgramChange="116" />
+      <Patch Number="246" Name="Soft SynBrs2" ProgramChange="117" />
+      <Patch Number="247" Name="Soft SynBrs3" ProgramChange="118" />
+      <Patch Number="248" Name="Reso Brass" ProgramChange="119" />
+      <Patch Number="249" Name="Juno Brass" ProgramChange="120" />
+      <Patch Number="250" Name="FM Brass" ProgramChange="121" />
+      <Patch Number="251" Name="80's Brass 3" ProgramChange="122" />
+      <Patch Number="252" Name="80's Brass 4" ProgramChange="123" />
+      <Patch Number="253" Name="80's Brass 5" ProgramChange="124" />
+      <Patch Number="254" Name="80's Brass 6" ProgramChange="125" />
+      <Patch Number="255" Name="80's Brass 7" ProgramChange="126" />
+      <Patch Number="256" Name="80's Brass 8" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (ExPCM) 257-384">
+      <Patch Number="257" Name="80's Brass 9" ProgramChange="0" />
+      <Patch Number="258" Name="80's Brass10" ProgramChange="1" />
+      <Patch Number="259" Name="JP Brass 2" ProgramChange="2" />
+      <Patch Number="260" Name="Warm SynBrs" ProgramChange="3" />
+      <Patch Number="261" Name="Brite SynBrs" ProgramChange="4" />
+      <Patch Number="262" Name="Express Brs" ProgramChange="5" />
+      <Patch Number="263" Name="EuroExpress1" ProgramChange="6" />
+      <Patch Number="264" Name="JP Brass 1" ProgramChange="7" />
+      <Patch Number="265" Name="Ox Brass" ProgramChange="8" />
+      <Patch Number="266" Name="Wide SynBrs" ProgramChange="9" />
+      <Patch Number="267" Name="106 Brass" ProgramChange="10" />
+      <Patch Number="268" Name="Poly Brass 1" ProgramChange="11" />
+      <Patch Number="269" Name="Poly Brass 2" ProgramChange="12" />
+      <Patch Number="270" Name="Dual Saw Brs" ProgramChange="13" />
+      <Patch Number="271" Name="VintageBrs 1" ProgramChange="14" />
+      <Patch Number="272" Name="VintageBrs 2" ProgramChange="15" />
+      <Patch Number="273" Name="Saw Lead 1" ProgramChange="16" />
+      <Patch Number="274" Name="Saw Lead 2" ProgramChange="17" />
+      <Patch Number="275" Name="Saw Lead 3" ProgramChange="18" />
+      <Patch Number="276" Name="Saw Lead 4" ProgramChange="19" />
+      <Patch Number="277" Name="Saw Lead 5" ProgramChange="20" />
+      <Patch Number="278" Name="Saw Lead 6" ProgramChange="21" />
+      <Patch Number="279" Name="Saw Lead 7" ProgramChange="22" />
+      <Patch Number="280" Name="Saw Lead 8" ProgramChange="23" />
+      <Patch Number="281" Name="Ana Vox Lead" ProgramChange="24" />
+      <Patch Number="282" Name="BellSaw Lead" ProgramChange="25" />
+      <Patch Number="283" Name="OSC-Sync" ProgramChange="26" />
+      <Patch Number="284" Name="Digi Lead" ProgramChange="27" />
+      <Patch Number="285" Name="EQ Lead" ProgramChange="28" />
+      <Patch Number="286" Name="Saw Lead 9" ProgramChange="29" />
+      <Patch Number="287" Name="Saw Lead 10" ProgramChange="30" />
+      <Patch Number="288" Name="Saw Lead 11" ProgramChange="31" />
+      <Patch Number="289" Name="Saw Lead 12" ProgramChange="32" />
+      <Patch Number="290" Name="Saw Lead 13" ProgramChange="33" />
+      <Patch Number="291" Name="Saw Lead 14" ProgramChange="34" />
+      <Patch Number="292" Name="Classic GR" ProgramChange="35" />
+      <Patch Number="293" Name="Bright GR" ProgramChange="36" />
+      <Patch Number="294" Name="Pro Fat Ld 1" ProgramChange="37" />
+      <Patch Number="295" Name="Fat GR Lead" ProgramChange="38" />
+      <Patch Number="296" Name="MODified Ld" ProgramChange="39" />
+      <Patch Number="297" Name="JupiterLead1" ProgramChange="40" />
+      <Patch Number="298" Name="JupiterLead2" ProgramChange="41" />
+      <Patch Number="299" Name="Saw Lead 15" ProgramChange="42" />
+      <Patch Number="300" Name="Classic Lead" ProgramChange="43" />
+      <Patch Number="301" Name="On Air" ProgramChange="44" />
+      <Patch Number="302" Name="Pro Fat Ld 2" ProgramChange="45" />
+      <Patch Number="303" Name="Ramp Lead" ProgramChange="46" />
+      <Patch Number="304" Name="Wormy Lead" ProgramChange="47" />
+      <Patch Number="305" Name="Waspy Lead" ProgramChange="48" />
+      <Patch Number="306" Name="Brass Lead" ProgramChange="49" />
+      <Patch Number="307" Name="Legato Tkno" ProgramChange="50" />
+      <Patch Number="308" Name="Follow Me" ProgramChange="51" />
+      <Patch Number="309" Name="Octa Juice" ProgramChange="52" />
+      <Patch Number="310" Name="Octa Saw" ProgramChange="53" />
+      <Patch Number="311" Name="Octa Sync" ProgramChange="54" />
+      <Patch Number="312" Name="Leading Sync" ProgramChange="55" />
+      <Patch Number="313" Name="Sync Lead" ProgramChange="56" />
+      <Patch Number="314" Name="A Leader" ProgramChange="57" />
+      <Patch Number="315" Name="Alpha Spit" ProgramChange="58" />
+      <Patch Number="316" Name="Air Lead" ProgramChange="59" />
+      <Patch Number="317" Name="Pulstar Lead" ProgramChange="60" />
+      <Patch Number="318" Name="Therasaw" ProgramChange="61" />
+      <Patch Number="319" Name="Juicy Lead" ProgramChange="62" />
+      <Patch Number="320" Name="Resoform" ProgramChange="63" />
+      <Patch Number="321" Name="Reso Saw" ProgramChange="64" />
+      <Patch Number="322" Name="Detune Ramp" ProgramChange="65" />
+      <Patch Number="323" Name="Sweep Saw" ProgramChange="66" />
+      <Patch Number="324" Name="Bell Lead" ProgramChange="67" />
+      <Patch Number="325" Name="Square Lead" ProgramChange="68" />
+      <Patch Number="326" Name="OB Lead" ProgramChange="69" />
+      <Patch Number="327" Name="Soft Lead" ProgramChange="70" />
+      <Patch Number="328" Name="Simple Tri" ProgramChange="71" />
+      <Patch Number="329" Name="Simple Sine" ProgramChange="72" />
+      <Patch Number="330" Name="Sine Lead 1" ProgramChange="73" />
+      <Patch Number="331" Name="Sine Lead 2" ProgramChange="74" />
+      <Patch Number="332" Name="Square Pipe" ProgramChange="75" />
+      <Patch Number="333" Name="Spooky Lead" ProgramChange="76" />
+      <Patch Number="334" Name="Pure Lead" ProgramChange="77" />
+      <Patch Number="335" Name="Round SQR" ProgramChange="78" />
+      <Patch Number="336" Name="Brite SQR" ProgramChange="79" />
+      <Patch Number="337" Name="Square SAW" ProgramChange="80" />
+      <Patch Number="338" Name="Simple SQR" ProgramChange="81" />
+      <Patch Number="339" Name="Sqr Lead" ProgramChange="82" />
+      <Patch Number="340" Name="Pulse Lead" ProgramChange="83" />
+      <Patch Number="341" Name="Octa Square" ProgramChange="84" />
+      <Patch Number="342" Name="Tranceformer" ProgramChange="85" />
+      <Patch Number="343" Name="CS Lead" ProgramChange="86" />
+      <Patch Number="344" Name="Mini Growl" ProgramChange="87" />
+      <Patch Number="345" Name="Hoover Again" ProgramChange="88" />
+      <Patch Number="346" Name="5th Voice" ProgramChange="89" />
+      <Patch Number="347" Name="Sweet House" ProgramChange="90" />
+      <Patch Number="348" Name="Juno-D Maj7" ProgramChange="91" />
+      <Patch Number="349" Name="Major 7" ProgramChange="92" />
+      <Patch Number="350" Name="Ju-D Fifths" ProgramChange="93" />
+      <Patch Number="351" Name="Dance Saws 1" ProgramChange="94" />
+      <Patch Number="352" Name="Seq 1" ProgramChange="95" />
+      <Patch Number="353" Name="Seq Pop" ProgramChange="96" />
+      <Patch Number="354" Name="Detune Saws" ProgramChange="97" />
+      <Patch Number="355" Name="Seq 2" ProgramChange="98" />
+      <Patch Number="356" Name="Seq 3" ProgramChange="99" />
+      <Patch Number="357" Name="Detune Seq" ProgramChange="100" />
+      <Patch Number="358" Name="Analog Seq" ProgramChange="101" />
+      <Patch Number="359" Name="LFO Saw" ProgramChange="102" />
+      <Patch Number="360" Name="Keep Going" ProgramChange="103" />
+      <Patch Number="361" Name="Electrostar" ProgramChange="104" />
+      <Patch Number="362" Name="Shimmer Pad" ProgramChange="105" />
+      <Patch Number="363" Name="Sci-Fi" ProgramChange="106" />
+      <Patch Number="364" Name="ResoSweep Dn" ProgramChange="107" />
+      <Patch Number="365" Name="909 Fx" ProgramChange="108" />
+      <Patch Number="366" Name="PolySweep Nz" ProgramChange="109" />
+      <Patch Number="367" Name="Passing By" ProgramChange="110" />
+      <Patch Number="368" Name="Cosmic Drops" ProgramChange="111" />
+      <Patch Number="369" Name="LoFi Piano" ProgramChange="112" />
+      <Patch Number="370" Name="FX Ramp" ProgramChange="113" />
+      <Patch Number="371" Name="Bubble 2" ProgramChange="114" />
+      <Patch Number="372" Name="Scratch 2" ProgramChange="115" />
+      <Patch Number="373" Name="Saws Key 1" ProgramChange="116" />
+      <Patch Number="374" Name="Saws Key 2" ProgramChange="117" />
+      <Patch Number="375" Name="Reso Key 1" ProgramChange="118" />
+      <Patch Number="376" Name="Analog Key" ProgramChange="119" />
+      <Patch Number="377" Name="Digital Key1" ProgramChange="120" />
+      <Patch Number="378" Name="Digital Key2" ProgramChange="121" />
+      <Patch Number="379" Name="Huge MIDI" ProgramChange="122" />
+      <Patch Number="380" Name="Dream Saws" ProgramChange="123" />
+      <Patch Number="381" Name="Dream Pulse" ProgramChange="124" />
+      <Patch Number="382" Name="Dream Trance" ProgramChange="125" />
+      <Patch Number="383" Name="Trance Synth" ProgramChange="126" />
+      <Patch Number="384" Name="Trance Keys" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Tone (ExPCM) 385-512">
+      <Patch Number="385" Name="Trance Saws" ProgramChange="0" />
+      <Patch Number="386" Name="Trancy" ProgramChange="1" />
+      <Patch Number="387" Name="S-Saw Poly" ProgramChange="2" />
+      <Patch Number="388" Name="Super Saws 1" ProgramChange="3" />
+      <Patch Number="389" Name="Analog Days" ProgramChange="4" />
+      <Patch Number="390" Name="Analog Saws" ProgramChange="5" />
+      <Patch Number="391" Name="Uni-G" ProgramChange="6" />
+      <Patch Number="392" Name="Digitaless" ProgramChange="7" />
+      <Patch Number="393" Name="Bustranza" ProgramChange="8" />
+      <Patch Number="394" Name="Jump Poly" ProgramChange="9" />
+      <Patch Number="395" Name="Super Saws 2" ProgramChange="10" />
+      <Patch Number="396" Name="Poly Synth 2" ProgramChange="11" />
+      <Patch Number="397" Name="Poly Synth 3" ProgramChange="12" />
+      <Patch Number="398" Name="Poly Synth 4" ProgramChange="13" />
+      <Patch Number="399" Name="Poly Synth 5" ProgramChange="14" />
+      <Patch Number="400" Name="Waspy Synth" ProgramChange="15" />
+      <Patch Number="401" Name="Vintage Key" ProgramChange="16" />
+      <Patch Number="402" Name="Str Machine" ProgramChange="17" />
+      <Patch Number="403" Name="Reso Key 2" ProgramChange="18" />
+      <Patch Number="404" Name="Reso Key 3" ProgramChange="19" />
+      <Patch Number="405" Name="EuroExpress2" ProgramChange="20" />
+      <Patch Number="406" Name="Fat Synth" ProgramChange="21" />
+      <Patch Number="407" Name="Hi Saw Band" ProgramChange="22" />
+      <Patch Number="408" Name="PWM Pad 1" ProgramChange="23" />
+      <Patch Number="409" Name="Ox Synth" ProgramChange="24" />
+      <Patch Number="410" Name="Heaven Key" ProgramChange="25" />
+      <Patch Number="411" Name="DigitalDream" ProgramChange="26" />
+      <Patch Number="412" Name="Dreamvox 1" ProgramChange="27" />
+      <Patch Number="413" Name="Dreamvox 2" ProgramChange="28" />
+      <Patch Number="414" Name="Sweet Keys" ProgramChange="29" />
+      <Patch Number="415" Name="Vox Key" ProgramChange="30" />
+      <Patch Number="416" Name="Air Key 1" ProgramChange="31" />
+      <Patch Number="417" Name="Air Key 2" ProgramChange="32" />
+      <Patch Number="418" Name="Stacc Heaven" ProgramChange="33" />
+      <Patch Number="419" Name="Dreamheaven" ProgramChange="34" />
+      <Patch Number="420" Name="Heaven Pad 1" ProgramChange="35" />
+      <Patch Number="421" Name="Heaven Pad 2" ProgramChange="36" />
+      <Patch Number="422" Name="Analog Dream" ProgramChange="37" />
+      <Patch Number="423" Name="DOC Stack" ProgramChange="38" />
+      <Patch Number="424" Name="Dance Saws 2" ProgramChange="39" />
+      <Patch Number="425" Name="Sync Key" ProgramChange="40" />
+      <Patch Number="426" Name="Harp Pad" ProgramChange="41" />
+      <Patch Number="427" Name="Sitar Pad" ProgramChange="42" />
+      <Patch Number="428" Name="Pipe Key" ProgramChange="43" />
+      <Patch Number="429" Name="80's Strings" ProgramChange="44" />
+      <Patch Number="430" Name="106 Strings" ProgramChange="45" />
+      <Patch Number="431" Name="Fading Str" ProgramChange="46" />
+      <Patch Number="432" Name="OB Strings" ProgramChange="47" />
+      <Patch Number="433" Name="Sawtooth Str" ProgramChange="48" />
+      <Patch Number="434" Name="JP Strings 1" ProgramChange="49" />
+      <Patch Number="435" Name="JP Strings 2" ProgramChange="50" />
+      <Patch Number="436" Name="PWM Str 1" ProgramChange="51" />
+      <Patch Number="437" Name="JX Strings" ProgramChange="52" />
+      <Patch Number="438" Name="VintageStr 1" ProgramChange="53" />
+      <Patch Number="439" Name="VintageStr 2" ProgramChange="54" />
+      <Patch Number="440" Name="VintageStr 3" ProgramChange="55" />
+      <Patch Number="441" Name="VintageStr 4" ProgramChange="56" />
+      <Patch Number="442" Name="VintageStr 5" ProgramChange="57" />
+      <Patch Number="443" Name="Airy Pad" ProgramChange="58" />
+      <Patch Number="444" Name="VintageStr 6" ProgramChange="59" />
+      <Patch Number="445" Name="VintageStr 7" ProgramChange="60" />
+      <Patch Number="446" Name="Nu Epic Pad" ProgramChange="61" />
+      <Patch Number="447" Name="Trance Pad" ProgramChange="62" />
+      <Patch Number="448" Name="Giant Sweep" ProgramChange="63" />
+      <Patch Number="449" Name="Voyager" ProgramChange="64" />
+      <Patch Number="450" Name="Stringship" ProgramChange="65" />
+      <Patch Number="451" Name="Soft Pad 6" ProgramChange="66" />
+      <Patch Number="452" Name="PWM Str 2" ProgramChange="67" />
+      <Patch Number="453" Name="PWM Pad 2" ProgramChange="68" />
+      <Patch Number="454" Name="Reso Pad" ProgramChange="69" />
+      <Patch Number="455" Name="Brite Wine" ProgramChange="70" />
+      <Patch Number="456" Name="Wine Pad" ProgramChange="71" />
+      <Patch Number="457" Name="Sweep Pad 2" ProgramChange="72" />
+      <Patch Number="458" Name="Sweep Pad 3" ProgramChange="73" />
+      <Patch Number="459" Name="Sweep Pad 4" ProgramChange="74" />
+      <Patch Number="460" Name="Angelis Pad" ProgramChange="75" />
+      <Patch Number="461" Name="TrnsSweepPad" ProgramChange="76" />
+      <Patch Number="462" Name="Scoop Pad 1" ProgramChange="77" />
+      <Patch Number="463" Name="Scoop Pad 2" ProgramChange="78" />
+      <Patch Number="464" Name="BPF Pad" ProgramChange="79" />
+      <Patch Number="465" Name="Bubble 3" ProgramChange="80" />
+      <Patch Number="466" Name="Strobe Pad" ProgramChange="81" />
+      <Patch Number="467" Name="5th Pad 2" ProgramChange="82" />
+      <Patch Number="468" Name="JP8 Strings1" ProgramChange="83" />
+      <Patch Number="469" Name="JP8 Strings2" ProgramChange="84" />
+      <Patch Number="470" Name="Soft Pad 1" ProgramChange="85" />
+      <Patch Number="471" Name="Soft Pad 3" ProgramChange="86" />
+      <Patch Number="472" Name="Soft Pad 4" ProgramChange="87" />
+      <Patch Number="473" Name="JP8 Hollow 1" ProgramChange="88" />
+      <Patch Number="474" Name="JP8 Hollow 2" ProgramChange="89" />
+      <Patch Number="475" Name="Hollow Pad 1" ProgramChange="90" />
+      <Patch Number="476" Name="Hollow Pad 2" ProgramChange="91" />
+      <Patch Number="477" Name="Heaven Pad 3" ProgramChange="92" />
+      <Patch Number="478" Name="Warm Heaven" ProgramChange="93" />
+      <Patch Number="479" Name="Heaven Pad 4" ProgramChange="94" />
+      <Patch Number="480" Name="Heaven Pad 5" ProgramChange="95" />
+      <Patch Number="481" Name="Oct Heaven" ProgramChange="96" />
+      <Patch Number="482" Name="FineWinePad1" ProgramChange="97" />
+      <Patch Number="483" Name="FineWinePad2" ProgramChange="98" />
+      <Patch Number="484" Name="Digital Pad" ProgramChange="99" />
+      <Patch Number="485" Name="5th Pad 1" ProgramChange="100" />
+      <Patch Number="486" Name="Fairy's Song" ProgramChange="101" />
+      <Patch Number="487" Name="Org Pad" ProgramChange="102" />
+      <Patch Number="488" Name="Bubble 4" ProgramChange="103" />
+      <Patch Number="489" Name="ParadisePad" ProgramChange="104" />
+      <Patch Number="490" Name="Soft PWM Pad" ProgramChange="105" />
+      <Patch Number="491" Name="Soft Pad 2" ProgramChange="106" />
+      <Patch Number="492" Name="Soft Pad 5" ProgramChange="107" />
+      <Patch Number="493" Name="Jazz Scat 1" ProgramChange="108" />
+      <Patch Number="494" Name="Jazz Scat 2" ProgramChange="109" />
+      <Patch Number="495" Name="Choir Pad" ProgramChange="110" />
+      <Patch Number="496" Name="Angels Choir" ProgramChange="111" />
+      <Patch Number="497" Name="Aerial Choir" ProgramChange="112" />
+      <Patch Number="498" Name="Doo Pad" ProgramChange="113" />
+      <Patch Number="499" Name="Humming 2" ProgramChange="114" />
+      <Patch Number="500" Name="Humming 3" ProgramChange="115" />
+      <Patch Number="501" Name="Gospel Hum" ProgramChange="116" />
+      <Patch Number="502" Name="Vox Pad 1" ProgramChange="117" />
+      <Patch Number="503" Name="Vox Pad 2" ProgramChange="118" />
+      <Patch Number="504" Name="VP-330 Chr" ProgramChange="119" />
+      <Patch Number="505" Name="80's Vox" ProgramChange="120" />
+      <Patch Number="506" Name="SynVox 2" ProgramChange="121" />
+      <Patch Number="507" Name="SynVox 3" ProgramChange="122" />
+      <Patch Number="508" Name="Mini Vox" ProgramChange="123" />
+      <Patch Number="509" Name="Chipmunk" ProgramChange="124" />
+      <Patch Number="510" Name="Sample Opera" ProgramChange="125" />
+      <Patch Number="511" Name="Sop Vox" ProgramChange="126" />
+      <Patch Number="512" Name="Sad Ceremony" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Capital">
+      <Patch Number="001" Name="Piano 1" ProgramChange="0" />
+      <Patch Number="002" Name="Piano 2" ProgramChange="1" />
+      <Patch Number="003" Name="Piano 3" ProgramChange="2" />
+      <Patch Number="004" Name="Honky-tonk" ProgramChange="3" />
+      <Patch Number="005" Name="E.Piano 1" ProgramChange="4" />
+      <Patch Number="006" Name="E.Piano 2" ProgramChange="5" />
+      <Patch Number="007" Name="Harpsichord" ProgramChange="6" />
+      <Patch Number="008" Name="Clav" ProgramChange="7" />
+      <Patch Number="009" Name="Celesta" ProgramChange="8" />
+      <Patch Number="010" Name="Glockenspiel" ProgramChange="9" />
+      <Patch Number="011" Name="Music Box" ProgramChange="10" />
+      <Patch Number="012" Name="Vibraphone" ProgramChange="11" />
+      <Patch Number="013" Name="Marimba" ProgramChange="12" />
+      <Patch Number="014" Name="Xylophone" ProgramChange="13" />
+      <Patch Number="015" Name="TubularBells" ProgramChange="14" />
+      <Patch Number="016" Name="Santur" ProgramChange="15" />
+      <Patch Number="017" Name="Organ 1" ProgramChange="16" />
+      <Patch Number="018" Name="Organ 2" ProgramChange="17" />
+      <Patch Number="019" Name="Organ 3" ProgramChange="18" />
+      <Patch Number="020" Name="Church Org 1" ProgramChange="19" />
+      <Patch Number="021" Name="Reed Organ" ProgramChange="20" />
+      <Patch Number="022" Name="Accordion Fr" ProgramChange="21" />
+      <Patch Number="023" Name="Harmonica" ProgramChange="22" />
+      <Patch Number="024" Name="Bandoneon" ProgramChange="23" />
+      <Patch Number="025" Name="Nylon Gtr 1" ProgramChange="24" />
+      <Patch Number="026" Name="Steel-str.Gt" ProgramChange="25" />
+      <Patch Number="027" Name="Jazz Guitar" ProgramChange="26" />
+      <Patch Number="028" Name="Clean Guitar" ProgramChange="27" />
+      <Patch Number="029" Name="Muted Guitar" ProgramChange="28" />
+      <Patch Number="030" Name="Overdrive Gt" ProgramChange="29" />
+      <Patch Number="031" Name="DistortionGt" ProgramChange="30" />
+      <Patch Number="032" Name="Gt Harmonics" ProgramChange="31" />
+      <Patch Number="033" Name="Acoustic Bs" ProgramChange="32" />
+      <Patch Number="034" Name="Fingered Bs" ProgramChange="33" />
+      <Patch Number="035" Name="Picked Bass" ProgramChange="34" />
+      <Patch Number="036" Name="Fretless Bs" ProgramChange="35" />
+      <Patch Number="037" Name="Slap Bass 1" ProgramChange="36" />
+      <Patch Number="038" Name="Slap Bass 2" ProgramChange="37" />
+      <Patch Number="039" Name="Synth Bass 1" ProgramChange="38" />
+      <Patch Number="040" Name="Synth Bass 2" ProgramChange="39" />
+      <Patch Number="041" Name="Violin" ProgramChange="40" />
+      <Patch Number="042" Name="Viola" ProgramChange="41" />
+      <Patch Number="043" Name="Cello" ProgramChange="42" />
+      <Patch Number="044" Name="Contrabass" ProgramChange="43" />
+      <Patch Number="045" Name="Tremolo Str" ProgramChange="44" />
+      <Patch Number="046" Name="PizzicatoStr" ProgramChange="45" />
+      <Patch Number="047" Name="Harp" ProgramChange="46" />
+      <Patch Number="048" Name="Timpani" ProgramChange="47" />
+      <Patch Number="049" Name="Strings" ProgramChange="48" />
+      <Patch Number="050" Name="Slow Strings" ProgramChange="49" />
+      <Patch Number="051" Name="Syn.Strings1" ProgramChange="50" />
+      <Patch Number="052" Name="Syn.Strings2" ProgramChange="51" />
+      <Patch Number="053" Name="Choir Aahs" ProgramChange="52" />
+      <Patch Number="054" Name="Voice Oohs" ProgramChange="53" />
+      <Patch Number="055" Name="SynVox" ProgramChange="54" />
+      <Patch Number="056" Name="OrchestraHit" ProgramChange="55" />
+      <Patch Number="057" Name="Trumpet" ProgramChange="56" />
+      <Patch Number="058" Name="Trombone 1" ProgramChange="57" />
+      <Patch Number="059" Name="Tuba" ProgramChange="58" />
+      <Patch Number="060" Name="MuteTrumpet1" ProgramChange="59" />
+      <Patch Number="061" Name="F.Horn Sect" ProgramChange="60" />
+      <Patch Number="062" Name="Brass 1" ProgramChange="61" />
+      <Patch Number="063" Name="Synth Brass1" ProgramChange="62" />
+      <Patch Number="064" Name="Synth Brass2" ProgramChange="63" />
+      <Patch Number="065" Name="Soprano Sax" ProgramChange="64" />
+      <Patch Number="066" Name="Alto Sax" ProgramChange="65" />
+      <Patch Number="067" Name="Tenor Sax" ProgramChange="66" />
+      <Patch Number="068" Name="Baritone Sax" ProgramChange="67" />
+      <Patch Number="069" Name="Oboe" ProgramChange="68" />
+      <Patch Number="070" Name="English Horn" ProgramChange="69" />
+      <Patch Number="071" Name="Bassoon" ProgramChange="70" />
+      <Patch Number="072" Name="Clarinet" ProgramChange="71" />
+      <Patch Number="073" Name="Piccolo" ProgramChange="72" />
+      <Patch Number="074" Name="Flute" ProgramChange="73" />
+      <Patch Number="075" Name="Recorder" ProgramChange="74" />
+      <Patch Number="076" Name="Pan Flute" ProgramChange="75" />
+      <Patch Number="077" Name="Bottle Blow" ProgramChange="76" />
+      <Patch Number="078" Name="Shakuhachi" ProgramChange="77" />
+      <Patch Number="079" Name="Whistle" ProgramChange="78" />
+      <Patch Number="080" Name="Ocarina" ProgramChange="79" />
+      <Patch Number="081" Name="Square Wave" ProgramChange="80" />
+      <Patch Number="082" Name="Saw Wave" ProgramChange="81" />
+      <Patch Number="083" Name="Syn.Calliope" ProgramChange="82" />
+      <Patch Number="084" Name="Chiffer Lead" ProgramChange="83" />
+      <Patch Number="085" Name="Charang" ProgramChange="84" />
+      <Patch Number="086" Name="Solo Vox" ProgramChange="85" />
+      <Patch Number="087" Name="5th Saw Wave" ProgramChange="86" />
+      <Patch Number="088" Name="Bass &amp; Lead" ProgramChange="87" />
+      <Patch Number="089" Name="Fantasia" ProgramChange="88" />
+      <Patch Number="090" Name="Warm Pad" ProgramChange="89" />
+      <Patch Number="091" Name="Poly Synth" ProgramChange="90" />
+      <Patch Number="092" Name="Space Voice" ProgramChange="91" />
+      <Patch Number="093" Name="Bowed Glass" ProgramChange="92" />
+      <Patch Number="094" Name="Metal Pad" ProgramChange="93" />
+      <Patch Number="095" Name="Halo Pad" ProgramChange="94" />
+      <Patch Number="096" Name="Sweep Pad" ProgramChange="95" />
+      <Patch Number="097" Name="Ice Rain" ProgramChange="96" />
+      <Patch Number="098" Name="Soundtrack" ProgramChange="97" />
+      <Patch Number="099" Name="Crystal" ProgramChange="98" />
+      <Patch Number="100" Name="Atmosphere" ProgramChange="99" />
+      <Patch Number="101" Name="Brightness" ProgramChange="100" />
+      <Patch Number="102" Name="Goblin" ProgramChange="101" />
+      <Patch Number="103" Name="Echo Drops" ProgramChange="102" />
+      <Patch Number="104" Name="Star Theme" ProgramChange="103" />
+      <Patch Number="105" Name="Sitar 1" ProgramChange="104" />
+      <Patch Number="106" Name="Banjo" ProgramChange="105" />
+      <Patch Number="107" Name="Shamisen" ProgramChange="106" />
+      <Patch Number="108" Name="Koto" ProgramChange="107" />
+      <Patch Number="109" Name="Kalimba" ProgramChange="108" />
+      <Patch Number="110" Name="Bagpipe" ProgramChange="109" />
+      <Patch Number="111" Name="Fiddle" ProgramChange="110" />
+      <Patch Number="112" Name="Shanai" ProgramChange="111" />
+      <Patch Number="113" Name="Tinkle Bell" ProgramChange="112" />
+      <Patch Number="114" Name="Agogo" ProgramChange="113" />
+      <Patch Number="115" Name="Steel Drums" ProgramChange="114" />
+      <Patch Number="116" Name="Woodblock" ProgramChange="115" />
+      <Patch Number="117" Name="Taiko" ProgramChange="116" />
+      <Patch Number="118" Name="Melo. Tom 1" ProgramChange="117" />
+      <Patch Number="119" Name="Synth Drum" ProgramChange="118" />
+      <Patch Number="120" Name="Reverse Cymb" ProgramChange="119" />
+      <Patch Number="121" Name="Gt FretNoise" ProgramChange="120" />
+      <Patch Number="122" Name="Breath Noise" ProgramChange="121" />
+      <Patch Number="123" Name="Seashore" ProgramChange="122" />
+      <Patch Number="124" Name="Bird" ProgramChange="123" />
+      <Patch Number="125" Name="Telephone 1" ProgramChange="124" />
+      <Patch Number="126" Name="Helicopter" ProgramChange="125" />
+      <Patch Number="127" Name="Applause" ProgramChange="126" />
+      <Patch Number="128" Name="Gun Shot" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #1">
+      <Patch Number="001" Name="Piano 1 w" ProgramChange="0" />
+      <Patch Number="002" Name="Piano 2 w" ProgramChange="1" />
+      <Patch Number="003" Name="Piano 3 w" ProgramChange="2" />
+      <Patch Number="004" Name="Honky-tonk w" ProgramChange="3" />
+      <Patch Number="005" Name="St.Soft EP" ProgramChange="4" />
+      <Patch Number="006" Name="Detuned EP" ProgramChange="5" />
+      <Patch Number="007" Name="Coupled Hps" ProgramChange="6" />
+      <Patch Number="008" Name="Pulse Clav" ProgramChange="7" />
+      <Patch Number="012" Name="Vibraphone w" ProgramChange="11" />
+      <Patch Number="013" Name="Marimba w" ProgramChange="12" />
+      <Patch Number="015" Name="Church Bell" ProgramChange="14" />
+      <Patch Number="017" Name="Trem. Organ" ProgramChange="16" />
+      <Patch Number="018" Name="Chorus Organ" ProgramChange="17" />
+      <Patch Number="020" Name="Church Org 2" ProgramChange="19" />
+      <Patch Number="021" Name="Puff Organ" ProgramChange="20" />
+      <Patch Number="022" Name="Accordion It" ProgramChange="21" />
+      <Patch Number="025" Name="Ukulele" ProgramChange="24" />
+      <Patch Number="026" Name="12-str.Gtr" ProgramChange="25" />
+      <Patch Number="027" Name="Pedal Steel" ProgramChange="26" />
+      <Patch Number="028" Name="Chorus Gtr" ProgramChange="27" />
+      <Patch Number="029" Name="Funk Pop" ProgramChange="28" />
+      <Patch Number="030" Name="Guitar Pinch" ProgramChange="29" />
+      <Patch Number="031" Name="Gt Feedback1" ProgramChange="30" />
+      <Patch Number="032" Name="Gt Feedback2" ProgramChange="31" />
+      <Patch Number="034" Name="Finger Slap" ProgramChange="33" />
+      <Patch Number="039" Name="SynthBass101" ProgramChange="38" />
+      <Patch Number="040" Name="SynSlap Bass" ProgramChange="39" />
+      <Patch Number="041" Name="Slow Violin" ProgramChange="40" />
+      <Patch Number="047" Name="Yang Qin" ProgramChange="46" />
+      <Patch Number="049" Name="Orchestra" ProgramChange="48" />
+      <Patch Number="051" Name="Syn.Strings3" ProgramChange="50" />
+      <Patch Number="053" Name="Chorus Aahs" ProgramChange="52" />
+      <Patch Number="054" Name="Humming" ProgramChange="53" />
+      <Patch Number="055" Name="Analog Voice" ProgramChange="54" />
+      <Patch Number="056" Name="Bass Hit" ProgramChange="55" />
+      <Patch Number="057" Name="Dark Trumpet" ProgramChange="56" />
+      <Patch Number="058" Name="Trombone 2" ProgramChange="57" />
+      <Patch Number="060" Name="MuteTrumpet2" ProgramChange="59" />
+      <Patch Number="061" Name="French Horn" ProgramChange="60" />
+      <Patch Number="062" Name="Brass 2" ProgramChange="61" />
+      <Patch Number="063" Name="JP Brass" ProgramChange="62" />
+      <Patch Number="064" Name="SynBrass sfz" ProgramChange="63" />
+      <Patch Number="081" Name="MG Square" ProgramChange="80" />
+      <Patch Number="082" Name="OB2 Saw" ProgramChange="81" />
+      <Patch Number="085" Name="Wire Lead" ProgramChange="84" />
+      <Patch Number="088" Name="Delayed Lead" ProgramChange="87" />
+      <Patch Number="090" Name="Sine Pad" ProgramChange="89" />
+      <Patch Number="092" Name="Itopia" ProgramChange="91" />
+      <Patch Number="099" Name="Syn Mallet" ProgramChange="98" />
+      <Patch Number="103" Name="Echo Bell" ProgramChange="102" />
+      <Patch Number="105" Name="Sitar 2" ProgramChange="104" />
+      <Patch Number="108" Name="Taisho Koto" ProgramChange="107" />
+      <Patch Number="116" Name="Castanets" ProgramChange="115" />
+      <Patch Number="117" Name="Concert BD" ProgramChange="116" />
+      <Patch Number="118" Name="Melo. Tom 2" ProgramChange="117" />
+      <Patch Number="119" Name="808 Tom" ProgramChange="118" />
+      <Patch Number="121" Name="Gt Cut Noise" ProgramChange="120" />
+      <Patch Number="122" Name="Fl.Key Click" ProgramChange="121" />
+      <Patch Number="123" Name="Rain" ProgramChange="122" />
+      <Patch Number="124" Name="Dog" ProgramChange="123" />
+      <Patch Number="125" Name="Telephone 2" ProgramChange="124" />
+      <Patch Number="126" Name="Car Engine" ProgramChange="125" />
+      <Patch Number="127" Name="Laughing" ProgramChange="126" />
+      <Patch Number="128" Name="Machine Gun" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #2">
+      <Patch Number="001" Name="European Pf" ProgramChange="0" />
+      <Patch Number="005" Name="EP Legend 1" ProgramChange="4" />
+      <Patch Number="006" Name="St.FM EP" ProgramChange="5" />
+      <Patch Number="007" Name="Harpsi w" ProgramChange="6" />
+      <Patch Number="015" Name="Carillon" ProgramChange="14" />
+      <Patch Number="017" Name="60's Organ" ProgramChange="16" />
+      <Patch Number="018" Name="Perc. Organ" ProgramChange="17" />
+      <Patch Number="020" Name="Church Org 3" ProgramChange="19" />
+      <Patch Number="025" Name="Nylon Gtr 1o" ProgramChange="24" />
+      <Patch Number="026" Name="Mandolin" ProgramChange="25" />
+      <Patch Number="028" Name="Mid Tone Gtr" ProgramChange="27" />
+      <Patch Number="029" Name="Funk Guitar" ProgramChange="28" />
+      <Patch Number="031" Name="Dist Rtm Gtr" ProgramChange="30" />
+      <Patch Number="039" Name="Acid Bass" ProgramChange="38" />
+      <Patch Number="040" Name="Rubber Bass" ProgramChange="39" />
+      <Patch Number="049" Name="Oct Strings" ProgramChange="48" />
+      <Patch Number="056" Name="6th Hit" ProgramChange="55" />
+      <Patch Number="058" Name="Bright Tb" ProgramChange="57" />
+      <Patch Number="063" Name="Oct SynBrass" ProgramChange="62" />
+      <Patch Number="064" Name="Velo Brass" ProgramChange="63" />
+      <Patch Number="081" Name="2600 Sine" ProgramChange="80" />
+      <Patch Number="082" Name="Doctor Solo" ProgramChange="81" />
+      <Patch Number="103" Name="Echo Pan" ProgramChange="102" />
+      <Patch Number="119" Name="Elec Perc" ProgramChange="118" />
+      <Patch Number="121" Name="String Slap" ProgramChange="120" />
+      <Patch Number="123" Name="Thunder" ProgramChange="122" />
+      <Patch Number="124" Name="Horse Gallop" ProgramChange="123" />
+      <Patch Number="125" Name="DoorCreaking" ProgramChange="124" />
+      <Patch Number="126" Name="Car Stop" ProgramChange="125" />
+      <Patch Number="127" Name="Screaming" ProgramChange="126" />
+      <Patch Number="128" Name="Laser Gun" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #3">
+      <Patch Number="005" Name="Wurly" ProgramChange="4" />
+      <Patch Number="006" Name="EP Legend 2" ProgramChange="5" />
+      <Patch Number="007" Name="Harpsi o" ProgramChange="6" />
+      <Patch Number="017" Name="70's E.Organ" ProgramChange="16" />
+      <Patch Number="025" Name="Nylon Gtr 2" ProgramChange="24" />
+      <Patch Number="026" Name="Steel + Body" ProgramChange="25" />
+      <Patch Number="029" Name="Jazz Man" ProgramChange="28" />
+      <Patch Number="039" Name="Clav Bass" ProgramChange="38" />
+      <Patch Number="040" Name="Attack Pulse" ProgramChange="39" />
+      <Patch Number="056" Name="Euro Hit" ProgramChange="55" />
+      <Patch Number="063" Name="Jump Brass" ProgramChange="62" />
+      <Patch Number="082" Name="Natural Lead" ProgramChange="81" />
+      <Patch Number="123" Name="Wind" ProgramChange="122" />
+      <Patch Number="124" Name="Bird 2" ProgramChange="123" />
+      <Patch Number="125" Name="Door" ProgramChange="124" />
+      <Patch Number="126" Name="Car Pass" ProgramChange="125" />
+      <Patch Number="127" Name="Punch" ProgramChange="126" />
+      <Patch Number="128" Name="Explosion" ProgramChange="127" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #4">
+      <Patch Number="006" Name="EP Phase" ProgramChange="5" />
+      <Patch Number="039" Name="Hammer Bass" ProgramChange="38" />
+      <Patch Number="082" Name="SequencedSaw" ProgramChange="81" />
+      <Patch Number="123" Name="Stream" ProgramChange="122" />
+      <Patch Number="125" Name="Scratch" ProgramChange="124" />
+      <Patch Number="126" Name="Car Crash" ProgramChange="125" />
+      <Patch Number="127" Name="Heart Beat" ProgramChange="126" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #5">
+      <Patch Number="123" Name="Bubble" ProgramChange="122" />
+      <Patch Number="125" Name="Wind Chimes" ProgramChange="124" />
+      <Patch Number="126" Name="Siren" ProgramChange="125" />
+      <Patch Number="127" Name="Footsteps" ProgramChange="126" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #6">
+      <Patch Number="126" Name="Train" ProgramChange="125" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #7">
+      <Patch Number="126" Name="Jetplane" ProgramChange="125" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #8">
+      <Patch Number="126" Name="Starship" ProgramChange="125" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Tone Var #9">
+      <Patch Number="126" Name="Burst Noise" ProgramChange="125" />
+    </PatchNameList>
+    <PatchNameList Name="Studio Set">
+      <Patch Number="001" Name="Integra Preview" ProgramChange="0" />
+      <Patch Number="002" Name="Full Orch Set" ProgramChange="1" />
+      <Patch Number="003" Name="Chamber Orch Set" ProgramChange="2" />
+      <Patch Number="004" Name="Electro Set" ProgramChange="3" />
+      <Patch Number="005" Name="Techno Set" ProgramChange="4" />
+      <Patch Number="006" Name="Rock Band Set" ProgramChange="5" />
+      <Patch Number="007" Name="Jazz Band Set" ProgramChange="6" />
+      <Patch Number="008" Name="Big Band Set" ProgramChange="7" />
+      <Patch Number="009" Name="Ac Pop Set" ProgramChange="8" />
+      <Patch Number="010" Name="R&amp;B Set" ProgramChange="9" />
+      <Patch Number="011" Name="Country Set" ProgramChange="10" />
+      <Patch Number="012" Name="World Pop Set" ProgramChange="11" />
+      <Patch Number="013" Name="Keyboard Set" ProgramChange="12" />
+      <Patch Number="014" Name="Guitar Set" ProgramChange="13" />
+      <Patch Number="015" Name="House Set" ProgramChange="14" />
+      <Patch Number="016" Name="Game Set" ProgramChange="15" />
+      <Patch Number="017" Name="INIT STUDIO" ProgramChange="16" />
+      <Patch Number="018" Name="INIT STUDIO" ProgramChange="17" />
+      <Patch Number="019" Name="INIT STUDIO" ProgramChange="18" />
+      <Patch Number="020" Name="INIT STUDIO" ProgramChange="19" />
+      <Patch Number="021" Name="INIT STUDIO" ProgramChange="20" />
+      <Patch Number="022" Name="INIT STUDIO" ProgramChange="21" />
+      <Patch Number="023" Name="INIT STUDIO" ProgramChange="22" />
+      <Patch Number="024" Name="INIT STUDIO" ProgramChange="23" />
+      <Patch Number="025" Name="INIT STUDIO" ProgramChange="24" />
+      <Patch Number="026" Name="INIT STUDIO" ProgramChange="25" />
+      <Patch Number="027" Name="INIT STUDIO" ProgramChange="26" />
+      <Patch Number="028" Name="INIT STUDIO" ProgramChange="27" />
+      <Patch Number="029" Name="INIT STUDIO" ProgramChange="28" />
+      <Patch Number="030" Name="INIT STUDIO" ProgramChange="29" />
+      <Patch Number="031" Name="INIT STUDIO" ProgramChange="30" />
+      <Patch Number="032" Name="INIT STUDIO" ProgramChange="31" />
+      <Patch Number="033" Name="INIT STUDIO" ProgramChange="32" />
+      <Patch Number="034" Name="INIT STUDIO" ProgramChange="33" />
+      <Patch Number="035" Name="INIT STUDIO" ProgramChange="34" />
+      <Patch Number="036" Name="INIT STUDIO" ProgramChange="35" />
+      <Patch Number="037" Name="INIT STUDIO" ProgramChange="36" />
+      <Patch Number="038" Name="INIT STUDIO" ProgramChange="37" />
+      <Patch Number="039" Name="INIT STUDIO" ProgramChange="38" />
+      <Patch Number="040" Name="INIT STUDIO" ProgramChange="39" />
+      <Patch Number="041" Name="INIT STUDIO" ProgramChange="40" />
+      <Patch Number="042" Name="INIT STUDIO" ProgramChange="41" />
+      <Patch Number="043" Name="INIT STUDIO" ProgramChange="42" />
+      <Patch Number="044" Name="INIT STUDIO" ProgramChange="43" />
+      <Patch Number="045" Name="INIT STUDIO" ProgramChange="44" />
+      <Patch Number="046" Name="INIT STUDIO" ProgramChange="45" />
+      <Patch Number="047" Name="INIT STUDIO" ProgramChange="46" />
+      <Patch Number="048" Name="INIT STUDIO" ProgramChange="47" />
+      <Patch Number="049" Name="INIT STUDIO" ProgramChange="48" />
+      <Patch Number="050" Name="INIT STUDIO" ProgramChange="49" />
+      <Patch Number="051" Name="INIT STUDIO" ProgramChange="50" />
+      <Patch Number="052" Name="INIT STUDIO" ProgramChange="51" />
+      <Patch Number="053" Name="INIT STUDIO" ProgramChange="52" />
+      <Patch Number="054" Name="INIT STUDIO" ProgramChange="53" />
+      <Patch Number="055" Name="INIT STUDIO" ProgramChange="54" />
+      <Patch Number="056" Name="INIT STUDIO" ProgramChange="55" />
+      <Patch Number="057" Name="INIT STUDIO" ProgramChange="56" />
+      <Patch Number="058" Name="INIT STUDIO" ProgramChange="57" />
+      <Patch Number="059" Name="INIT STUDIO" ProgramChange="58" />
+      <Patch Number="060" Name="INIT STUDIO" ProgramChange="59" />
+      <Patch Number="061" Name="INIT STUDIO" ProgramChange="60" />
+      <Patch Number="062" Name="INIT STUDIO" ProgramChange="61" />
+      <Patch Number="063" Name="INIT STUDIO" ProgramChange="62" />
+      <Patch Number="064" Name="INIT STUDIO" ProgramChange="63" />
+    </PatchNameList>
+    <PatchNameList Name="User PCM Drum Kit">
+      <Patch Number="001" Name="INIT KIT" ProgramChange="0" />
+      <Patch Number="002" Name="INIT KIT" ProgramChange="1" />
+      <Patch Number="003" Name="INIT KIT" ProgramChange="2" />
+      <Patch Number="004" Name="INIT KIT" ProgramChange="3" />
+      <Patch Number="005" Name="INIT KIT" ProgramChange="4" />
+      <Patch Number="006" Name="INIT KIT" ProgramChange="5" />
+      <Patch Number="007" Name="INIT KIT" ProgramChange="6" />
+      <Patch Number="008" Name="INIT KIT" ProgramChange="7" />
+      <Patch Number="009" Name="INIT KIT" ProgramChange="8" />
+      <Patch Number="010" Name="INIT KIT" ProgramChange="9" />
+      <Patch Number="011" Name="INIT KIT" ProgramChange="10" />
+      <Patch Number="012" Name="INIT KIT" ProgramChange="11" />
+      <Patch Number="013" Name="INIT KIT" ProgramChange="12" />
+      <Patch Number="014" Name="INIT KIT" ProgramChange="13" />
+      <Patch Number="015" Name="INIT KIT" ProgramChange="14" />
+      <Patch Number="016" Name="INIT KIT" ProgramChange="15" />
+      <Patch Number="017" Name="INIT KIT" ProgramChange="16" />
+      <Patch Number="018" Name="INIT KIT" ProgramChange="17" />
+      <Patch Number="019" Name="INIT KIT" ProgramChange="18" />
+      <Patch Number="020" Name="INIT KIT" ProgramChange="19" />
+      <Patch Number="021" Name="INIT KIT" ProgramChange="20" />
+      <Patch Number="022" Name="INIT KIT" ProgramChange="21" />
+      <Patch Number="023" Name="INIT KIT" ProgramChange="22" />
+      <Patch Number="024" Name="INIT KIT" ProgramChange="23" />
+      <Patch Number="025" Name="INIT KIT" ProgramChange="24" />
+      <Patch Number="026" Name="INIT KIT" ProgramChange="25" />
+      <Patch Number="027" Name="INIT KIT" ProgramChange="26" />
+      <Patch Number="028" Name="INIT KIT" ProgramChange="27" />
+      <Patch Number="029" Name="INIT KIT" ProgramChange="28" />
+      <Patch Number="030" Name="INIT KIT" ProgramChange="29" />
+      <Patch Number="031" Name="INIT KIT" ProgramChange="30" />
+      <Patch Number="032" Name="INIT KIT" ProgramChange="31" />
+    </PatchNameList>
+    <PatchNameList Name="Preset PCM Drum Kit">
+      <Patch Number="001" Name="PopDrumSet 1" ProgramChange="0" />
+      <Patch Number="002" Name="PopDrumSet 2" ProgramChange="1" />
+      <Patch Number="003" Name="PowerDrumSet" ProgramChange="2" />
+      <Patch Number="004" Name="RaveDrumSet" ProgramChange="3" />
+      <Patch Number="005" Name="JazzDrumSet2" ProgramChange="4" />
+      <Patch Number="006" Name="OrchDrumSet" ProgramChange="5" />
+      <Patch Number="007" Name="PowerDrmSet2" ProgramChange="6" />
+      <Patch Number="008" Name="PowerRaveSet" ProgramChange="7" />
+      <Patch Number="009" Name="XV Pop Kit" ProgramChange="8" />
+      <Patch Number="010" Name="XV Rock Kit" ProgramChange="9" />
+      <Patch Number="011" Name="XV Jazz Kit" ProgramChange="10" />
+      <Patch Number="012" Name="XV Rust Kit" ProgramChange="11" />
+      <Patch Number="013" Name="XV WayHipKit" ProgramChange="12" />
+      <Patch Number="014" Name="XV Bully Kit" ProgramChange="13" />
+    </PatchNameList>
+    <PatchNameList Name="User SN Drum Kit">
+      <Patch Number="001" Name="INIT KIT" ProgramChange="0" />
+      <Patch Number="002" Name="INIT KIT" ProgramChange="1" />
+      <Patch Number="003" Name="INIT KIT" ProgramChange="2" />
+      <Patch Number="004" Name="INIT KIT" ProgramChange="3" />
+      <Patch Number="005" Name="INIT KIT" ProgramChange="4" />
+      <Patch Number="006" Name="INIT KIT" ProgramChange="5" />
+      <Patch Number="007" Name="INIT KIT" ProgramChange="6" />
+      <Patch Number="008" Name="INIT KIT" ProgramChange="7" />
+      <Patch Number="009" Name="INIT KIT" ProgramChange="8" />
+      <Patch Number="010" Name="INIT KIT" ProgramChange="9" />
+      <Patch Number="011" Name="INIT KIT" ProgramChange="10" />
+      <Patch Number="012" Name="INIT KIT" ProgramChange="11" />
+      <Patch Number="013" Name="INIT KIT" ProgramChange="12" />
+      <Patch Number="014" Name="INIT KIT" ProgramChange="13" />
+      <Patch Number="015" Name="INIT KIT" ProgramChange="14" />
+      <Patch Number="016" Name="INIT KIT" ProgramChange="15" />
+      <Patch Number="017" Name="INIT KIT" ProgramChange="16" />
+      <Patch Number="018" Name="INIT KIT" ProgramChange="17" />
+      <Patch Number="019" Name="INIT KIT" ProgramChange="18" />
+      <Patch Number="020" Name="INIT KIT" ProgramChange="19" />
+      <Patch Number="021" Name="INIT KIT" ProgramChange="20" />
+      <Patch Number="022" Name="INIT KIT" ProgramChange="21" />
+      <Patch Number="023" Name="INIT KIT" ProgramChange="22" />
+      <Patch Number="024" Name="INIT KIT" ProgramChange="23" />
+      <Patch Number="025" Name="INIT KIT" ProgramChange="24" />
+      <Patch Number="026" Name="INIT KIT" ProgramChange="25" />
+      <Patch Number="027" Name="INIT KIT" ProgramChange="26" />
+      <Patch Number="028" Name="INIT KIT" ProgramChange="27" />
+      <Patch Number="029" Name="INIT KIT" ProgramChange="28" />
+      <Patch Number="030" Name="INIT KIT" ProgramChange="29" />
+      <Patch Number="031" Name="INIT KIT" ProgramChange="30" />
+      <Patch Number="032" Name="INIT KIT" ProgramChange="31" />
+      <Patch Number="033" Name="INIT KIT" ProgramChange="32" />
+      <Patch Number="034" Name="INIT KIT" ProgramChange="33" />
+      <Patch Number="035" Name="INIT KIT" ProgramChange="34" />
+      <Patch Number="036" Name="INIT KIT" ProgramChange="35" />
+      <Patch Number="037" Name="INIT KIT" ProgramChange="36" />
+      <Patch Number="038" Name="INIT KIT" ProgramChange="37" />
+      <Patch Number="039" Name="INIT KIT" ProgramChange="38" />
+      <Patch Number="040" Name="INIT KIT" ProgramChange="39" />
+      <Patch Number="041" Name="INIT KIT" ProgramChange="40" />
+      <Patch Number="042" Name="INIT KIT" ProgramChange="41" />
+      <Patch Number="043" Name="INIT KIT" ProgramChange="42" />
+      <Patch Number="044" Name="INIT KIT" ProgramChange="43" />
+      <Patch Number="045" Name="INIT KIT" ProgramChange="44" />
+      <Patch Number="046" Name="INIT KIT" ProgramChange="45" />
+      <Patch Number="047" Name="INIT KIT" ProgramChange="46" />
+      <Patch Number="048" Name="INIT KIT" ProgramChange="47" />
+      <Patch Number="049" Name="INIT KIT" ProgramChange="48" />
+      <Patch Number="050" Name="INIT KIT" ProgramChange="49" />
+      <Patch Number="051" Name="INIT KIT" ProgramChange="50" />
+      <Patch Number="052" Name="INIT KIT" ProgramChange="51" />
+      <Patch Number="053" Name="INIT KIT" ProgramChange="52" />
+      <Patch Number="054" Name="INIT KIT" ProgramChange="53" />
+      <Patch Number="055" Name="INIT KIT" ProgramChange="54" />
+      <Patch Number="056" Name="INIT KIT" ProgramChange="55" />
+      <Patch Number="057" Name="INIT KIT" ProgramChange="56" />
+      <Patch Number="058" Name="INIT KIT" ProgramChange="57" />
+      <Patch Number="059" Name="INIT KIT" ProgramChange="58" />
+      <Patch Number="060" Name="INIT KIT" ProgramChange="59" />
+      <Patch Number="061" Name="INIT KIT" ProgramChange="60" />
+      <Patch Number="062" Name="INIT KIT" ProgramChange="61" />
+      <Patch Number="063" Name="INIT KIT" ProgramChange="62" />
+      <Patch Number="064" Name="INIT KIT" ProgramChange="63" />
+    </PatchNameList>
+    <PatchNameList Name="Preset SN Drum Kit">
+      <Patch Number="001" Name="Session Kit" ProgramChange="0" />
+      <Patch Number="002" Name="Studio Kit" ProgramChange="1" />
+      <Patch Number="003" Name="Tight Kit" ProgramChange="2" />
+      <Patch Number="004" Name="Regular Kit" ProgramChange="3" />
+      <Patch Number="005" Name="Dry Funk Kit" ProgramChange="4" />
+      <Patch Number="006" Name="Loud Gig" ProgramChange="5" />
+      <Patch Number="007" Name="Jazz Kit" ProgramChange="6" />
+      <Patch Number="008" Name="Dry Jazz Kit" ProgramChange="7" />
+      <Patch Number="009" Name="Jazz Brushes" ProgramChange="8" />
+      <Patch Number="010" Name="LA Studio" ProgramChange="9" />
+      <Patch Number="011" Name="Medium Room" ProgramChange="10" />
+      <Patch Number="012" Name="Vintage Rock" ProgramChange="11" />
+      <Patch Number="013" Name="MuffledMaple" ProgramChange="12" />
+      <Patch Number="014" Name="Solid Kit" ProgramChange="13" />
+      <Patch Number="015" Name="Alternative" ProgramChange="14" />
+      <Patch Number="016" Name="80's Live" ProgramChange="15" />
+      <Patch Number="017" Name="Fat Kit" ProgramChange="16" />
+      <Patch Number="018" Name="Big Garage" ProgramChange="17" />
+      <Patch Number="019" Name="Bit Crash" ProgramChange="18" />
+      <Patch Number="020" Name="Lo-Fi Kit" ProgramChange="19" />
+      <Patch Number="021" Name="Orchestra" ProgramChange="20" />
+      <Patch Number="022" Name="Snare Menu" ProgramChange="21" />
+      <Patch Number="023" Name="BD/T/HH Menu" ProgramChange="22" />
+      <Patch Number="024" Name="Cymbal Menu" ProgramChange="23" />
+      <Patch Number="025" Name="Perc Menu 1" ProgramChange="24" />
+      <Patch Number="026" Name="Perc Menu 2" ProgramChange="25" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion SN Drum (ExSN6)">
+      <Patch Number="001" Name="SFX 1" ProgramChange="0" />
+      <Patch Number="002" Name="SFX 2" ProgramChange="1" />
+      <Patch Number="003" Name="SFX 1 Mono" ProgramChange="2" />
+      <Patch Number="004" Name="SFX 2 Mono" ProgramChange="3" />
+      <Patch Number="005" Name="SFX Menu 1" ProgramChange="4" />
+      <Patch Number="006" Name="SFX Menu 2" ProgramChange="5" />
+      <Patch Number="007" Name="SFX Menu 3" ProgramChange="6" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX01)">
+      <Patch Number="001" Name="Poppin KIT" ProgramChange="0" />
+      <Patch Number="002" Name="StdRock1 KIT" ProgramChange="1" />
+      <Patch Number="003" Name="TightRck1KIT" ProgramChange="2" />
+      <Patch Number="004" Name="StudioJz KIT" ProgramChange="3" />
+      <Patch Number="005" Name="Latin KIT" ProgramChange="4" />
+      <Patch Number="006" Name="BigRock1 KIT" ProgramChange="5" />
+      <Patch Number="007" Name="Pwr Blld KIT" ProgramChange="6" />
+      <Patch Number="008" Name="TightRck2KIT" ProgramChange="7" />
+      <Patch Number="009" Name="Dry Rock KIT" ProgramChange="8" />
+      <Patch Number="010" Name="StdRock2 KIT" ProgramChange="9" />
+      <Patch Number="011" Name="OhBabyRckKIT" ProgramChange="10" />
+      <Patch Number="012" Name="StudioFatKIT" ProgramChange="11" />
+      <Patch Number="013" Name="RoomBlld KIT" ProgramChange="12" />
+      <Patch Number="014" Name="Big Blld KIT" ProgramChange="13" />
+      <Patch Number="015" Name="BigRock2 KIT" ProgramChange="14" />
+      <Patch Number="016" Name="All Beef KIT" ProgramChange="15" />
+      <Patch Number="017" Name="Disco KIT" ProgramChange="16" />
+      <Patch Number="018" Name="VintagFnkKIT" ProgramChange="17" />
+      <Patch Number="019" Name="Phunque KIT" ProgramChange="18" />
+      <Patch Number="020" Name="70JzFunk KIT" ProgramChange="19" />
+      <Patch Number="021" Name="Jazz Mix KIT" ProgramChange="20" />
+      <Patch Number="022" Name="DynBrush KIT" ProgramChange="21" />
+      <Patch Number="023" Name="70'sBrushKIT" ProgramChange="22" />
+      <Patch Number="024" Name="PwrBrush KIT" ProgramChange="23" />
+      <Patch Number="025" Name="Latin Dry K" ProgramChange="24" />
+      <Patch Number="026" Name="Cool Dry K" ProgramChange="25" />
+      <Patch Number="027" Name="Disco/Funk K" ProgramChange="26" />
+      <Patch Number="028" Name="Old Funk K" ProgramChange="27" />
+      <Patch Number="029" Name="Power Rock K" ProgramChange="28" />
+      <Patch Number="030" Name="StudioRock K" ProgramChange="29" />
+      <Patch Number="031" Name="StreetRock K" ProgramChange="30" />
+      <Patch Number="032" Name="Big Rock K" ProgramChange="31" />
+      <Patch Number="033" Name="Wham Bam K" ProgramChange="32" />
+      <Patch Number="034" Name="StandrdJaz K" ProgramChange="33" />
+      <Patch Number="035" Name="Jazz Soul K" ProgramChange="34" />
+      <Patch Number="036" Name="Old Funk Sn" ProgramChange="35" />
+      <Patch Number="037" Name="70Phunque Sn" ProgramChange="36" />
+      <Patch Number="038" Name="Latin Sn" ProgramChange="37" />
+      <Patch Number="039" Name="HiPiccolo Sn" ProgramChange="38" />
+      <Patch Number="040" Name="Tight Sn" ProgramChange="39" />
+      <Patch Number="041" Name="Std Rock1 Sn" ProgramChange="40" />
+      <Patch Number="042" Name="Std Rock2 Sn" ProgramChange="41" />
+      <Patch Number="043" Name="OhBabyRck Sn" ProgramChange="42" />
+      <Patch Number="044" Name="Poppin Sn" ProgramChange="43" />
+      <Patch Number="045" Name="StudioFat Sn" ProgramChange="44" />
+      <Patch Number="046" Name="JazzStick Sn" ProgramChange="45" />
+      <Patch Number="047" Name="StudioJz Sn" ProgramChange="46" />
+      <Patch Number="048" Name="Ballad Sn" ProgramChange="47" />
+      <Patch Number="049" Name="PwrBallad Sn" ProgramChange="48" />
+      <Patch Number="050" Name="All Beef Sn" ProgramChange="49" />
+      <Patch Number="051" Name="Big Rock Sn" ProgramChange="50" />
+      <Patch Number="052" Name="70's BrushSn" ProgramChange="51" />
+      <Patch Number="053" Name="JazzBrush Sn" ProgramChange="52" />
+      <Patch Number="054" Name="Latin Tom" ProgramChange="53" />
+      <Patch Number="055" Name="Tight Tom" ProgramChange="54" />
+      <Patch Number="056" Name="JzStick Tom" ProgramChange="55" />
+      <Patch Number="057" Name="Old Funk Tom" ProgramChange="56" />
+      <Patch Number="058" Name="Oh Baby Tom" ProgramChange="57" />
+      <Patch Number="059" Name="PwrBalladTom" ProgramChange="58" />
+      <Patch Number="060" Name="Big Rock Tom" ProgramChange="59" />
+      <Patch Number="061" Name="OldBrush Tom" ProgramChange="60" />
+      <Patch Number="062" Name="Oh Baby Hat" ProgramChange="61" />
+      <Patch Number="063" Name="JzStick Hat" ProgramChange="62" />
+      <Patch Number="064" Name="Latin Hat" ProgramChange="63" />
+      <Patch Number="065" Name="Disco Hat" ProgramChange="64" />
+      <Patch Number="066" Name="Old Funk Hat" ProgramChange="65" />
+      <Patch Number="067" Name="Street Hat" ProgramChange="66" />
+      <Patch Number="068" Name="Big Rock Hat" ProgramChange="67" />
+      <Patch Number="069" Name="OldBrush Hat" ProgramChange="68" />
+      <Patch Number="070" Name="Stndrd Crash" ProgramChange="69" />
+      <Patch Number="071" Name="Jazz Crash" ProgramChange="70" />
+      <Patch Number="072" Name="Rock Crash" ProgramChange="71" />
+      <Patch Number="073" Name="Ballad Crash" ProgramChange="72" />
+      <Patch Number="074" Name="Brush Crash" ProgramChange="73" />
+      <Patch Number="075" Name="Jazz Ride" ProgramChange="74" />
+      <Patch Number="076" Name="Rock Ride" ProgramChange="75" />
+      <Patch Number="077" Name="Ballad Ride" ProgramChange="76" />
+      <Patch Number="078" Name="Latin Ride" ProgramChange="77" />
+      <Patch Number="079" Name="Brush Ride" ProgramChange="78" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX03)">
+      <Patch Number="001" Name="WideRock KIT" ProgramChange="0" />
+      <Patch Number="002" Name="WideJazz KIT" ProgramChange="1" />
+      <Patch Number="003" Name="TightRoomKIT" ProgramChange="2" />
+      <Patch Number="004" Name="3rdBalladKIT" ProgramChange="3" />
+      <Patch Number="005" Name="Studio 1 KIT" ProgramChange="4" />
+      <Patch Number="006" Name="Studio 2 KIT" ProgramChange="5" />
+      <Patch Number="007" Name="Studio 3 KIT" ProgramChange="6" />
+      <Patch Number="008" Name="Studio 4 KIT" ProgramChange="7" />
+      <Patch Number="009" Name="HipHop KIT" ProgramChange="8" />
+      <Patch Number="010" Name="Dyn.Perc KIT" ProgramChange="9" />
+      <Patch Number="011" Name="Drums MENU" ProgramChange="10" />
+      <Patch Number="012" Name="Perc. MENU" ProgramChange="11" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX05)">
+      <Patch Number="001" Name="PhatTrak Kit" ProgramChange="0" />
+      <Patch Number="002" Name="Euro Kit" ProgramChange="1" />
+      <Patch Number="003" Name="Urban Kit" ProgramChange="2" />
+      <Patch Number="004" Name="Tight Kit" ProgramChange="3" />
+      <Patch Number="005" Name="BitzOHitzKit" ProgramChange="4" />
+      <Patch Number="006" Name="Intl.Tek Kit" ProgramChange="5" />
+      <Patch Number="007" Name="GloblHousKit" ProgramChange="6" />
+      <Patch Number="008" Name="BreakBts Kit" ProgramChange="7" />
+      <Patch Number="009" Name="Trip Kit" ProgramChange="8" />
+      <Patch Number="010" Name="Bright Kit" ProgramChange="9" />
+      <Patch Number="011" Name="Soulful Kit" ProgramChange="10" />
+      <Patch Number="012" Name="LiteStep Kit" ProgramChange="11" />
+      <Patch Number="013" Name="4onFloorKit" ProgramChange="12" />
+      <Patch Number="014" Name="Street Kit" ProgramChange="13" />
+      <Patch Number="015" Name="Machine Kit" ProgramChange="14" />
+      <Patch Number="016" Name="LoTek Kit" ProgramChange="15" />
+      <Patch Number="017" Name="Solid Kit" ProgramChange="16" />
+      <Patch Number="018" Name="TekTrio Kit" ProgramChange="17" />
+      <Patch Number="019" Name="TekQuartoKit" ProgramChange="18" />
+      <Patch Number="020" Name="Hit Menu" ProgramChange="19" />
+      <Patch Number="021" Name="Kick Menu 1" ProgramChange="20" />
+      <Patch Number="022" Name="Kick Menu 2" ProgramChange="21" />
+      <Patch Number="023" Name="Snare Menu 1" ProgramChange="22" />
+      <Patch Number="024" Name="Snare Menu 2" ProgramChange="23" />
+      <Patch Number="025" Name="Snare Menu 3" ProgramChange="24" />
+      <Patch Number="026" Name="RimShot Menu" ProgramChange="25" />
+      <Patch Number="027" Name="Tom Menu" ProgramChange="26" />
+      <Patch Number="028" Name="HiHats Menu" ProgramChange="27" />
+      <Patch Number="029" Name="Clap Menu" ProgramChange="28" />
+      <Patch Number="030" Name="Cymbal Menu" ProgramChange="29" />
+      <Patch Number="031" Name="Perc. Menu" ProgramChange="30" />
+      <Patch Number="032" Name="FX Menu" ProgramChange="31" />
+      <Patch Number="033" Name="SynPerc.Menu" ProgramChange="32" />
+      <Patch Number="034" Name="All TR Menu" ProgramChange="33" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX06)">
+      <Patch Number="001" Name="Orch. Kit 1" ProgramChange="0" />
+      <Patch Number="002" Name="Orch. Kit 2" ProgramChange="1" />
+      <Patch Number="003" Name="Melo OrchKit" ProgramChange="2" />
+      <Patch Number="004" Name="GM AssignKit" ProgramChange="3" />
+      <Patch Number="005" Name="All Orch Kit" ProgramChange="4" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX07)">
+      <Patch Number="001" Name="Ring Kit" ProgramChange="0" />
+      <Patch Number="002" Name="Slam Kit" ProgramChange="1" />
+      <Patch Number="003" Name="Verb Kit" ProgramChange="2" />
+      <Patch Number="004" Name="Slap Kit" ProgramChange="3" />
+      <Patch Number="005" Name="RockOn Kit" ProgramChange="4" />
+      <Patch Number="006" Name="DryFat Kit" ProgramChange="5" />
+      <Patch Number="007" Name="LiteFunk Kit" ProgramChange="6" />
+      <Patch Number="008" Name="Warm Kit" ProgramChange="7" />
+      <Patch Number="009" Name="HiTune Kit" ProgramChange="8" />
+      <Patch Number="010" Name="AnalogRhyKit" ProgramChange="9" />
+      <Patch Number="011" Name="AllRhy Menu" ProgramChange="10" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX08)">
+      <Patch Number="001" Name="Techno Kit 2" ProgramChange="0" />
+      <Patch Number="002" Name="HipHop Kit" ProgramChange="1" />
+      <Patch Number="003" Name="House Kit 2" ProgramChange="2" />
+      <Patch Number="004" Name="Trance Kit" ProgramChange="3" />
+      <Patch Number="005" Name="DnB Kit" ProgramChange="4" />
+      <Patch Number="006" Name="BrekBeatsKit" ProgramChange="5" />
+      <Patch Number="007" Name="R&amp;B Kit 3" ProgramChange="6" />
+      <Patch Number="008" Name="TR-909 Kit" ProgramChange="7" />
+      <Patch Number="009" Name="TR-808 Kit" ProgramChange="8" />
+      <Patch Number="010" Name="TR606/707Kit" ProgramChange="9" />
+      <Patch Number="011" Name="Kick Menu" ProgramChange="10" />
+      <Patch Number="012" Name="Snare1 Menu" ProgramChange="11" />
+      <Patch Number="013" Name="Snr2&amp;RimMenu" ProgramChange="12" />
+      <Patch Number="014" Name="HHat&amp;TomMenu" ProgramChange="13" />
+      <Patch Number="015" Name="Cym&amp;Clp Menu" ProgramChange="14" />
+      <Patch Number="016" Name="Hit&amp;StabMenu" ProgramChange="15" />
+      <Patch Number="017" Name="Perc. Menu" ProgramChange="16" />
+      <Patch Number="018" Name="Vox Menu" ProgramChange="17" />
+      <Patch Number="019" Name="FX Menu" ProgramChange="18" />
+      <Patch Number="020" Name="Beat Menu 1" ProgramChange="19" />
+      <Patch Number="021" Name="Beat Menu 2" ProgramChange="20" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (SRX09)">
+      <Patch Number="001" Name="LatinDrmKit" ProgramChange="0" />
+      <Patch Number="002" Name="AsiaDrm Kit" ProgramChange="1" />
+      <Patch Number="003" Name="IndiaDrmKit" ProgramChange="2" />
+      <Patch Number="004" Name="MidEastDrKit" ProgramChange="3" />
+      <Patch Number="005" Name="World Phrase" ProgramChange="4" />
+      <Patch Number="006" Name="Gtr Phrase" ProgramChange="5" />
+      <Patch Number="007" Name="Latin Menu1" ProgramChange="6" />
+      <Patch Number="008" Name="Latin Menu2" ProgramChange="7" />
+      <Patch Number="009" Name="Latin Menu3" ProgramChange="8" />
+      <Patch Number="010" Name="Asia Menu" ProgramChange="9" />
+      <Patch Number="011" Name="India Menu" ProgramChange="10" />
+      <Patch Number="012" Name="MidEast Menu" ProgramChange="11" />
+    </PatchNameList>
+    <PatchNameList Name="Expansion PCM Drum (ExPCM)">
+      <Patch Number="001" Name="Standard 1" ProgramChange="0" />
+      <Patch Number="002" Name="Standard 2" ProgramChange="1" />
+      <Patch Number="003" Name="Standard 3" ProgramChange="2" />
+      <Patch Number="004" Name="Rock Kit" ProgramChange="3" />
+      <Patch Number="005" Name="Jazz Kit" ProgramChange="4" />
+      <Patch Number="006" Name="Brush Kit" ProgramChange="5" />
+      <Patch Number="007" Name="TR-808" ProgramChange="6" />
+      <Patch Number="008" Name="TR-909" ProgramChange="7" />
+      <Patch Number="009" Name="CR-78" ProgramChange="8" />
+      <Patch Number="010" Name="TR-606" ProgramChange="9" />
+      <Patch Number="011" Name="TR-707" ProgramChange="10" />
+      <Patch Number="012" Name="Machine Kit" ProgramChange="11" />
+      <Patch Number="013" Name="R&amp;B T-Analog" ProgramChange="12" />
+      <Patch Number="014" Name="R&amp;B Mini Kit" ProgramChange="13" />
+      <Patch Number="015" Name="HipHop Kit" ProgramChange="14" />
+      <Patch Number="016" Name="R&amp;B Kit" ProgramChange="15" />
+      <Patch Number="017" Name="Dance Kit 1" ProgramChange="16" />
+      <Patch Number="018" Name="Dance Kit 2" ProgramChange="17" />
+      <Patch Number="019" Name="Dance Kit 3" ProgramChange="18" />
+    </PatchNameList>
+    <PatchNameList Name="GM2 Drum Kit">
+      <Patch Number="001" Name="GM2 STANDARD" ProgramChange="0" />
+      <Patch Number="009" Name="GM2 ROOM" ProgramChange="8" />
+      <Patch Number="017" Name="GM2 POWER" ProgramChange="16" />
+      <Patch Number="025" Name="GM2 ELECTRIC" ProgramChange="24" />
+      <Patch Number="026" Name="GM2 ANALOG" ProgramChange="25" />
+      <Patch Number="033" Name="GM2 JAZZ" ProgramChange="32" />
+      <Patch Number="041" Name="GM2 BRUSH" ProgramChange="40" />
+      <Patch Number="049" Name="GM2 ORCHSTRA" ProgramChange="48" />
+      <Patch Number="057" Name="GM2 SFX" ProgramChange="56" />
+    </PatchNameList>
+  </MasterDeviceNames>
+</MIDINameDocument>


### PR DESCRIPTION
This merge request adds a patch file for the Roland INTEGRA-7 sound module.

The patch file is adapted from the Cakewalk Sonar Instrument Definition files found on the Roland website. I wrote the [ins2midnam.py script](https://codeberg.org/brettweir/ins2midnam.py) to convert from the .INS format Cakewalk uses to the .MIDNAM format adopted by Ardour.

In the course of writing this script, I found the DTD for the MIDNAM format was no longer available on the MIDI Association website. I was unable to find it anywhere, so I had to reverse engineer the MIDNAM format from other patch files.

I'm happy to address any comments or feedback on this pull request. Having this MIDNAM file has already made using Ardour and the INTEGRA together a lot more enjoyable for me, and I hope that others will find this work useful.