### PR TITLE
pianoroll: add FL Studio-style draw mode (FL mode)

### DIFF
--- a/gtk2_ardour/editing_context.h
+++ b/gtk2_ardour/editing_context.h
@@ -123,6 +123,9 @@ class EditingContext : public ARDOUR::SessionHandlePtr, public AxisViewProvider,
 	virtual void stop_canvas_autoscroll () = 0;
 	virtual bool autoscroll_active() const = 0;
 
+	/** Return true if the editing context is in FL-style draw+delete mode */
+	virtual bool fl_mode() const { return false; }
+
 	void scroll_left_step ();
 	void scroll_right_step ();
 	void scroll_left_half_page ();

--- a/gtk2_ardour/midi_view.cc
+++ b/gtk2_ardour/midi_view.cc
@@ -577,6 +577,10 @@ bool
 MidiView::button_press (GdkEventButton* ev)
 {
 	if (Keyboard::is_context_menu_event (ev)) {
+		/* In FL mode, suppress all right-click context menus */
+		if (_editing_context.fl_mode()) {
+			return true;
+		}
 		return show_context_menu (ev);
 	}
 
@@ -588,6 +592,18 @@ MidiView::button_press (GdkEventButton* ev)
 	int held_note = -1;
 
 	if (m == MouseDraw || (m == MouseContent && Keyboard::modifier_state_contains (ev->state, Keyboard::insert_note_modifier()))) {
+
+		/* FL mode + Ctrl: rubberband select instead of draw/create */
+		if (_editing_context.fl_mode() && Keyboard::modifier_state_contains (ev->state, Keyboard::PrimaryModifier)) {
+			selection_drag = new MidiRubberbandSelectDrag (_editing_context, this);
+			selection_drag->set_bounding_item (_editing_context.get_trackview_group());
+			_editing_context.drags()->set (selection_drag, (GdkEvent *) ev);
+			if (!Keyboard::modifier_state_equals (ev->state, Keyboard::TertiaryModifier)) {
+				clear_selection_internal ();
+				_mouse_changed_selection = true;
+			}
+			return true;
+		}
 
 		_editing_context.set_canvas_cursor (_editing_context.cursors()->midi_pencil);
 

--- a/gtk2_ardour/pianoroll.cc
+++ b/gtk2_ardour/pianoroll.cc
@@ -73,6 +73,9 @@ Pianoroll::Pianoroll (std::string const & name, bool with_transport)
 	: CueEditor (name, with_transport)
 	, prh (nullptr)
 	, layered_automation (true)
+	, fl_mode_button (nullptr)
+	, _fl_mode (false)
+	, _pre_fl_mode (Editing::MouseContent)
 	, bg (nullptr)
 	, view (nullptr)
 	, bbt_metric (*this)
@@ -372,6 +375,34 @@ Pianoroll::pack_outer (Gtk::Box& box)
 	box.pack_start (visible_channel_label, false, false);
 	box.pack_start (visible_channel_selector, false, false);
 	box.pack_start (note_mode_button, false, false);
+
+	/* FL mode toggle button */
+	fl_mode_button = manage (new ArdourButton (ArdourButton::Element (ArdourButton::Text | ArdourButton::Edge | ArdourButton::Body)));
+	fl_mode_button->set_text (_("FL"));
+	fl_mode_button->set_name ("transport button");
+	fl_mode_button->set_active_state (Gtkmm2ext::Off);
+	set_tooltip (*fl_mode_button, _("FL Mode: draw notes with left-click/drag, right-click to delete, Ctrl+drag to select"));
+	fl_mode_button->signal_clicked.connect (sigc::mem_fun (*this, &Pianoroll::toggle_fl_mode));
+	fl_mode_button->show ();
+	box.pack_start (*fl_mode_button, false, false, 4);
+}
+
+void
+Pianoroll::toggle_fl_mode ()
+{
+	EC_LOCAL_TEMPO_SCOPE;
+
+	_fl_mode = !_fl_mode;
+	fl_mode_button->set_active_state (_fl_mode ? Gtkmm2ext::ExplicitActive : Gtkmm2ext::Off);
+
+	if (_fl_mode) {
+		/* Save whatever mode was active before FL, then switch to draw */
+		_pre_fl_mode = current_mouse_mode ();
+		set_mouse_mode (Editing::MouseDraw, true);
+	} else {
+		/* Restore the mode that was active before FL was turned on */
+		set_mouse_mode (_pre_fl_mode, true);
+	}
 }
 
 void
@@ -865,6 +896,17 @@ Pianoroll::button_press_handler (ArdourCanvas::Item* item, GdkEvent* event, Item
 		break;
 
 	case 3:
+		/* In FL mode right-click deletes notes; swallow the event so
+		   no context menu appears. */
+		if (_fl_mode) {
+			if (item_type == NoteItem) {
+				NoteBase* nb = reinterpret_cast<NoteBase*> (item->get_data ("notebase"));
+				if (nb && view) {
+					view->delete_note (nb->note());
+				}
+			}
+			return true;   /* consumed – no context menu */
+		}
 		break;
 
 	default:
@@ -880,6 +922,18 @@ bool
 Pianoroll::button_press_handler_1 (ArdourCanvas::Item* item, GdkEvent* event, ItemType item_type)
 {
 	EC_LOCAL_TEMPO_SCOPE;
+
+	/* FL mode + Ctrl on a non-note item: rubber-band select.
+	   On a NoteItem, fall through so NoteDrag picks up the copy (Ctrl = CopyModifier). */
+	if (_fl_mode && Keyboard::modifier_state_contains (event->button.state, Keyboard::PrimaryModifier) && item_type != NoteItem) {
+		if (!Keyboard::modifier_state_equals (event->button.state, Keyboard::TertiaryModifier)) {
+			view->clear_selection ();
+		}
+		MidiRubberbandSelectDrag* sel_drag = new MidiRubberbandSelectDrag (*this, view);
+		sel_drag->set_bounding_item (get_trackview_group ());
+		_drags->set (sel_drag, event);
+		return true;
+	}
 
 	NoteBase* note = nullptr;
 	Editing::MouseMode mouse_mode = current_mouse_mode();
@@ -1030,6 +1084,12 @@ Pianoroll::button_release_handler (ArdourCanvas::Item* item, GdkEvent* event, It
 
 	} else {
 
+		/* In FL mode, right-click was already handled on press (note
+		   deletion); suppress the context menu entirely. */
+		if (_fl_mode) {
+			return true;
+		}
+
 		switch (item_type) {
 		case NoteItem:
 			if (internal_editing()) {
@@ -1153,12 +1213,54 @@ Pianoroll::key_release_handler (ArdourCanvas::Item*, GdkEvent*, ItemType)
 }
 
 void
+Pianoroll::mouse_mode_chosen (Editing::MouseMode m)
+{
+	EC_LOCAL_TEMPO_SCOPE;
+
+	if (!mouse_mode_actions[m]->get_active()) {
+		/* Notification that old mode was left — track it as pre-FL
+		   candidate only when FL is not active */
+		if (!_fl_mode) {
+			_pre_fl_mode = m;
+		}
+		return;
+	}
+
+	/* The new mode is now active.  If FL is on and the user switched to
+	   anything other than draw (e.g. pressed 'e' via global keybinding),
+	   turn FL off now so the UI stays consistent. */
+	if (_fl_mode && m != Editing::MouseDraw) {
+		_fl_mode = false;
+		if (fl_mode_button) {
+			fl_mode_button->set_active_state (Gtkmm2ext::Off);
+		}
+	}
+
+	/* Let CueEditor do its re_enter / cursor work */
+	CueEditor::mouse_mode_chosen (m);
+}
+
+void
 Pianoroll::set_mouse_mode (Editing::MouseMode m, bool force)
 {
 	EC_LOCAL_TEMPO_SCOPE;
 
 	if (m != Editing::MouseDraw && m != Editing::MouseContent) {
 		return;
+	}
+
+	/* Track the last mode used when FL is off, so we can restore it */
+	if (!_fl_mode) {
+		_pre_fl_mode = m;
+	}
+
+	/* If the user directly requests a non-draw mode while FL is active
+	   (e.g. via the canvas 'e' key handler), turn FL off */
+	if (_fl_mode && m != Editing::MouseDraw && !force) {
+		_fl_mode = false;
+		if (fl_mode_button) {
+			fl_mode_button->set_active_state (Gtkmm2ext::Off);
+		}
 	}
 
 	EditingContext::set_mouse_mode (m, force);
@@ -1947,12 +2049,9 @@ Pianoroll::map_transport_state ()
 		if (_session->get_play_loop ()) {
 
 			loop_button.set_active (true);
+			/* loop-is-mode: show play active too since we are rolling */
+			play_button.set_active (true);
 
-			if (Config->get_loop_is_mode()) {
-				play_button.set_active (true);
-			} else {
-				play_button.set_active (false);
-			}
 		} else {
 			play_button.set_active (true);
 			loop_button.set_active (false);
@@ -1960,11 +2059,8 @@ Pianoroll::map_transport_state ()
 	} else {
 		play_button.set_active (false);
 
-		if (Config->get_loop_is_mode()) {
-			loop_button.set_active (true);
-		} else {
-			loop_button.set_active (false);
-		}
+		/* loop button reflects the armed loop-mode state even when stopped */
+		loop_button.set_active (_session->get_play_loop ());
 
 		hide_count_in ();
 	}

--- a/gtk2_ardour/pianoroll.h
+++ b/gtk2_ardour/pianoroll.h
@@ -105,6 +105,7 @@ class Pianoroll : public CueEditor
 	void set_samples_per_pixel (samplecnt_t);
 
 	void set_mouse_mode (Editing::MouseMode, bool force = false);
+	void mouse_mode_chosen (Editing::MouseMode);
 
 	void midi_action (void (MidiView::*method)());
 
@@ -182,6 +183,15 @@ class Pianoroll : public CueEditor
 	ArdourWidgets::ArdourButton* layered_automation_button;
 	bool layered_automation;
 	void layered_automation_button_clicked();
+
+	/* FL-mode: draw + right-click-delete + Ctrl-drag-select */
+	ArdourWidgets::ArdourButton* fl_mode_button;
+	bool _fl_mode;
+	Editing::MouseMode _pre_fl_mode;  /* mode to restore when FL is turned off */
+	void toggle_fl_mode ();
+  public:
+	bool fl_mode () const override { return _fl_mode; }
+  private:
 
 	ControllerControls* velocity_button;
 	ControllerControls* bender_button;


### PR DESCRIPTION
FL mode is toggled via an 'FL' button in the pianoroll toolbar.

Behaviour:
- Left-click / drag on empty canvas: draw/create notes (MouseDraw)
- Right-click on a note: delete it immediately (no context menu)
- Right-click on background: no context menu ( menus slow you down here )
- Ctrl + drag on empty canvas: rubber-band box select
- Ctrl + drag on a note: copy-drag the note(s) 
- Pressing 'e' / Edit button while FL active: turns FL mode off, returns to edit mode
- Pressing FL button again: turns FL off, restores mode that was active before FL

Implementation:
- EditingContext: virtual fl_mode() accessor (defaults false)
- Pianoroll: _fl_mode bool, _pre_fl_mode to restore previous mode, fl_mode_button ArdourButton, toggle_fl_mode(), mouse_mode_chosen() override to catch global keybinding action path
- MidiView::button_press: intercept Ctrl+left in fl_mode to launch MidiRubberbandSelectDrag instead of NoteCreateDrag; suppress show_context_menu when fl_mode active
- pianoroll.cc button handlers: rubberband only on non-note items, suppress context menu in release handler

ive alwayed dreamed of having a piano roll like fl studio again. this mode works to mimic the piano roll from fl. its very fast and easy to edit midi this way. 

<img width="1301" height="860" alt="image" src="https://github.com/user-attachments/assets/357642a1-e07c-4779-974c-1fafccf37a45" />

[fl_mode.webm](https://github.com/user-attachments/assets/9b26704f-0157-41ec-99af-f329a5c079c6)

im also these using the patches for the piano roll snap, and drag and drop from here in the video. ( its terrible without them ), but this commit is just for the fl mode. 
https://github.com/Ardour/ardour/pull/1077
https://github.com/Ardour/ardour/pull/1078