### PR TITLE
Add Program Change dropdown to Virtual Keyboard

### DIFF
--- a/gtk2_ardour/virtual_keyboard_window.h
+++ b/gtk2_ardour/virtual_keyboard_window.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2019 Robin Gareus <robin@gareus.org>
+ * Copyright (C) 2025 Brent Baccala <cosine@freesoft.org>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -131,6 +132,7 @@ private:
 	void update_cc (size_t, int);
 	bool send_panic_message (GdkEventButton*);
 	bool on_velocity_scroll_event (GdkEventScroll*);
+	void program_change_event_handler ();
 
 	APianoKeyboard  _piano;
 
@@ -139,6 +141,7 @@ private:
 	ArdourWidgets::ArdourDropdown  _piano_octave_key;
 	ArdourWidgets::ArdourDropdown  _piano_octave_range;
 	ArdourWidgets::ArdourDropdown  _transpose_output;
+	ArdourWidgets::ArdourDropdown  _program_change;
 	ArdourWidgets::ArdourButton    _send_panic;
 
 	std::shared_ptr<VKBDControl>    _pitchbend;


### PR DESCRIPTION
This was coded by Claude Sonnet 4, running in Windsurf, using the following prompt:

> Ardour has a virtual keyboard with an upper row of controls that starts "channel", then "pitchbend", then "modulation", then 4 continous controllers, then "octave", then a few more controls.  I want you to add a new control called "Program" just to the left of "Octave".  "Program" should be a dropdown (like "Octave"), with 128 choices from 0 to 127.  When one of these is selected, the corresponding MIDI Program Change message should be sent on the current channel.

I tested and reviewed the AI's code.  It looks fine; I accepted it without any changes other than adding copyright messages.
