### PR TITLE
Fix crash that happens when bottom piano roll is open and the audio recording renders waveform

### DIFF
--- a/gtk2_ardour/selection_properties_box.cc
+++ b/gtk2_ardour/selection_properties_box.cc
@@ -274,7 +274,11 @@ SelectionPropertiesBox::selection_changed ()
 #endif
 			}
 
-			rv->RegionViewGoingAway.connect_same_thread (_region_connection, std::bind (&SelectionPropertiesBox::delete_region_editor, this));
+			rv->RegionViewGoingAway.connect_same_thread (_region_connection, [this, rv] (RegionView* going_away) {
+				if (going_away == rv) {
+					delete_region_editor ();
+				}
+			});
 		}
 
 		show_similar_midi_regions (rs);


### PR DESCRIPTION
For steps to reproduce, refer to the bug: https://tracker.ardour.org/view.php?id=10276
This PR addresses that bug.

The application crashes in this scenario because when the waveform of a audio recording is rendered, it creates a temporary region. When the recording is stopped, the region is removed. That triggers the signal RegionViewGoingAway globally to all regions, including the midi region with the bottom piano roll open. The signal then calls delete_region_editor() which then deletes the _pianoroll. This is just supposed to close the bottom piano roll once the _pianoroll is deleted, but the signal in the method Pianoroll::set_session() which uses MISSING_INVALIDATOR does not cancel and causes the crash.
The fix only calls delete_region_editor() to delete the _pianoroll when the same region is going away.