### PR TITLE
improve jack port diagnostics and ignore other ports to improve responsiveness

### DIFF
--- a/libs/backends/jack/jack_audiobackend.h
+++ b/libs/backends/jack/jack_audiobackend.h
@@ -301,7 +301,7 @@ class JACKAudioBackend : public AudioBackend {
 	/* used to manage _jack_ports, specifically for ports belonging to the
 	   JACK backend or other clients.
 	*/
-	void jack_registration_callback (jack_port_id_t, int);
+	bool jack_registration_callback (jack_port_id_t, int);
 
 	typedef std::map<std::string,std::shared_ptr<JackPort> > JackPorts;
 	mutable SerializedRCUManager<JackPorts> _jack_ports; /* can be modified in ::get_port_by_name () */

--- a/libs/backends/jack/jack_portengine.cc
+++ b/libs/backends/jack/jack_portengine.cc
@@ -229,25 +229,30 @@ JACKAudioBackend::_registration_callback (jack_port_id_t id, int reg, void* arg)
 {
 	DEBUG_TRACE (DEBUG::BackendCallbacks, string_compose ("%1/%2 jack port registration callback\n", DEBUG_THREAD_SELF, pthread_name()));
 
+	JACKAudioBackend* backend = static_cast<JACKAudioBackend*> (arg);
+
 	/* we don't use a virtual method for the registration callback, because
 	   JACK is the only backend that delivers the arguments shown above. So
 	   call our own JACK-centric registration callback, then the generic
 	   one.
 	*/
-	static_cast<JACKAudioBackend*> (arg)->jack_registration_callback (id, reg);
-	static_cast<JACKAudioBackend*> (arg)->manager.registration_callback ();
-	static_cast<JACKAudioBackend*> (arg)->engine.latency_callback (false);
-	static_cast<JACKAudioBackend*> (arg)->engine.latency_callback (true);
+	if (!backend->jack_registration_callback (id, reg)) {
+		return;
+	}
+
+	backend->manager.registration_callback ();
+	backend->engine.latency_callback (false);
+	backend->engine.latency_callback (true);
 }
 
-void
+bool
 JACKAudioBackend::jack_registration_callback (jack_port_id_t id, int reg)
 {
-	GET_PRIVATE_JACK_POINTER (_priv_jack);
+	GET_PRIVATE_JACK_POINTER_RET (_priv_jack, false);
 	jack_port_t* jack_port = jack_port_by_id (_priv_jack, id);
 
 	if (!jack_port) {
-		return;
+		return false;
 	}
 
 	/* We only need to care about ports that we do not register/unregister
@@ -268,22 +273,34 @@ JACKAudioBackend::jack_registration_callback (jack_port_id_t id, int reg)
 	 */
 
 	if (!jack_port_is_mine (_priv_jack, jack_port)) {
-
 		const char* name = jack_port_name (jack_port);
+		const char* type = jack_port_type (jack_port);
+
+		if (strcmp (type, "other") == 0) {
+			/* Ports that fall under "other" include video ports. Avoiding them
+			 * here avoids a ton of churn caused by actions such as hovering
+			 * over panel icons in kwin which causes stutter in Ardour.
+			 */
+			return false;
+		}
 
 		std::shared_ptr<JackPorts> ports = _jack_ports.write_copy();
 
 		if (!reg) {
 			if (ports->erase (name)) {
+				PBD::debug << "JACK port (" << name << ", " << type << ") unregistered" << endmsg;
 				_jack_ports.update (ports);
 			} else {
+				PBD::debug << "JACK port (" << name << ", " << type << ") unregistered, but not found locally" << endmsg;
 				_jack_ports.no_update();
 			}
 		} else {
 			if (ports->find (name) != ports->end()) {
 				/* hmmm, we already have this port */
-				std::cout << "re-registration of JACK port named " << name << std::endl;
+				PBD::debug << "JACK port (" << name << ", " << type << ") re-registered" << endmsg;
 				ports->erase (name);
+			} else {
+				PBD::debug << "JACK port (" << name << ", " << type << ") registered" << endmsg;
 			}
 
 			std::shared_ptr<JackPort> jp (new JackPort (jack_port));
@@ -292,6 +309,8 @@ JACKAudioBackend::jack_registration_callback (jack_port_id_t id, int reg)
 			_jack_ports.update (ports);
 		}
 	}
+
+	return true;
 }
 
 int

--- a/libs/backends/jack/jack_portengine.cc
+++ b/libs/backends/jack/jack_portengine.cc
@@ -277,9 +277,10 @@ JACKAudioBackend::jack_registration_callback (jack_port_id_t id, int reg)
 		const char* type = jack_port_type (jack_port);
 
 		if (strcmp (type, "other") == 0) {
-			/* Ports that fall under "other" include video ports. Avoiding them
-			 * here avoids a ton of churn caused by actions such as hovering
-			 * over panel icons in kwin which causes stutter in Ardour.
+			/* Ports that fall under "other" include video ports in pipewire.
+			 * Avoiding them here avoids a ton of churn caused by actions such
+			 * as hovering over panel icons in kwin which causes stutter in
+			 * Ardour.
 			 */
 			return false;
 		}
@@ -288,19 +289,19 @@ JACKAudioBackend::jack_registration_callback (jack_port_id_t id, int reg)
 
 		if (!reg) {
 			if (ports->erase (name)) {
-				PBD::debug << "JACK port (" << name << ", " << type << ") unregistered" << endmsg;
+				DEBUG_TRACE (DEBUG::Ports, string_compose ("%1/%2 jack port (%3, %4) unregistered\n", DEBUG_THREAD_SELF, pthread_name(), name, type));
 				_jack_ports.update (ports);
 			} else {
-				PBD::debug << "JACK port (" << name << ", " << type << ") unregistered, but not found locally" << endmsg;
+				DEBUG_TRACE (DEBUG::Ports, string_compose ("%1/%2 jack port (%3, %4) unregistered, but not found locally\n", DEBUG_THREAD_SELF, pthread_name(), name, type));
 				_jack_ports.no_update();
 			}
 		} else {
 			if (ports->find (name) != ports->end()) {
 				/* hmmm, we already have this port */
-				PBD::debug << "JACK port (" << name << ", " << type << ") re-registered" << endmsg;
+				DEBUG_TRACE (DEBUG::Ports, string_compose ("%1/%2 jack port (%3, %4) re-registered\n", DEBUG_THREAD_SELF, pthread_name(), name, type));
 				ports->erase (name);
 			} else {
-				PBD::debug << "JACK port (" << name << ", " << type << ") registered" << endmsg;
+				DEBUG_TRACE (DEBUG::Ports, string_compose ("%1/%2 jack port (%3, %4) registered\n", DEBUG_THREAD_SELF, pthread_name(), name, type));
 			}
 
 			std::shared_ptr<JackPort> jp (new JackPort (jack_port));


### PR DESCRIPTION
I've had an issue with jack/pipewire where meters and audio stutters as you alt+tab or hover over panel icons in kwin.

The cause seems to be churn induced by the rapid addition and removal of video nodes in pipewire that are used by kwin to stream the window preview. The result is that for low latency configurations on my system (64 samples or less) hovering over a panel icon or alt+tabbing causes significant stuttering in the UI and xruns, presumably because ports are being reconfigured.

In this patch I've added code to ignore jack ports with the type `"other"` early. This encompasses the short-lived video nodes in kwin and avoids most of this churn on my system. I've also improved diagnostics for when ports are added / removed.

This is a video showcasing how meters are affected on my system without this patch (sorry, couldn't do audio right now, but it is also stuttering):
[Screencast_20260410_221530.webm](https://github.com/user-attachments/assets/5b4351ef-8edf-4490-9078-7a825e824e7c)

With the patch the vast majority of stuttering is avoided.

At the moment I'm just looking for a review. I'm not sure whether `"other"` ports really aren't used. It would be nice to include some option I could use to avoid this stuttering because it's the biggest issue I'm having at the moment. I want to be able to alt+tab while working without stuttering.