### PR TITLE
editor_ops: paste automation at leftmost selected point, not at timel…

### DIFF
--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -4461,12 +4461,29 @@ Editor::cut_copy_points (Editing::CutCopyOp op, timepos_t const & earliest_time)
 
 		/* Add all selected points to the relevant copy ControlLists */
 
+		bool earliest_set = false;
 		for (auto & selected_point : selection->points) {
 			std::shared_ptr<AutomationList>    al = selected_point->line().the_list();
 			AutomationList::const_iterator ctrl_evt = selected_point->model ();
 
 			lists[al].copy->fast_simple_add ((*ctrl_evt)->when, (*ctrl_evt)->value);
-			earliest = std::min (earliest, (*ctrl_evt)->when);
+
+			/* Track the leftmost (earliest) selected point so that the copy
+			 * buffer can be normalised to zero-relative offsets below.
+			 * We cannot rely on the earliest_time parameter as a sentinel:
+			 * callers pass timepos_t(AudioTime) == 0 samples, which is
+			 * always less-than-or-equal to any real event position, so
+			 * std::min would always keep 0 and shift_earlier(0) would be
+			 * a no-op -- leaving the raw model-space positions in the copy
+			 * buffer.  On paste those positions would be added to the paste
+			 * target, placing automation far to the right of where the user
+			 * intended.  Instead, seed earliest from the first real event. */
+			if (!earliest_set) {
+				earliest     = (*ctrl_evt)->when;
+				earliest_set = true;
+			} else {
+				earliest = std::min (earliest, (*ctrl_evt)->when);
+			}
 		}
 
 		for (Lists::iterator i = lists.begin(); i != lists.end(); ++i) {


### PR DESCRIPTION
When automation points are selected and copied (Ctrl+C / Ctrl+V or Ctrl+D), the pasted automation was placed far to the right of the paste cursor -- as if the entire automation lane from the start of the song was being copied rather than just the selected nodes.

Root cause: cut_copy_points() tracks the earliest selected point in order to normalise the copy buffer to zero-relative offsets before storing it. It initialised 'earliest' from the earliest_time parameter, which callers pass as timepos_t(AudioTime) == 0 samples.  Since 0 is always <=  any real event position on the timeline, std::min() always kept 0 as 'earliest'. shift_earlier(0) was then a no-op, leaving every event in the copy buffer at its raw model-space position (e.g. 30 seconds into the song).  On paste, paste_one() adds model_pos (the paste cursor position) on top, producing raw_pos + cursor instead of just cursor.

Fix: seed 'earliest' from the first real event encountered rather than from the caller-supplied sentinel.  Subsequent points are compared against that real baseline, so the leftmost selected node correctly becomes position 0 in the copy buffer, and paste lands exactly at the edit cursor regardless of where the automation sits on the timeline.

basically, the issue was, when selecting automation points and pasting it somewhere else, it would also paste the start of the automation lane, when it should just paste the nodes that you selected. i would expect it to paste the left most node that you selected where your cursor is. 

related to this https://tracker.ardour.org/view.php?id=9771