### PR TITLE
pianoroll: update loop range when switching regions in loop mode

### DIFF
--- a/gtk2_ardour/pianoroll.cc
+++ b/gtk2_ardour/pianoroll.cc
@@ -54,6 +54,7 @@
 #include "pianoroll_midi_view.h"
 #include "note_base.h"
 #include "prh.h"
+#include "public_editor.h"
 #include "timers.h"
 #include "ui_config.h"
 #include "verbose_cursor.h"
@@ -1536,6 +1537,14 @@ Pianoroll::set_region (std::shared_ptr<ARDOUR::Region> region)
 		if (mt) {
 			note_mode_actions[mt->note_mode()]->set_active (true);
 		}
+	}
+
+	/* If the session is currently in loop mode, update the loop range
+	 * to cover the newly-selected region so the user doesn't have to
+	 * manually re-set the loop every time they switch clips.
+	 */
+	if (_session && _session->get_play_loop()) {
+		PublicEditor::instance().set_loop_range (r->position(), r->end(), _("loop region"));
 	}
 }
 


### PR DESCRIPTION
this makes it so, when you have the bottom panel open, and you click on a midi region with loop mode on, it sets up the range to that region so you don't have to click the loop mode button over and over to reset it. 

[Screencast_20260316_235546.webm](https://github.com/user-attachments/assets/0631dec4-a073-452e-bf8c-a7da05e0064d)
