### PR TITLE
add -fno-finite-math-only to avoid miscompilations (fixes #10274)

### DIFF
--- a/wscript
+++ b/wscript
@@ -42,7 +42,7 @@ compiler_flags_dictionaries= {
         # Flags to use posix pipes between compiler stages
         'pipe' : '-pipe',
         # Flags for maximally optimized build
-        'full-optimization' : [ '-O3', '-fomit-frame-pointer', '-ffast-math', '-fstrength-reduce' ],
+        'full-optimization' : [ '-O3', '-fomit-frame-pointer', '-ffast-math', '-fno-finite-math-only', '-fstrength-reduce' ],
         # Flag to ensure that compiler error output includes column/line numbers
         'show-column' : '-fshow-column',
         # Flags required to build for x86 only (OS X feature)
@@ -152,12 +152,12 @@ clang_dict['cxx-strict'] = [ '-ansi', '-Wnon-virtual-dtor', '-Woverloaded-virtua
 clang_dict['strict'] = ['-Wall', '-Wcast-align', '-Wextra', '-Wwrite-strings' ]
 clang_dict['generic-x86'] = [ '-arch', 'i386' ]
 clang_dict['generic-arm64'] = [ '-arch', 'arm64' ]
-clang_dict['full-optimization'] = [ '-O3', '-fomit-frame-pointer', '-ffast-math', ]
+clang_dict['full-optimization'] = [ '-O3', '-fomit-frame-pointer', '-ffast-math', '-fno-finite-math-only']
 compiler_flags_dictionaries['clang'] = clang_dict
 
 clang_darwin_dict = compiler_flags_dictionaries['clang'].copy()
 clang_darwin_dict['cxx-strict'] = [ '-ansi', '-Wnon-virtual-dtor', '-Woverloaded-virtual', ]
-clang_darwin_dict['full-optimization'] = [ '-O3', '-ffast-math']
+clang_darwin_dict['full-optimization'] = [ '-O3', '-ffast-math', '-fno-finite-math-only']
 compiler_flags_dictionaries['clang-darwin'] = clang_darwin_dict
 
 # Xcode 15 does not like our boost version, producing warnings from almost every file


### PR DESCRIPTION
This fixes the issue I was facing in https://tracker.ardour.org/view.php?id=10274

When compiling with `-ffast-math`, under many compilers any operations involving infinites or nans is considered UB. This can lead to [undesirable optimizations](https://godbolt.org/z/Y78Yj9YhT) such as the one I was facing with `clang version 22.1.1 (Fedora 22.1.1-2.fc44)` which caused the float / double to_string functions to always produce `"inf"`.

This might have *other* side effects, since it would effectively change the behavior elsewhere where `isinf` / `isnan` checks or other comparisons are currently being optimized away.

For MSVC it seems like `fast-math` does not seem to have anything similar to `-ffinite-math-only`. But it might be worth looking over the optimization flags it sets and compare with what's being used in Ardour.

<details>
<summary>disassembly of <code>PBD::float_to_string</code> <b>without</b> <code>--no-finite-math-only</code></summary>

```
Dump of assembler code for function _ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE:
   0x00007ffff67ecde0 <+0>: push %rax
   0x00007ffff67ecde1 <+1>: mov 0x8(%rdi),%rdx
   0x00007ffff67ecde5 <+5>: lea 0x49a89(%rip),%rcx # 0x7ffff6836875
   0x00007ffff67ecdec <+12>: mov $0x3,%r8d
   0x00007ffff67ecdf2 <+18>: xor %esi,%esi
   0x00007ffff67ecdf4 <+20>: call 0x7ffff67a76f0 <_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm@plt>
   0x00007ffff67ecdf9 <+25>: mov $0x1,%al
   0x00007ffff67ecdfb <+27>: pop %rcx
   0x00007ffff67ecdfc <+28>: ret
```
</details>

<details>
<summary>disassembly of <code>PBD::float_to_string</code> <b>with</b> <code>--no-finite-math-only</code></summary>

```
Dump of assembler code for function _ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE:
   0x00007ffff67ece50 <+0>: push %rbp
   0x00007ffff67ece51 <+1>: push %r15
   0x00007ffff67ece53 <+3>: push %r14
   0x00007ffff67ece55 <+5>: push %rbx
   0x00007ffff67ece56 <+6>: sub $0x28,%rsp
   0x00007ffff67ece5a <+10>: ucomiss 0x49ee7(%rip),%xmm0 # 0x7ffff6836d48
   0x00007ffff67ece61 <+17>: jb 0x7ffff67ece76 <_ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+38>
   0x00007ffff67ece63 <+19>: mov 0x8(%rdi),%rdx
   0x00007ffff67ece67 <+23>: lea 0x49a47(%rip),%rcx # 0x7ffff68368b5
   0x00007ffff67ece6e <+30>: mov $0x3,%r8d
   0x00007ffff67ece74 <+36>: jmp 0x7ffff67ece94 <_ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+68>
   0x00007ffff67ece76 <+38>: movss 0x49ece(%rip),%xmm1 # 0x7ffff6836d4c
   0x00007ffff67ece7e <+46>: ucomiss %xmm0,%xmm1
   0x00007ffff67ece81 <+49>: jb 0x7ffff67ecea8 <_ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+88>
   0x00007ffff67ece83 <+51>: mov 0x8(%rdi),%rdx
   0x00007ffff67ece87 <+55>: lea 0x49a35(%rip),%rcx # 0x7ffff68368c3
   0x00007ffff67ece8e <+62>: mov $0x4,%r8d
   0x00007ffff67ece94 <+68>: xor %esi,%esi
   0x00007ffff67ece96 <+70>: call 0x7ffff67a76f0 <_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm@plt>
   0x00007ffff67ece9b <+75>: mov $0x1,%al
   0x00007ffff67ece9d <+77>: add $0x28,%rsp
   0x00007ffff67ecea1 <+81>: pop %rbx
   0x00007ffff67ecea2 <+82>: pop %r14
   0x00007ffff67ecea4 <+84>: pop %r15
   0x00007ffff67ecea6 <+86>: pop %rbp
   0x00007ffff67ecea7 <+87>: ret
   0x00007ffff67ecea8 <+88>: mov %rdi,%rbx
   0x00007ffff67eceab <+91>: cvtss2sd %xmm0,%xmm0
   0x00007ffff67eceaf <+95>: mov %rsp,%rdi
   0x00007ffff67eceb2 <+98>: mov $0x27,%esi
   0x00007ffff67eceb7 <+103>: call 0x7ffff67a9520 <g_ascii_dtostr@plt>
   0x00007ffff67ecebc <+108>: mov %rax,%r15
   0x00007ffff67ecebf <+111>: test %rax,%rax
   0x00007ffff67ecec2 <+114>: setne %al
   0x00007ffff67ecec5 <+117>: je 0x7ffff67ece9d <_ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+77>
   0x00007ffff67ecec7 <+119>: mov 0x8(%rbx),%r14
   0x00007ffff67ececb <+123>: mov %r15,%rdi
   0x00007ffff67ecece <+126>: mov %eax,%ebp
   0x00007ffff67eced0 <+128>: call 0x7ffff67a7330 <strlen@plt>
   0x00007ffff67eced5 <+133>: mov %rbx,%rdi
   0x00007ffff67eced8 <+136>: xor %esi,%esi
   0x00007ffff67eceda <+138>: mov %r14,%rdx
   0x00007ffff67ecedd <+141>: mov %r15,%rcx
   0x00007ffff67ecee0 <+144>: mov %rax,%r8
   0x00007ffff67ecee3 <+147>: call 0x7ffff67a76f0 <_ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEE10_M_replaceEmmPKcm@plt>
   0x00007ffff67ecee8 <+152>: mov %ebp,%eax
   0x00007ffff67eceea <+154>: jmp 0x7ffff67ece9d <_ZN3PBD15float_to_stringEfRNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+77>
End of assembler dump.
```
</details>