### PR TITLE
Perform horizontal scrolling when mouse is on the midi region and shift + scroll

### DIFF
--- a/gtk2_ardour/midi_region_view.cc
+++ b/gtk2_ardour/midi_region_view.cc
@@ -415,10 +415,9 @@ MidiRegionView::scroll (GdkEventScroll* ev)
 		return false;
 	}
 
-	if (Keyboard::modifier_state_equals (ev->state, Keyboard::PrimaryModifier)) {
-		/* XXX: bit of a hack; allow PrimaryModifier scroll
-		 * through so that it still works for navigation and zoom.
-		 */
+	if (Keyboard::modifier_state_equals (ev->state, Keyboard::PrimaryModifier) ||
+	    Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
+		/* Let primary-modifier and shift-only scroll propagate to editor-level handlers. */
 		return false;
 	}
 

--- a/gtk2_ardour/midi_view.cc
+++ b/gtk2_ardour/midi_view.cc
@@ -760,10 +760,9 @@ MidiView::scroll (GdkEventScroll* ev)
 		return false;
 	}
 
-	if (Keyboard::modifier_state_equals (ev->state, Keyboard::PrimaryModifier)) {
-		/* XXX: bit of a hack; allow PrimaryModifier scroll
-		 * through so that it still works for navigation and zoom.
-		 */
+	if (Keyboard::modifier_state_equals (ev->state, Keyboard::PrimaryModifier) ||
+	    Keyboard::modifier_state_equals (ev->state, Keyboard::ScrollHorizontalModifier)) {
+		/* Let primary-modifier and shift-only scroll propagate to editor-level handlers. */
 		return false;
 	}
 


### PR DESCRIPTION
When mouse is on the midi region on the track and whether a midi note is selected or not, it should scroll horizontally when shift + scroll is performed. That is how it used to work in 8.x version.
Right now, when shift+scroll is performed, then it changes velocity when midi note is selected, or performs normal vertical scroll when not selected. It basically ignores vertical scroll.
The regression happened from this commit: c509de6814

Resolves: https://tracker.ardour.org/view.php?id=10108