### PR TITLE
more guarded git commands in waf

### DIFF
--- a/wscript
+++ b/wscript
@@ -170,15 +170,25 @@ compiler_flags_dictionaries['clang15-darwin'] = clang15_darwin_dict
 
 # Version stuff
 
+def git(args):
+    cmd = ["git"] + args
+    p = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
+    p.wait()
+    (out, _) = p.communicate()
+    assert p.returncode == 0, "git {}: {}: {}".format(' '.join(args), p.returncode, out.decode('utf-8').strip())
+
+    lines = out.decode('utf-8').strip().splitlines()
+
+    if not lines:
+        raise Exception("git {}: no output".format(' '.join(args)))
+
+    return lines[0]
+
 def fetch_git_revision_date ():
-    cmd = ["git", "describe", "HEAD"]
-    output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE).communicate()[0].splitlines()
-    rev = re.sub(r"^[A-Za-z0-9]*\+", "", output[0].decode('utf-8'))
-
-    cmd = ["git", "log", "-1", "--pretty=format:%ci", "HEAD"]
-    output = subprocess.Popen(cmd, stderr=subprocess.STDOUT, stdout=subprocess.PIPE).communicate()[0].splitlines()
-    date = output[0].decode('utf-8').split(None, 2)[0]
-
+    output = git(["describe", "HEAD"])
+    rev = re.sub(r"^[A-Za-z0-9]*\+", "", output)
+    output = git(["log", "-1", "--pretty=format:%ci", "HEAD"])
+    date = output.split(None, 2)[0]
     return rev, date
 
 def fetch_tarball_revision_date():


### PR DESCRIPTION
Right now, if you check out Ardour without tags and try to build it you get an interesting error during configuration:

```
Traceback (most recent call last):
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Scripting.py", line 119, in waf_entry_point
    run_commands()
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Scripting.py", line 182, in run_commands
    ctx=run_command(cmd_name)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Scripting.py", line 173, in run_command
    ctx.execute()
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Configure.py", line 85, in execute
    super(ConfigurationContext,self).execute()
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Context.py", line 92, in execute
    self.recurse([os.path.dirname(g_module.root_path)])
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Context.py", line 133, in recurse
    user_function(self)
  File "/home/runner/work/ardour/ardour/wscript", line 1482, in configure
    conf.recurse(i)
  File "/home/runner/work/ardour/ardour/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Context.py", line 133, in recurse
    user_function(self)
  File "/home/runner/work/ardour/ardour/gtk2_ardour/wscript", line 542, in configure
    conf.define('CODENAME', enoify(int(conf.env['MAJOR']), int(conf.env['MINOR'])))
                                   ^^^^^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: 'fatal: No names found, cannot describe anything'
```

After this change we catch and prints the failing git command instead of having it leak into the build process, making it clearer what goes wrong:

```
Traceback (most recent call last):
  File "ardour-shallow/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Scripting.py", line 119, in waf_entry_point
    run_commands()
    ~~~~~~~~~~~~^^
  File "ardour-shallow/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Scripting.py", line 182, in run_commands
    ctx=run_command(cmd_name)
  File "ardour-shallow/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Scripting.py", line 173, in run_command
    ctx.execute()
    ~~~~~~~~~~~^^
  File "ardour-shallow/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Configure.py", line 85, in execute
    super(ConfigurationContext,self).execute()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "ardour-shallow/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Context.py", line 92, in execute
    self.recurse([os.path.dirname(g_module.root_path)])
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "ardour-shallow/.waf3-2.0.26-44bc421a5f6bb452d70d83cbd5abc3fa/waflib/Context.py", line 133, in recurse
    user_function(self)
    ~~~~~~~~~~~~~^^^^^^
  File "ardour-shallow/wscript", line 973, in configure
    set_version ()
    ~~~~~~~~~~~~^^
  File "ardour-shallow/wscript", line 275, in set_version
    rev, rev_date = fetch_git_revision_date()
                    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "ardour-shallow/wscript", line 188, in fetch_git_revision_date
    output = git(["describe", "HEAD"])
  File "ardour-shallow/wscript", line 178, in git
    assert p.returncode == 0, "git {}: {}: {}".format(' '.join(args), p.returncode, out.decode('utf-8').strip())
           ^^^^^^^^^^^^^^^^^
AssertionError: git describe HEAD: 128: fatal: No names found, cannot describe anything.
```