### PR TITLE
Remove duplicate include statement

### DIFF
--- a/gtk2_ardour/midi_time_axis.cc
+++ b/gtk2_ardour/midi_time_axis.cc
@@ -101,8 +101,6 @@
 #include "step_editor.h"
 #include "note_base.h"
 
-#include "ardour/midi_track.h"
-
 #include "pbd/i18n.h"
 
 using namespace ARDOUR;


### PR DESCRIPTION
Redoing https://github.com/Ardour/ardour/pull/1102

The following 2 commits added the same include statement in the same file:

https://github.com/Ardour/ardour/commit/e0aaed6d65f
https://github.com/Ardour/ardour/commit/6fa6514cfdb

Looks like an oversight, so removing it.

