### PR TITLE
start rejecting invalid session state (fixes crash in #10274)

### DIFF
--- a/libs/pbd/pbd/string_convert.h
+++ b/libs/pbd/pbd/string_convert.h
@@ -20,6 +20,7 @@
 #define PBD_STRING_CONVERT_H
 
 #include <string>
+#include <functional>
 #include <stdint.h>
 
 #include "pbd/libpbd_visibility.h"
@@ -64,8 +65,10 @@ LIBPBD_API bool string_to_int64 (const std::string& str, int64_t& val);
 
 LIBPBD_API bool string_to_uint64 (const std::string& str, uint64_t& val);
 
+LIBPBD_API bool string_to_float (const std::string& str, float& val, std::function<bool(const float&)> filter);
 LIBPBD_API bool string_to_float (const std::string& str, float& val);
 
+LIBPBD_API bool string_to_double (const std::string& str, double& val, std::function<bool(const double&)> filter);
 LIBPBD_API bool string_to_double (const std::string& str, double& val);
 
 template <class T>
@@ -217,13 +220,34 @@ inline bool string_to (const std::string& str, uint64_t& val)
 template <class T>
 inline bool string_to (const std::string& str, float& val)
 {
-	return string_to_float (str, val);
+	return string_to_float (str, val, [](auto) { return true; });
 }
 
 template <class T>
 inline bool string_to (const std::string& str, double& val)
 {
-	return string_to_double (str, val);
+	return string_to_double (str, val, [](auto) { return true; });
+}
+
+template <class T, class Filter>
+inline T string_to_if (const std::string& str, T& val, Filter filter)
+{
+	// This will cause a compile time error if this function is ever
+	// instantiated, which is useful to catch unintended conversions
+	typename T::STRING_TO_OR_REJECT_TEMPLATE_NOT_DEFINED_FOR_THIS_TYPE invalid_type;
+	return T();
+}
+
+template <class T, class Filter>
+inline bool string_to_if (const std::string& str, float& val, Filter filter)
+{
+	return string_to_float (str, val, filter);
+}
+
+template <class T, class Filter>
+inline bool string_to_if (const std::string& str, double& val, Filter filter)
+{
+	return string_to_double (str, val, filter);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -349,7 +373,7 @@ inline int8_t string_to (const std::string& str)
 {
 	int16_t tmp;
 	string_to_int16 (str, tmp);
-	return (int8_t) tmp;
+	return (int8_t)tmp;
 }
 
 template <>

--- a/libs/pbd/pbd/xml++.h
+++ b/libs/pbd/pbd/xml++.h
@@ -171,6 +171,10 @@ public:
 
 	bool get_property (const char* name, std::string& value) const;
 
+	/**
+	 * This is a variant of get_property that is implemented for all types,
+	 * including floats and doubles, that rejects missing or invalid values.
+	 */
 	template <class T>
 	bool get_property (const char* name, T& value) const
 	{
@@ -180,6 +184,23 @@ public:
 		}
 
 		return PBD::string_to<T> (prop->value (), value);
+	}
+
+	/**
+	 * A variant of get_property that is implemented for all types, including
+	 * floats and doubles, that rejects missing or invalid values, and applies a
+	 * filter before accepting a value.
+	 */
+	template <class T, class Filter>
+	bool get_property_if (const char* name, T& value, Filter filter) const
+	{
+		XMLProperty const* const prop = property (name);
+
+		if (!prop) {
+			return false;
+		}
+
+		return PBD::string_to_if<T, Filter> (prop->value (), value, filter);
 	}
 
 	void remove_property(const std::string&);

--- a/libs/pbd/string_convert.cc
+++ b/libs/pbd/string_convert.cc
@@ -143,28 +143,30 @@ bool string_to_uint64 (const std::string& str, uint64_t& val)
 	return true;
 }
 
-template <class FloatType>
-static bool
-_string_to_infinity (const std::string& str, FloatType& val)
+bool string_to_float (const std::string& str, float& val, std::function<bool(const float&)> filter)
 {
-	if (!g_ascii_strncasecmp (str.c_str (), X_ ("inf"), str.length ()) ||
-	    !g_ascii_strncasecmp (str.c_str (), X_ ("+inf"), str.length ()) ||
-	    !g_ascii_strncasecmp (str.c_str (), X_ ("INFINITY"), str.length ()) ||
-	    !g_ascii_strncasecmp (str.c_str (), X_ ("+INFINITY"), str.length ())) {
-		val = std::numeric_limits<FloatType>::infinity ();
-		return true;
-	} else if (!g_ascii_strncasecmp (str.c_str (), X_ ("-inf"), str.length ()) ||
-	           !g_ascii_strncasecmp (str.c_str (), X_ ("-INFINITY"), str.length ())) {
-		val = -std::numeric_limits<FloatType>::infinity ();
+	auto inner_filter = [filter = std::move(filter)](const double& value) {
+		return filter((float) value);
+	};
+
+	double tmp;
+
+	if (string_to_double (str, tmp, inner_filter)) {
+		val = (float)tmp;
 		return true;
 	}
+
 	return false;
 }
 
-bool
-_string_to_double (const std::string& str, double& val)
+bool string_to_float (const std::string& str, float& val)
 {
-	val = g_ascii_strtod (str.c_str (), NULL);
+	return string_to_float (str, val, [](const float&) { return true; });
+}
+
+bool string_to_double (const std::string& str, double& val, std::function<bool(const double&)> filter)
+{
+	double tmp = g_ascii_strtod (str.c_str (), NULL);
 
 	// It is possible that the conversion was successful and another thread
 	// has set errno meanwhile but as most conversions are currently not
@@ -175,35 +177,34 @@ _string_to_double (const std::string& str, double& val)
 		// contents so returning false here should not have any impact...
 		return false;
 	}
+
+	// We've eskewed all other tests for infinite values except here, and it's
+	// worth elaborating why.
+    //
+	// We had a list of fixed strings that we tested against (`inf`, `INFINITY`,
+	// ...), but all of those values are non-numerical values which are not
+	// supported by g_ascii_strtod and would fail with ERANGE above.
+	//
+	// There are values that g_ascii_strtod supports which we did not catch
+	// before (very specifically NaN). Instead of matching the internal
+	// representation of g_ascii_strtod we opt to reject the output.
+	if (!std::isfinite(tmp)) {
+		DEBUG_SCONVERT (string_compose ("string_to_double tried to produce non-finite value for %1", str));
+		return false;
+	}
+
+	if (!filter(tmp)) {
+		DEBUG_SCONVERT (string_compose ("string_to_double value rejected by filter for %1", str));
+		return false;
+	}
+
+	val = tmp;
 	return true;
-}
-
-bool string_to_float (const std::string& str, float& val)
-{
-	double tmp;
-	if (_string_to_double (str, tmp)) {
-		val = (float)tmp;
-		return true;
-	}
-
-	if (_string_to_infinity (str, val)) {
-		return true;
-	}
-
-	return false;
 }
 
 bool string_to_double (const std::string& str, double& val)
 {
-	if (_string_to_double (str, val)) {
-		return true;
-	}
-
-	if (_string_to_infinity (str, val)) {
-		return true;
-	}
-
-	return false;
+	return string_to_double (str, val, [](const double&) { return true; });
 }
 
 bool bool_to_string (bool val, std::string& str)
@@ -306,17 +307,23 @@ bool uint64_to_string (uint64_t val, std::string& str)
 	return true;
 }
 
+/**
+ * Fixate some non-finite floating point values to preferred representations.
+ */
 template <class FloatType>
 static bool
-_infinity_to_string (FloatType val, std::string& str)
+_non_finite_to_string (FloatType val, std::string& str)
 {
-	if (val == std::numeric_limits<FloatType>::infinity ()) {
-		str = "inf";
+	if (std::isinf(val)) {
+		str = val < 0.0 ? "-inf" : "inf";
 		return true;
-	} else if (val == -std::numeric_limits<FloatType>::infinity ()) {
-		str = "-inf";
+	} else if (std::isnan (val)) {
+		str = "nan";
 		return true;
 	}
+
+	// NB: We still fall through to _double_to_string for denormal values and
+	// let it handle them as-it-sees-fit. They will *likely* flush to zero.
 	return false;
 }
 
@@ -330,13 +337,14 @@ _double_to_string (double val, std::string& str)
 	if (d_cstr == NULL) {
 		return false;
 	}
+
 	str = d_cstr;
 	return true;
 }
 
 bool float_to_string (float val, std::string& str)
 {
-	if (_infinity_to_string (val, str)) {
+	if (_non_finite_to_string (val, str)) {
 		return true;
 	}
 
@@ -350,7 +358,7 @@ bool float_to_string (float val, std::string& str)
 
 bool double_to_string (double val, std::string& str)
 {
-	if (_infinity_to_string (val, str)) {
+	if (_non_finite_to_string (val, str)) {
 		return true;
 	}
 

--- a/libs/pbd/test/string_convert_test.cc
+++ b/libs/pbd/test/string_convert_test.cc
@@ -430,9 +430,10 @@ _test_infinity_conversion ()
 
 	for (std::vector<std::string>::const_iterator i = pos_inf_strings.begin ();
 	     i != pos_inf_strings.end (); ++i) {
-		FloatType pos_infinity_arg;
-		CPPUNIT_ASSERT (string_to<FloatType> (*i, pos_infinity_arg));
-		CPPUNIT_ASSERT_EQUAL (pos_infinity_arg, pos_infinity);
+		FloatType pos_infinity_arg = (FloatType) 42.0;
+		CPPUNIT_ASSERT (!string_to<FloatType> (*i, pos_infinity_arg));
+		// argument should not be modified
+		CPPUNIT_ASSERT_EQUAL (pos_infinity_arg, (FloatType) 42.0);
 	}
 
 	// Check string -> float for all supported string representations of "-INFINITY"
@@ -440,14 +441,44 @@ _test_infinity_conversion ()
 
 	for (std::vector<std::string>::const_iterator i = neg_inf_strings.begin ();
 	     i != neg_inf_strings.end (); ++i) {
-		FloatType neg_infinity_arg;
-		CPPUNIT_ASSERT (string_to<FloatType> (*i, neg_infinity_arg));
-		CPPUNIT_ASSERT_EQUAL (neg_infinity_arg, neg_infinity);
+		FloatType neg_infinity_arg = (FloatType) 42.0;
+		CPPUNIT_ASSERT (!string_to<FloatType> (*i, neg_infinity_arg));
+		// argument should not be modified
+		CPPUNIT_ASSERT_EQUAL (neg_infinity_arg, (FloatType) 42.0);
 	}
 
-	// Check round-trip equality
-	CPPUNIT_ASSERT_EQUAL (pos_infinity, string_to<FloatType> (to_string<FloatType> (pos_infinity)));
-	CPPUNIT_ASSERT_EQUAL (neg_infinity, string_to<FloatType> (to_string<FloatType> (neg_infinity)));
+	// Ensure that the to_string infinite representations are rejected while
+	// reading.
+	auto pos_inf_str = to_string<FloatType> (pos_infinity);
+	FloatType pos_inf_val = (FloatType) 42.0;
+	CPPUNIT_ASSERT (!string_to<FloatType> (pos_inf_str, pos_inf_val));
+	CPPUNIT_ASSERT_EQUAL (pos_inf_val, (FloatType) 42.0);
+
+	auto neg_inf_str = to_string<FloatType> (neg_infinity);
+	FloatType neg_inf_val = (FloatType) 42.0;
+	CPPUNIT_ASSERT (!string_to<FloatType> (neg_inf_str, neg_inf_val));
+	CPPUNIT_ASSERT_EQUAL (neg_inf_val, (FloatType) 42.0);
+}
+
+static const std::string QUIET_NAN_STR ("nan");
+
+template <class FloatType>
+void
+_test_nan_conversion ()
+{
+	const FloatType nan_value = numeric_limits<FloatType>::quiet_NaN ();
+
+	// Check float -> string
+	string str;
+	CPPUNIT_ASSERT (to_string<FloatType> (nan_value, str));
+	CPPUNIT_ASSERT_EQUAL (QUIET_NAN_STR, str);
+
+	// Ensure that the to_string NaN representations are rejected while
+	// reading.
+	auto nan_str = to_string<FloatType> (nan_value);
+	FloatType nan_val = (FloatType) 42.0;
+	CPPUNIT_ASSERT (!string_to<FloatType> (nan_str, nan_val));
+	CPPUNIT_ASSERT_EQUAL (nan_val, (FloatType) 42.0);
 }
 
 static const std::string MAX_FLOAT_WIN ("3.4028234663852886e+038");
@@ -512,6 +543,7 @@ _test_float_conversion ()
 #endif
 
 	_test_infinity_conversion<float>();
+	_test_nan_conversion<float>();
 }
 
 void
@@ -555,6 +587,7 @@ _test_double_conversion ()
 	CPPUNIT_ASSERT_EQUAL (min, string_to<double>(to_string<double> (min)));
 
 	_test_infinity_conversion<double>();
+	_test_nan_conversion<double>();
 }
 
 void

--- a/libs/temporal/tempo.cc
+++ b/libs/temporal/tempo.cc
@@ -92,12 +92,13 @@ Tempo::Tempo (XMLNode const & node)
 {
 	TEMPO_MAP_ASSERT (node.name() == xml_node_name);
 
+	if (node.get_property_if (X_("npm"), _npm, [](auto v) { return v != 0.0; })) {
+		_superclocks_per_note_type = double_npm_to_scpn (_npm);
+	}
 
-	node.get_property (X_("npm"), _npm);
-	node.get_property (X_("enpm"), _enpm);
-
-	_superclocks_per_note_type = double_npm_to_scpn (_npm);
-	_end_superclocks_per_note_type = double_npm_to_scpn (_enpm);
+	if (node.get_property_if (X_("enpm"), _enpm, [](auto v) { return v != 0.0; })) {
+		_end_superclocks_per_note_type = double_npm_to_scpn (_enpm);
+	}
 
 	if (!node.get_property (X_("note-type"), _note_type)) {
 		throw failed_constructor ();
@@ -164,11 +165,13 @@ Tempo::set_state (XMLNode const & node, int /*version*/)
 		return -1;
 	}
 
-	node.get_property (X_("npm"), _npm);
-	node.get_property (X_("enpm"), _enpm);
+	if (node.get_property_if (X_("npm"), _npm, [](auto v) { return v != 0.0; })) {
+		_superclocks_per_note_type = double_npm_to_scpn (_npm);
+	}
 
-	_superclocks_per_note_type = double_npm_to_scpn (_npm);
-	_end_superclocks_per_note_type = double_npm_to_scpn (_enpm);
+	if (node.get_property_if (X_("enpm"), _enpm, [](auto v) { return v != 0.0; })) {
+		_end_superclocks_per_note_type = double_npm_to_scpn (_enpm);
+	}
 
 	node.get_property (X_("note-type"), _note_type);
 


### PR DESCRIPTION
In this patch I've fixed loading of sessions that contain "invalid" float values which causes various crashes I've found in relation to https://tracker.ardour.org/view.php?id=10274 when I tried to load a corrupted session file.

#### Background

While it's not expected that Ardour will save infinites or nans to a session file, it is a format that is specifically supported by the string_to_* family of functions (either explicitly or implicitly through the glib double-to-string implementation), so hardening session loading against memory issues when these are encountered is important. Session files are just regular files after all, and might be shared across systems. It is in my view a useful goal that Ardour tries to eliminate potential vectors for logic bugs that might lead to more serious issues by validating untrusted inputs.

#### Implementation

This is just the first step. I removed support for loading floats from the existing `get_property` function and added another called `get_property_or_reject`. This was just done to ensure that all cases where floats are involved are caught as compilation errors. Additionally the last parameter acts as a filter, that can be used to perform more input validation. I've only included one such example right now that I think is correct, but more could be added.

I've also added a non-fallible (as in it cannot fail) variant which is simply called `get_property_or_default`, that if a property is rejected will simply use a default value instead.

I think the behavior of `get_property_or_reject` could and probably should more-or-less be merged into `get_property`. Right now I'm keeping it separate because 1) it's easier for my editor to search for it and 2) I personally don't like overloads that differ too much. Once filters have been added everywhere appropriate the remaining calls can be folded back into `get_property` with a default permissible filter.

Since how to approach this is matter of opinion I'm open to feedback. Consider this patch a suggestion.