### PR TITLE
mcp_http: simplify MIDI JSON import format

### DIFF
--- a/libs/surfaces/mcp_http/README.md
+++ b/libs/surfaces/mcp_http/README.md
@@ -135,11 +135,20 @@ Use the JSON tools for fast note generation and round-trip editing:
 - Beat and tick fields:
   - `b` is beat number in the bar and may be fractional. Example: `b: 1.5` is an off-beat 8th note in 4/4.
   - `t` is additional tick offset inside the beat, using `ticks_per_quarter`.
+- Note length:
+  - `l` is note length in Ardour beats and may be fractional. Example: `l: 0.5` is an 8th note in 4/4.
+  - For melodic MIDI, omit `l` to use a default length of 1 beat.
+- Repeat bars:
+  - Use `{ "bar": 2, "repeat": 1 }` to copy all notes from relative bar 1 into relative bar 2.
+  - A repeat item should only include `bar` and `repeat`; do not include note fields on the same item.
 - Drum mode behavior:
-  - `is_drum_mode: true`: `note_off` events are optional; you can provide drum hits as `note_on` only.
-  - Imported hits are written as zero-length notes (note-on and note-off at the same timestamp).
+  - `is_drum_mode` defaults to `false`; omit it for melodic parts, bass lines, chords, and other sustained MIDI.
+  - When `is_drum_mode` is omitted, `channel` defaults to `1`.
+  - Set `is_drum_mode: true` for drum grooves; note items do not need `l` unless you want a visible duration.
+  - When `is_drum_mode: true`, omitted `channel` defaults to `10` with one-based channel numbering.
+  - Imported drum hits default to zero-length notes (note-on and note-off at the same timestamp).
 - Non-drum mode behavior:
-  - Use normal `note_on` + `note_off` timing pairs for sustained notes/chords.
+  - Use `l` for sustained notes/chords instead of separate `note_on` and `note_off` events.
 
 ## Prompt Cookbook
 

--- a/libs/surfaces/mcp_http/mcp_http_server.cc
+++ b/libs/surfaces/mcp_http/mcp_http_server.cc
@@ -23,7 +23,6 @@
 #include <cmath>
 #include <condition_variable>
 #include <cstdlib>
-#include <cstring>
 #include <ctime>
 #include <iomanip>
 #include <map>
@@ -1387,7 +1386,7 @@ struct MidiJsonEventDef {
 	int         note;
 	int         velocity;
 	int         channel;
-	std::string type;
+	double      length;
 };
 
 struct MidiJsonNoteDef {
@@ -1600,7 +1599,9 @@ parse_midi_json_events (
 		return false;
 	}
 
-	const int64_t default_channel = one_based_channel_input ? 10 : 9;
+	is_drum_mode = midi_root.get<bool> ("is_drum_mode", false);
+
+	const int64_t default_channel = is_drum_mode ? (one_based_channel_input ? 10 : 9) : (one_based_channel_input ? 1 : 0);
 	const int64_t channel_in      = midi_root.get<int64_t> ("channel", default_channel);
 	if (!parse_midi_json_channel_value (channel_in, one_based_channel_input, "midi.channel", channel, error)) {
 		if (!explicit_channel_base) {
@@ -1608,8 +1609,6 @@ parse_midi_json_events (
 		}
 		return false;
 	}
-
-	is_drum_mode = midi_root.get<bool> ("is_drum_mode", true);
 
 	const int64_t tpq_in = midi_root.get<int64_t> ("ticks_per_quarter", 480);
 	if (tpq_in <= 0 || tpq_in > 96000) {
@@ -1635,7 +1634,12 @@ parse_midi_json_events (
 		const pt::ptree& ev = it->second;
 
 		if (get_optional_std<std::string> (ev, "comment")) {
-			continue;
+			error = "midi event comments are not supported";
+			return false;
+		}
+		if (get_optional_std<std::string> (ev, "type")) {
+			error = "midi event type is not supported; use l for note length instead of note_on/note_off events";
+			return false;
 		}
 
 		const std::optional<int64_t> bar_opt = get_optional_std<int64_t> (ev, "bar");
@@ -1647,12 +1651,16 @@ parse_midi_json_events (
 
 		const std::optional<int64_t> repeat_opt = get_optional_std<int64_t> (ev, "repeat");
 		if (repeat_opt) {
-			if (*repeat_opt < 0 || *repeat_opt > 1000000) {
-				error = "Invalid repeat value (expected >= 0)";
+			if (get_optional_std<double> (ev, "b") || get_optional_std<int64_t> (ev, "n") || get_optional_std<int64_t> (ev, "v") || get_optional_std<double> (ev, "l") || get_optional_std<int64_t> (ev, "t") || get_optional_std<int64_t> (ev, "channel")) {
+				error = "Repeat midi events must only provide bar and repeat";
+				return false;
+			}
+			if (*repeat_opt < 1 || *repeat_opt > 1000000) {
+				error = "Invalid repeat value (expected source bar >= 1)";
 				return false;
 			}
 
-			const int                                                    source_bar = (*repeat_opt == 0) ? (bar - 1) : (int)*repeat_opt;
+			const int                                                    source_bar = (int)*repeat_opt;
 			std::map<int, std::vector<MidiJsonEventDef>>::const_iterator src        = events_by_bar.find (source_bar);
 			if (src == events_by_bar.end ()) {
 				std::ostringstream w;
@@ -1672,13 +1680,24 @@ parse_midi_json_events (
 
 		const std::optional<double> beat_opt = get_optional_std<double> (ev, "b");
 		if (!beat_opt || !std::isfinite (*beat_opt) || *beat_opt < 1.0) {
-			error = "Each normal midi event must provide b >= 1";
+			error = "Each midi note event must provide b >= 1";
 			return false;
 		}
 
 		const std::optional<int64_t> note_opt = get_optional_std<int64_t> (ev, "n");
 		if (!note_opt || *note_opt < 0 || *note_opt > 127) {
-			error = "Each normal midi event must provide n (0..127)";
+			error = "Each midi note event must provide n (0..127)";
+			return false;
+		}
+
+		const double default_length = is_drum_mode ? 0.0 : 1.0;
+		const double length_in      = ev.get<double> ("l", default_length);
+		if (!std::isfinite (length_in) || length_in < 0.0) {
+			error = "Invalid midi event l (expected note length >= 0)";
+			return false;
+		}
+		if (!is_drum_mode && length_in <= 0.0) {
+			error = "Invalid midi event l (expected note length > 0 when is_drum_mode is false)";
 			return false;
 		}
 
@@ -1705,9 +1724,6 @@ parse_midi_json_events (
 			}
 		}
 
-		std::string type = ev.get<std::string> ("type", "note_on");
-		std::transform (type.begin (), type.end (), type.begin (), ::tolower);
-
 		MidiJsonEventDef out;
 		out.bar      = bar;
 		out.beat     = *beat_opt;
@@ -1715,7 +1731,7 @@ parse_midi_json_events (
 		out.note     = (int)*note_opt;
 		out.velocity = (int)velocity_in;
 		out.channel  = event_channel;
-		out.type     = type;
+		out.length   = length_in;
 
 		expanded_events.push_back (out);
 		events_by_bar[bar].push_back (out);
@@ -1726,14 +1742,13 @@ parse_midi_json_events (
 
 static bool
 build_midi_json_note_defs (
-    const std::vector<MidiJsonEventDef>& expanded_events,
-    bool                                 is_drum_mode,
-    int                                  ticks_per_quarter,
-    int                                  time_sig_num,
-    int                                  time_sig_den,
-    std::vector<MidiJsonNoteDef>&        notes,
-    std::vector<std::string>&            warnings,
-    std::string&                         error)
+	const std::vector<MidiJsonEventDef>& expanded_events,
+	int                                  ticks_per_quarter,
+	int                                  time_sig_num,
+	int                                  time_sig_den,
+	std::vector<MidiJsonNoteDef>&        notes,
+	std::vector<std::string>&            warnings,
+	std::string&                         error)
 {
 	notes.clear ();
 	error.clear ();
@@ -1770,85 +1785,22 @@ build_midi_json_note_defs (
 		    return a.ordinal < b.ordinal;
 	    });
 
-	if (is_drum_mode) {
-		const double default_length = 0.0;
-
-		for (size_t i = 0; i < events.size (); ++i) {
-			MidiJsonNoteDef n;
-			n.start_quarters  = events[i].quarters;
-			n.length_quarters = default_length;
-			n.note            = events[i].ev.note;
-			n.velocity        = events[i].ev.velocity;
-			n.channel         = events[i].ev.channel;
-			notes.push_back (n);
-		}
-		return true;
-	}
-
-	struct PendingOn {
-		double quarters;
-		int    velocity;
-	};
-	std::map<int, std::vector<PendingOn>> active_by_note;
-
 	for (size_t i = 0; i < events.size (); ++i) {
-		const MidiJsonEventDef& ev       = events[i].ev;
-		const bool              is_off   = (ev.type == "note_off") || (ev.velocity == 0);
-		const bool              is_on    = (ev.type.empty () || ev.type == "note_on");
-		const int               note_key = (ev.channel * 128) + ev.note;
-
-		if (is_off) {
-			std::vector<PendingOn>& stack = active_by_note[note_key];
-			if (stack.empty ()) {
-				std::ostringstream w;
-				w << "Unmatched note_off skipped for note " << ev.note << " on channel " << (ev.channel + 1) << " at bar " << ev.bar;
-				warnings.push_back (w.str ());
-				continue;
-			}
-
-			const PendingOn on = stack.back ();
-			stack.pop_back ();
-
-			const double len = events[i].quarters - on.quarters;
-			if (!std::isfinite (len) || len <= 0.0) {
-				std::ostringstream w;
-				w << "Non-positive note length skipped for note " << ev.note << " at bar " << ev.bar;
-				warnings.push_back (w.str ());
-				continue;
-			}
-
-			MidiJsonNoteDef n;
-			n.start_quarters  = on.quarters;
-			n.length_quarters = len;
-			n.note            = ev.note;
-			n.velocity        = on.velocity;
-			n.channel         = ev.channel;
-			notes.push_back (n);
-			continue;
-		}
-
-		if (!is_on) {
+		const MidiJsonEventDef& ev = events[i].ev;
+		if (!std::isfinite (ev.length) || ev.length < 0.0) {
 			std::ostringstream w;
-			w << "Unknown event type '" << ev.type << "' skipped at bar " << ev.bar;
+			w << "Invalid note length skipped for note " << ev.note << " at bar " << ev.bar;
 			warnings.push_back (w.str ());
 			continue;
 		}
 
-		PendingOn on;
-		on.quarters = events[i].quarters;
-		on.velocity = ev.velocity;
-		active_by_note[note_key].push_back (on);
-	}
-
-	for (std::map<int, std::vector<PendingOn>>::const_iterator it = active_by_note.begin (); it != active_by_note.end (); ++it) {
-		if (!it->second.empty ()) {
-			const int          channel = it->first / 128;
-			const int          note    = it->first % 128;
-			std::ostringstream w;
-			w << "Unclosed note_on skipped for note " << note << " on channel " << (channel + 1)
-			  << " (" << it->second.size () << " pending)";
-			warnings.push_back (w.str ());
-		}
+		MidiJsonNoteDef n;
+		n.start_quarters  = events[i].quarters;
+		n.length_quarters = ev.length;
+		n.note            = ev.note;
+		n.velocity        = ev.velocity;
+		n.channel         = ev.channel;
+		notes.push_back (n);
 	}
 
 	return true;
@@ -6717,7 +6669,7 @@ handle_midi_note_import_json_tool (ARDOUR::Session& session, pt::ptree& root, co
 	std::vector<std::string>      warnings;
 	int                           channel                 = 9;
 	bool                          one_based_channel_input = true;
-	bool                          is_drum_mode            = true;
+	bool                          is_drum_mode            = false;
 	int                           ticks_per_quarter       = 480;
 	int                           time_sig_num            = 4;
 	int                           time_sig_den            = 4;
@@ -6726,7 +6678,7 @@ handle_midi_note_import_json_tool (ARDOUR::Session& session, pt::ptree& root, co
 	if (!parse_midi_json_events (*midi_opt, expanded_events, channel, one_based_channel_input, is_drum_mode, ticks_per_quarter, time_sig_num, time_sig_den, warnings, parse_error)) {
 		return jsonrpc_error (id, -32602, parse_error);
 	}
-	if (!build_midi_json_note_defs (expanded_events, is_drum_mode, ticks_per_quarter, time_sig_num, time_sig_den, note_defs, warnings, parse_error)) {
+	if (!build_midi_json_note_defs (expanded_events, ticks_per_quarter, time_sig_num, time_sig_den, note_defs, warnings, parse_error)) {
 		return jsonrpc_error (id, -32602, parse_error);
 	}
 
@@ -6875,11 +6827,11 @@ handle_midi_note_get_json_tool (ARDOUR::Session& session, pt::ptree& root, const
 
 	struct ExportEvent {
 		double      quarters;
+		double      length;
 		size_t      ordinal;
 		int         note;
 		int         velocity;
 		int         channel;
-		const char* type;
 	};
 
 	std::vector<ExportEvent> events;
@@ -6926,25 +6878,14 @@ handle_midi_note_get_json_tool (ARDOUR::Session& session, pt::ptree& root, const
 			continue;
 		}
 
-		const size_t base_ordinal = events.size ();
-
-		ExportEvent on;
-		on.quarters = start_quarters;
-		on.ordinal  = base_ordinal;
-		on.note     = note_num;
-		on.velocity = velocity;
-		on.channel  = channel;
-		on.type     = "note_on";
-		events.push_back (on);
-
-		ExportEvent off;
-		off.quarters = end_quarters;
-		off.ordinal  = base_ordinal + 1;
-		off.note     = note_num;
-		off.velocity = 0;
-		off.channel  = channel;
-		off.type     = "note_off";
-		events.push_back (off);
+		ExportEvent ev;
+		ev.quarters = start_quarters;
+		ev.length   = end_quarters - start_quarters;
+		ev.ordinal  = events.size ();
+		ev.note     = note_num;
+		ev.velocity = velocity;
+		ev.channel  = channel;
+		events.push_back (ev);
 
 		channel_counts[channel] += 1;
 		++notes_exported;
@@ -6953,21 +6894,13 @@ handle_midi_note_get_json_tool (ARDOUR::Session& session, pt::ptree& root, const
 	std::sort (
 	    events.begin (),
 	    events.end (),
-	    [] (const ExportEvent& a, const ExportEvent& b) {
-		    if (a.quarters != b.quarters) {
-			    return a.quarters < b.quarters;
-		    }
-		    if (a.channel == b.channel && a.note == b.note && a.ordinal != b.ordinal) {
-			    return a.ordinal < b.ordinal;
-		    }
-		    const int a_type_order = (std::strcmp (a.type, "note_off") == 0) ? 0 : 1;
-		    const int b_type_order = (std::strcmp (b.type, "note_off") == 0) ? 0 : 1;
-		    if (a_type_order != b_type_order) {
-			    return a_type_order < b_type_order;
-		    }
-		    if (a.channel != b.channel) {
-			    return a.channel < b.channel;
-		    }
+		    [] (const ExportEvent& a, const ExportEvent& b) {
+			    if (a.quarters != b.quarters) {
+				    return a.quarters < b.quarters;
+			    }
+			    if (a.channel != b.channel) {
+				    return a.channel < b.channel;
+			    }
 		    if (a.note != b.note) {
 			    return a.note < b.note;
 		    }
@@ -7002,12 +6935,12 @@ handle_midi_note_get_json_tool (ARDOUR::Session& session, pt::ptree& root, const
 			events_json << ",";
 		}
 		first_event = false;
-		events_json << "{\"bar\":" << bar
-		            << ",\"b\":" << beat
-		            << ",\"t\":" << tick
-		            << ",\"n\":" << events[i].note
-		            << ",\"v\":" << events[i].velocity
-		            << ",\"type\":\"" << events[i].type << "\"";
+			events_json << "{\"bar\":" << bar
+			            << ",\"b\":" << beat
+			            << ",\"t\":" << tick
+			            << ",\"n\":" << events[i].note
+			            << ",\"v\":" << events[i].velocity
+			            << ",\"l\":" << events[i].length;
 		if (events[i].channel != default_channel) {
 			events_json << ",\"channel\":" << (events[i].channel + 1);
 		}

--- a/libs/surfaces/mcp_http/tools_json.inc
+++ b/libs/surfaces/mcp_http/tools_json.inc
@@ -3129,7 +3129,7 @@ R"mcp(
     {
       "name": "midi_note_import_json_into_region",
       "title": "Import MIDI JSON Into Existing Region",
-      "description": "Import MIDI JSON into an existing MIDI region. midi.midi_events is required. Event positions (bar/b) are relative to region start: bar 1 beat 1 = region start, not absolute session time. b may be fractional, for example 1.5 for an off-beat 8th note in 4/4. t is tick offset within the beat using ticks_per_quarter. Channel numbering is 1..16 by default (channel_base=\"one\"). For legacy 0..15 payloads set channel_base=\"zero\". In drum mode (is_drum_mode=true), note_off events are optional; hits may be provided as note_on only.",
+      "description": "Import MIDI JSON notes into an existing MIDI region. midi.midi_events is required. Event positions are relative to region start: bar 1 beat 1 = region start, not absolute session time. Each normal item is one note: bar, b, n, optional v, optional l, optional t, optional channel. b may be fractional, for example 1.5 for an off-beat 8th note in 4/4. l is note length in Ardour beats and may be fractional; omit l for 1 beat in melodic mode or 0 beats in drum mode. t is extra tick offset inside the beat using ticks_per_quarter. Repeat items use only bar and repeat; repeat is the source bar number to copy. Channel numbering is 1..16 by default (channel_base=\"one\"). For legacy 0..15 payloads set channel_base=\"zero\". By default is_drum_mode is false and omitted channel defaults to 1. Set is_drum_mode=true for drums; then omitted channel defaults to 10.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3167,65 +3167,50 @@ R"mcp(
                   "properties": {
                     "bar": {
                       "type": "integer",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Region-relative bar number. Bar 1 starts at the beginning of the region."
                     },
                     "repeat": {
                       "type": "integer",
-                      "minimum": 0
+                      "minimum": 1,
+                      "description": "Optional source bar number to copy into this bar. Repeat items should only include bar and repeat."
                     },
                     "b": {
                       "type": "number",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Beat number inside the bar. Decimal values are allowed; 1.5 is the off-beat eighth note after beat 1 in 4/4."
                     },
                     "t": {
                       "type": "integer",
-                      "minimum": 0
+                      "minimum": 0,
+                      "description": "Optional additional tick offset inside the beat using ticks_per_quarter."
                     },
                     "n": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 127
+                      "maximum": 127,
+                      "description": "MIDI note number."
                     },
                     "v": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 127
+                      "maximum": 127,
+                      "description": "Optional velocity. Defaults to 64."
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "note_on",
-                        "note_off"
-                      ]
+                    "l": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "Optional note length in Ardour beats. Decimal values are allowed; 0.5 is an eighth note in 4/4. Defaults to 1.0 for melodic MIDI and 0.0 for drum mode."
                     },
                     "channel": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 16
-                    },
-                    "comment": {
-                      "type": "string"
+                      "maximum": 16,
+                      "description": "Optional per-note channel using midi.channel_base."
                     }
                   },
-                  "oneOf": [
-                    {
-                      "required": [
-                        "comment"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bar",
-                        "repeat"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bar",
-                        "b",
-                        "n"
-                      ]
-                    }
+                  "required": [
+                    "bar"
                   ],
                   "additionalProperties": false
                 }
@@ -3276,7 +3261,7 @@ R"mcp(
     {
       "name": "midi_note_import_json_to_new_region_samples",
       "title": "Import MIDI JSON To New Region By Samples",
-      "description": "Create and populate a new MIDI region from MIDI JSON using absolute sample positions. midi.midi_events is required. Event positions (bar/b) are relative to the new region start: bar 1 beat 1 = region start, not absolute session time. b may be fractional, for example 1.5 for an off-beat 8th note in 4/4. t is tick offset within the beat using ticks_per_quarter. Channel numbering is 1..16 by default (channel_base=\"one\"). For legacy 0..15 payloads set channel_base=\"zero\". In drum mode (is_drum_mode=true), note_off events are optional; hits may be provided as note_on only.",
+      "description": "Create and populate a new MIDI region from MIDI JSON using absolute sample positions. midi.midi_events is required. Event positions are relative to the new region start: bar 1 beat 1 = region start, not absolute session time. Each normal item is one note: bar, b, n, optional v, optional l, optional t, optional channel. b may be fractional, for example 1.5 for an off-beat 8th note in 4/4. l is note length in Ardour beats and may be fractional; omit l for 1 beat in melodic mode or 0 beats in drum mode. t is extra tick offset inside the beat using ticks_per_quarter. Repeat items use only bar and repeat; repeat is the source bar number to copy. Channel numbering is 1..16 by default (channel_base=\"one\"). For legacy 0..15 payloads set channel_base=\"zero\". By default is_drum_mode is false and omitted channel defaults to 1. Set is_drum_mode=true for drums; then omitted channel defaults to 10.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3314,65 +3299,50 @@ R"mcp(
                   "properties": {
                     "bar": {
                       "type": "integer",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Region-relative bar number. Bar 1 starts at the beginning of the region."
                     },
                     "repeat": {
                       "type": "integer",
-                      "minimum": 0
+                      "minimum": 1,
+                      "description": "Optional source bar number to copy into this bar. Repeat items should only include bar and repeat."
                     },
                     "b": {
                       "type": "number",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Beat number inside the bar. Decimal values are allowed; 1.5 is the off-beat eighth note after beat 1 in 4/4."
                     },
                     "t": {
                       "type": "integer",
-                      "minimum": 0
+                      "minimum": 0,
+                      "description": "Optional additional tick offset inside the beat using ticks_per_quarter."
                     },
                     "n": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 127
+                      "maximum": 127,
+                      "description": "MIDI note number."
                     },
                     "v": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 127
+                      "maximum": 127,
+                      "description": "Optional velocity. Defaults to 64."
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "note_on",
-                        "note_off"
-                      ]
+                    "l": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "Optional note length in Ardour beats. Decimal values are allowed; 0.5 is an eighth note in 4/4. Defaults to 1.0 for melodic MIDI and 0.0 for drum mode."
                     },
                     "channel": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 16
-                    },
-                    "comment": {
-                      "type": "string"
+                      "maximum": 16,
+                      "description": "Optional per-note channel using midi.channel_base."
                     }
                   },
-                  "oneOf": [
-                    {
-                      "required": [
-                        "comment"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bar",
-                        "repeat"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bar",
-                        "b",
-                        "n"
-                      ]
-                    }
+                  "required": [
+                    "bar"
                   ],
                   "additionalProperties": false
                 }
@@ -3433,7 +3403,7 @@ R"mcp(
     {
       "name": "midi_note_import_json_to_new_region_bbt",
       "title": "Import MIDI JSON To New Region By Bar Beat",
-      "description": "Create and populate a new MIDI region from MIDI JSON using musical positions. midi.midi_events is required. Event positions (bar/b) are relative to the new region start: bar 1 beat 1 = region start, not absolute session time. b may be fractional, for example 1.5 for an off-beat 8th note in 4/4. t is tick offset within the beat using ticks_per_quarter. Channel numbering is 1..16 by default (channel_base=\"one\"). For legacy 0..15 payloads set channel_base=\"zero\". In drum mode (is_drum_mode=true), note_off events are optional; hits may be provided as note_on only.",
+      "description": "Create and populate a new MIDI region from MIDI JSON using musical positions. midi.midi_events is required. Event positions are relative to the new region start: bar 1 beat 1 = region start, not absolute session time. Each normal item is one note: bar, b, n, optional v, optional l, optional t, optional channel. b may be fractional, for example 1.5 for an off-beat 8th note in 4/4. l is note length in Ardour beats and may be fractional; omit l for 1 beat in melodic mode or 0 beats in drum mode. t is extra tick offset inside the beat using ticks_per_quarter. Repeat items use only bar and repeat; repeat is the source bar number to copy. Channel numbering is 1..16 by default (channel_base=\"one\"). For legacy 0..15 payloads set channel_base=\"zero\". By default is_drum_mode is false and omitted channel defaults to 1. Set is_drum_mode=true for drums; then omitted channel defaults to 10.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3471,65 +3441,50 @@ R"mcp(
                   "properties": {
                     "bar": {
                       "type": "integer",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Region-relative bar number. Bar 1 starts at the beginning of the region."
                     },
                     "repeat": {
                       "type": "integer",
-                      "minimum": 0
+                      "minimum": 1,
+                      "description": "Optional source bar number to copy into this bar. Repeat items should only include bar and repeat."
                     },
                     "b": {
                       "type": "number",
-                      "minimum": 1
+                      "minimum": 1,
+                      "description": "Beat number inside the bar. Decimal values are allowed; 1.5 is the off-beat eighth note after beat 1 in 4/4."
                     },
                     "t": {
                       "type": "integer",
-                      "minimum": 0
+                      "minimum": 0,
+                      "description": "Optional additional tick offset inside the beat using ticks_per_quarter."
                     },
                     "n": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 127
+                      "maximum": 127,
+                      "description": "MIDI note number."
                     },
                     "v": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 127
+                      "maximum": 127,
+                      "description": "Optional velocity. Defaults to 64."
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": [
-                        "note_on",
-                        "note_off"
-                      ]
+                    "l": {
+                      "type": "number",
+                      "minimum": 0,
+                      "description": "Optional note length in Ardour beats. Decimal values are allowed; 0.5 is an eighth note in 4/4. Defaults to 1.0 for melodic MIDI and 0.0 for drum mode."
                     },
                     "channel": {
                       "type": "integer",
                       "minimum": 0,
-                      "maximum": 16
-                    },
-                    "comment": {
-                      "type": "string"
+                      "maximum": 16,
+                      "description": "Optional per-note channel using midi.channel_base."
                     }
                   },
-                  "oneOf": [
-                    {
-                      "required": [
-                        "comment"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bar",
-                        "repeat"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "bar",
-                        "b",
-                        "n"
-                      ]
-                    }
+                  "required": [
+                    "bar"
                   ],
                   "additionalProperties": false
                 }
@@ -3600,7 +3555,7 @@ R"mcp(
     {
       "name": "midi_note_get_json",
       "title": "Export MIDI JSON",
-      "description": "Export all notes from a MIDI region as import-compatible MIDI JSON (standard mode with note_on/note_off events). Export uses channel_base=\"one\" and channels 1..16.",
+      "description": "Export all notes from a MIDI region as import-compatible MIDI JSON using one note item per note. Each item includes bar, b, t, n, v, and l. Export uses channel_base=\"one\" and channels 1..16.",
       "inputSchema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary

  This updates the Ardour MCP MIDI JSON import format to make bulk note generation simpler and more reliable for MCP clients and LLM-based assistants.

  The previous format exposed low-level `note_on` / `note_off` events, optional comment events, and multiple event shapes. Some clients handled this correctly, but others were confused by the schema and generated invalid or unnecessarily verbose payloads.

  This change makes `midi_events` a list of note objects instead.

  ## What Changed

  - Replaced `note_on` / `note_off` import pairing with one note object per note.
  - Added `l` as the note length field, measured in Ardour beats.
  - Kept `repeat` support for copying notes from another relative bar.
  - Removed comment event support from the import schema.
  - Changed `repeat` to require an explicit source bar number, with no special `repeat: 0` behavior.
  - Updated `midi_note_get_json` so exported JSON uses the same import-compatible note format.
  - Updated MCP tool descriptions and README documentation.

  ## New MIDI Event Shape

  Example melodic note:

  ```json
  {
    "bar": 1,
    "b": 1,
    "n": 60,
    "v": 80,
    "l": 0.5
  }
```
  Meaning:

  - bar: region-relative bar number, starting at 1.
  - b: beat within the bar, starting at 1. Decimal values are allowed.
  - n: MIDI note number.
  - v: velocity. Optional, defaults to 64.
  - l: note length in Ardour beats. Optional.

  Defaults:

  - Melodic mode: omitted l defaults to 1.0.
  - Drum mode: omitted l defaults to 0.0.

  ## Repeat Example

  ```json
  {
    "bar": 2,
    "repeat": 1
  }
```

  This copies all notes from relative bar 1 into relative bar 2.

  ## Rationale

  The simplified schema is easier for MCP clients and LLMs to use correctly. It avoids requiring clients to pair note-on and note-off events, while still supporting compact bulk MIDI generation and repeated bar patterns.

  ## Testing

  - Verified tools_json.inc parses as valid JSON.
  - Ran git diff --check.
  - Built successfully with ./build-macos.sh.
  - Tested with Gemini CLI; it generated a correct bulk JSON import payload in one attempt.

   [Sample prompts and system prompt suggestion](https://manual.ardour.org/using-control-surfaces/mcp-http/)
