### PR TITLE
Generic MIDI Surfaces: fix for erroneous feedback

### DIFF
--- a/libs/surfaces/generic_midi/midicontrollable.cc
+++ b/libs/surfaces/generic_midi/midicontrollable.cc
@@ -321,7 +321,9 @@ MIDIControllable::midi_sense_note (Parser &, EventTwoBytes *msg, bool /*is_on*/)
 		}
 	}
 
-	last_value = (MIDI::byte) (_controllable->get_value() * 127.0); // to prevent feedback fights
+	if (!_surface->get_feedback ()) {
+		last_value = (MIDI::byte) (_controllable->get_value() * 127.0); // to prevent feedback fights
+	}
 }
 
 void


### PR DESCRIPTION
last_value is updated in MIDIControllable::midi_sense_note without regard to the fact that last_value must be different from feedback value in MIDIControllable::write_feedback.

Update to only touch last_value in MIDIControllable::midi_sense_note if Surface Feedback is not in use.

Tested on AKAI MIDIMix with Normal mapping. Without the change there is erroneous feedback eventually. With the fix the lit up buttons correspond to the actual state of the Stripables.