### PR TITLE
Add support to set color transparency from Lua

### DIFF
--- a/gtk2_ardour/luainstance.cc
+++ b/gtk2_ardour/luainstance.cc
@@ -1106,9 +1106,10 @@ LuaInstance::register_classes (lua_State* L, bool sandbox)
 
 		.addCFunction ("actionlist", &lua_actionlist)
 
-
 		.beginClass <UIConfiguration> ("UIConfiguration")
+		.addFunction ("set_modifier", (void (UIConfiguration::*)(std::string const&, std::string const&))&UIConfiguration::set_modifier)
 #undef  UI_CONFIG_VARIABLE
+
 #define UI_CONFIG_VARIABLE(Type,var,name,value) \
 		.addFunction ("get_" # var, &UIConfiguration::get_##var) \
 		.addFunction ("set_" # var, &UIConfiguration::set_##var) \

--- a/gtk2_ardour/ui_config.cc
+++ b/gtk2_ardour/ui_config.cc
@@ -825,6 +825,13 @@ UIConfiguration::set_modifier (string const & name, SVAModifier svam)
 }
 
 void
+UIConfiguration::set_modifier (string const & name, string const & mod_str)
+{
+	SVAModifier svam (mod_str);
+	set_modifier (name, svam);
+}
+
+void
 UIConfiguration::load_rc_file (bool themechange, bool allow_own)
 {
 	string basename = ui_rc_file.get();

--- a/gtk2_ardour/ui_config.h
+++ b/gtk2_ardour/ui_config.h
@@ -81,6 +81,7 @@ public:
 	void set_alias (std::string const& name, std::string const& alias);
 	void set_color (const std::string& name, Gtkmm2ext::Color);
 	void set_modifier (std::string const&, Gtkmm2ext::SVAModifier svam);
+	void set_modifier (std::string const& name, std::string const& mod_str);
 
 	Gtkmm2ext::Color quantized (Gtkmm2ext::Color) const;
 

--- a/share/scripts/s_color_transparency.lua
+++ b/share/scripts/s_color_transparency.lua
@@ -1,0 +1,7 @@
+ardour { ["type"] = "Snippet", name = "Set color transparency" }
+
+function factory () return function ()
+  -- See Ardour - Preferences -> Appearance -> Colors -> Transparency for modifier names
+  ArdourUI.config():set_modifier("editable region", "= alpha:0.7")
+  ArdourUI.config():set_modifier("ghost track midi fill", "= alpha:0.7")
+end end


### PR DESCRIPTION
This extension to the Lua API allows to set the color transparency (like in Preferences -> Appearance -> Colors -> Transparency) from a script. I use it, for example, to quickly adapt region/automation lane transparency when working with layers of MIDI regions.