### PR TITLE
Fix DPF MIDI CC regex

### DIFF
--- a/libs/ardour/vst3_plugin.cc
+++ b/libs/ardour/vst3_plugin.cc
@@ -1345,7 +1345,7 @@ VST3PI::VST3PI (std::shared_ptr<ARDOUR::VST3PluginModule> m, std::string unique_
 	int32 n_params = _controller->getParameterCount ();
 	DEBUG_TRACE (DEBUG::VST3Config, string_compose ("VST3 parameter count: %1\n", n_params));
 
-	std::regex dpf_midi_CC ("MIDI Ch. [0-9]+ CC [0-9]+");
+	std::regex dpf_midi_CC ("MIDI Ch\\. [0-9]+ CC [0-9]+");
 
 	for (int32 i = 0; i < n_params; ++i) {
 		Vst::ParameterInfo pi;


### PR DESCRIPTION
Match dot with `\.` instead of `.`