### PR TITLE
Fix user-facing and non-user-facing typos

### DIFF
--- a/gtk2_ardour/rta_window.cc
+++ b/gtk2_ardour/rta_window.cc
@@ -122,7 +122,7 @@ RTAWindow::RTAWindow ()
 
 	ArdourWidgets::set_tooltip (_clear, _("Clear current set of analyzed signals (except for the master bus)."));
 	ArdourWidgets::set_tooltip (_pause, _("Toggle analysis enable, pause the visual update. Left mouse press on the analysis area can temporary freeze the display"));
-	ArdourWidgets::set_tooltip (_speed_dropdown, _("Set analysis return time. Noise Measurement has a fallback time of 1dB in 2 seconds. Slow mode falls 5dB/s, Moderate 48dB/sec. Fast and Rapid mode are fast enough to be freqency dependent with Fast mode falling 96dB/s."));
+	ArdourWidgets::set_tooltip (_speed_dropdown, _("Set analysis return time. Noise Measurement has a fallback time of 1dB in 2 seconds. Slow mode falls 5dB/s, Moderate 48dB/sec. Fast and Rapid mode are fast enough to be frequency dependent with Fast mode falling 96dB/s."));
 	ArdourWidgets::set_tooltip (_warp_dropdown, _("Frequency warp the spectrum to focus on given range. A high warp factor increases resolution in the low freqncy range, while the bark scale is a frequency scale on which equal distances correspond with perceptually equal distances."));
 
 	on_theme_changed ();

--- a/gtk2_ardour/trigger_page.cc
+++ b/gtk2_ardour/trigger_page.cc
@@ -156,7 +156,7 @@ TriggerPage::TriggerPage ()
 	hpacker.set_spacing (8);  //match to slot_properties_box::set_spacings
 	hpacker.set_border_width (1);
 
-	/* note thse are re-packed as needed below. see
+	/* note these are re-packed as needed below. see
 	 * hide_all(), selection_changed(), trigger_arm_changed()
 	 */
 	hpacker.pack_start (_properties_box, true, true);

--- a/share/midi_maps/Nektar_Impact_GX.map
+++ b/share/midi_maps/Nektar_Impact_GX.map
@@ -52,7 +52,7 @@ Set the "Smoothing" parameter above 15 and see if you like that setting
 
   <DeviceInfo bank-size="1"/>
 
-  <!-- The volume pot controles the fader for the selected track -->
+  <!-- The volume pot controls the fader for the selected track -->
   <Binding channel="16" ctl-dial="20" uri="/route/gain S1"/>
 
   <!-- Transport controls -->

--- a/share/midi_maps/Nektar_Impact_LX.map
+++ b/share/midi_maps/Nektar_Impact_LX.map
@@ -7,7 +7,7 @@ Ardour MIDI Binding Map for the Nektar Impact LX series of controllers (mainly L
 Device configuration (HW)
 
 The Impact LX indeed uses channel 16 as a fixed one, this does not seem to be editable.
-The Impact internal USB Port "000" (out of 0/1/2) should work fine. Otherways check Nektar's manual about changing USB Port config (in short: "Setup" then on keybed "A2" and "C3/D3" to adjust).
+The Impact internal USB Port "000" (out of 0/1/2) should work fine. Otherwise, check Nektar's manual about changing USB Port config (in short: "Setup" then on keybed "A2" and "C3/D3" to adjust).
 
 Ardour configuration:
 

--- a/share/scripts/new_clean_playlists.lua
+++ b/share/scripts/new_clean_playlists.lua
@@ -52,7 +52,7 @@ function factory (params) return function ()
 			local r_front = r:position():samples()
 			local r_end = r_front + r:length():samples()
 
-			-- region can be finally splited into many segments
+			-- region can be finally spli into many segments
 			-- 'segments' is a table containing segments with the form
 			-- {{seg1_start, seg1_end}, {seg2_start, seg2_finish}...}
 			-- segments will finally be regions


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.pdf,*.po,./.git,*.tosc,./waf,./share/patchfiles,./libs,./msvc_extra_headers,./share/web_surfaces,*.patch" -L acount,addin,ane,ba,buss,busses,caf,capela,devine,disconnectin,discreet,doubleclick,envolution,filetest,fo,ghandi,homs,hsi,layed,maschine,mis,nd,ontop,pass-thru,removeable,retrn,ro,scrollin,sectionin,seh,siz,sord,sur,te,trough,ue,vie,wth`