### PR TITLE
feat: allow bypassing plugins using midi generic control surface

### DIFF
--- a/gtk2_ardour/plugin_ui.cc
+++ b/gtk2_ardour/plugin_ui.cc
@@ -606,6 +606,7 @@ PlugUIBase::PlugUIBase (std::shared_ptr<PlugInsertBase> pib)
 	if (_pi) {
 		_pi->ActiveChanged.connect (active_connection, invalidator (*this), std::bind (&PlugUIBase::processor_active_changed, this, std::weak_ptr<Processor> (_pi)), gui_context ());
 		_bypass_button.set_active (!_pi->enabled ());
+		_bypass_button.set_controllable (_pi->bypass_control ());
 	} else {
 		_bypass_button.set_sensitive (false);
 	}

--- a/gtk2_ardour/processor_box.cc
+++ b/gtk2_ardour/processor_box.cc
@@ -242,6 +242,10 @@ ProcessorEntry::ProcessorEntry (ProcessorBox* parent, std::shared_ptr<Processor>
 		_processor->PropertyChanged.connect (name_connection, invalidator (*this), std::bind (&ProcessorEntry::processor_property_changed, this, _1), gui_context());
 		_processor->ConfigurationChanged.connect (config_connection, invalidator (*this), std::bind (&ProcessorEntry::processor_configuration_changed, this, _1, _2), gui_context());
 
+		if (pi) {
+			_button.set_controllable (pi->bypass_control ());
+		}
+
 		const uint32_t limit_inline_controls = UIConfiguration::instance().get_max_inline_controls ();
 
 		set<Evoral::Parameter> p = _processor->what_can_be_automated ();

--- a/gtk2_ardour/route_properties_box.cc
+++ b/gtk2_ardour/route_properties_box.cc
@@ -98,6 +98,12 @@ ProcessorUIFrame::ProcessorUIFrame (std::shared_ptr<Route> r, std::shared_ptr<Pr
 	set_tooltip (&_enable_btn, _("Bypass"));
 
 	_enable_btn.set_active (_proc->enabled ());
+	{
+		std::shared_ptr<PluginInsert> pi = std::dynamic_pointer_cast<PluginInsert> (p);
+		if (pi) {
+			_enable_btn.set_controllable (pi->bypass_control ());
+		}
+	}
 	_collapse_btn.signal_clicked.connect ([&] () {
 			bool a = !_collapse_btn.get_active ();
 			_ui->set_visible (a);

--- a/libs/ardour/ardour/plug_insert_base.h
+++ b/libs/ardour/ardour/plug_insert_base.h
@@ -109,6 +109,20 @@ public:
 		Variant         _value;
 	};
 
+	/** A host-level bypass control for plugins without native bypass port. */
+	class HostBypassControl : public AutomationControl {
+	public:
+		HostBypassControl (Session& s,
+		                   const Evoral::Parameter& param,
+		                   const ParameterDescriptor& desc,
+		                   std::shared_ptr<AutomationList> list = std::shared_ptr<AutomationList> ());
+
+		XMLNode& get_state () const;
+
+	protected:
+		virtual void actually_set_value (double val, PBD::Controllable::GroupControlDisposition);
+	};
+
 	/** Enumeration of the ways in which we can match our insert's
 	 *  IO to that of the plugin(s).
 	 */

--- a/libs/ardour/ardour/plugin_insert.h
+++ b/libs/ardour/ardour/plugin_insert.h
@@ -243,6 +243,8 @@ public:
 
 	std::shared_ptr<ReadOnlyControl> control_output (uint32_t) const;
 
+	std::shared_ptr<PBD::Controllable> bypass_control () const;
+
 	std::string describe_parameter (Evoral::Parameter param);
 
 	samplecnt_t signal_latency () const;
@@ -385,6 +387,12 @@ private:
 	bool _latency_changed;
 	uint32_t _bypass_port;
 	bool     _inverted_bypass_enable;
+
+	std::shared_ptr<AutomationControl> _host_bypass_control;
+	PBD::ScopedConnection _bypass_control_connection;
+	PBD::ScopedConnection _bypass_active_connection;
+	void sync_bypass_control ();
+	void host_bypass_control_changed ();
 
 	typedef std::map<uint32_t, std::shared_ptr<ReadOnlyControl> >CtrlOutMap;
 	CtrlOutMap _control_outputs;

--- a/libs/ardour/plug_insert_base.cc
+++ b/libs/ardour/plug_insert_base.cc
@@ -186,7 +186,7 @@ PlugInsertBase::set_control_ids (const XMLNode& node, int version, bool by_value
 			(*iter)->get_property (X_("parameter"), p);
 		}
 
-		if (p == (uint32_t)-1) {
+		if (p == (uint32_t)-1 && !control (Evoral::Parameter (PluginAutomation, 0, p))) {
 			continue;
 		}
 
@@ -416,6 +416,30 @@ double
 PlugInsertBase::PluginPropertyControl::get_value () const
 {
 	return _value.to_double ();
+}
+
+PlugInsertBase::HostBypassControl::HostBypassControl (Session&                        s,
+                                                      const Evoral::Parameter&        param,
+                                                      const ParameterDescriptor&      desc,
+                                                      std::shared_ptr<AutomationList> list)
+	: AutomationControl (s, param, desc, list, _("Plugin Enable"))
+{
+}
+
+void
+PlugInsertBase::HostBypassControl::actually_set_value (double val, PBD::Controllable::GroupControlDisposition gcd)
+{
+	/* Call parent class to update automation list and trigger Changed signal */
+	AutomationControl::actually_set_value (val, gcd);
+}
+
+XMLNode&
+PlugInsertBase::HostBypassControl::get_state () const
+{
+	XMLNode& node (AutomationControl::get_state ());
+	uint32_t param_id = parameter ().id ();
+	node.set_property (X_("parameter"), param_id);
+	return node;
 }
 
 std::ostream& operator<<(std::ostream& o, const ARDOUR::PlugInsertBase::Match& m)

--- a/libs/ardour/plugin_insert.cc
+++ b/libs/ardour/plugin_insert.cc
@@ -593,6 +593,29 @@ PluginInsert::create_automatable_parameters ()
 			ac->alist()->automation_state_changed.connect_same_thread (*this, std::bind (&PluginInsert::bypassable_changed, this));
 			ac->Changed.connect_same_thread (*this, std::bind (&PluginInsert::enable_changed, this));
 		}
+	} else {
+		// host-level Bypass
+		Evoral::Parameter    param (PluginAutomation, 0, UINT32_MAX);
+		ParameterDescriptor  desc;
+		desc.label   = _("Plugin Enable");
+		desc.toggled = true;
+		desc.normal  = 1;
+		desc.lower   = 0;
+		desc.upper   = 1;
+		desc.scale_points = std::make_shared<ScalePoints>();
+		desc.scale_points->insert (std::make_pair (_("Bypassed"), 0.0f));
+		desc.scale_points->insert (std::make_pair (_("Enabled"), 1.0f));
+
+		std::shared_ptr<AutomationList> list (new AutomationList (param, desc, *this));
+		std::shared_ptr<AutomationControl> c (new PlugInsertBase::HostBypassControl (_session, param, desc, list));
+		add_control (c);
+		_host_bypass_control = c;
+
+		c->Changed.connect_same_thread (_bypass_control_connection,
+			std::bind (&PluginInsert::host_bypass_control_changed, this));
+
+		ActiveChanged.connect_same_thread (_bypass_active_connection,
+			std::bind (&PluginInsert::sync_bypass_control, this));
 	}
 	plugin->PresetPortSetValue.connect_same_thread (*this, std::bind (&PluginInsert::preset_load_set_value, this, _1, _2));
 }
@@ -2882,6 +2905,14 @@ PluginInsert::set_state(const XMLNode& node, int version)
 		}
 	}
 
+	if (_host_bypass_control) {
+		std::shared_ptr<AutomationList> alist = _host_bypass_control->alist ();
+		if (alist && alist->empty ()) {
+			double new_val = enabled () ? 1.0 : 0.0;
+			_host_bypass_control->set_value_unchecked (new_val);
+		}
+	}
+
 	PluginConfigChanged (); /* EMIT SIGNAL */
 	return 0;
 }
@@ -2975,10 +3006,44 @@ PluginInsert::control_output (uint32_t num) const
 	}
 }
 
+std::shared_ptr<PBD::Controllable>
+PluginInsert::bypass_control () const
+{
+	if (_bypass_port != UINT32_MAX) {
+		/* Plugin exposes a native bypass/enable port – return it directly.
+		 * Ctrl+middle-click MIDI learn works through the AutomationControl. */
+		return std::const_pointer_cast<AutomationControl> (
+			automation_control (Evoral::Parameter (PluginAutomation, 0, _bypass_port)));
+	}
+	return _host_bypass_control;
+}
+
+void
+PluginInsert::sync_bypass_control ()
+{
+	if (_host_bypass_control) {
+		_host_bypass_control->set_value_unchecked (enabled () ? 1.0 : 0.0);
+	}
+}
+
+void
+PluginInsert::host_bypass_control_changed ()
+{
+	if (_host_bypass_control) {
+		bool want_enable = _host_bypass_control->get_value () >= 0.5;
+		if (enabled () != want_enable) {
+			enable (want_enable);
+		}
+	}
+}
+
 string
 PluginInsert::describe_parameter (Evoral::Parameter param)
 {
 	if (param.type() == PluginAutomation) {
+		if (param.id() == UINT32_MAX && _bypass_port == UINT32_MAX) {
+			return _("Plugin Enable");
+		}
 		return _plugins[0]->describe_parameter (param);
 	} else if (param.type() == PluginPropertyAutomation) {
 		std::shared_ptr<AutomationControl> c(automation_control(param));

--- a/libs/ardour/plugin_insert.cc
+++ b/libs/ardour/plugin_insert.cc
@@ -591,8 +591,31 @@ PluginInsert::create_automatable_parameters ()
 		std::shared_ptr<AutomationControl> ac = automation_control (Evoral::Parameter (PluginAutomation, 0, _bypass_port));
 		if (0 == (ac->flags () & Controllable::NotAutomatable)) {
 			ac->alist()->automation_state_changed.connect_same_thread (*this, std::bind (&PluginInsert::bypassable_changed, this));
-			ac->Changed.connect_same_thread (*this, std::bind (&PluginInsert::enable_changed, this));
 		}
+		ac->Changed.connect_same_thread (*this, std::bind (&PluginInsert::enable_changed, this));
+	} else {
+		// host-level Bypass
+		Evoral::Parameter    param (PluginAutomation, 0, UINT32_MAX);
+		ParameterDescriptor  desc;
+		desc.label   = _("Plugin Enable");
+		desc.toggled = true;
+		desc.normal  = 1;
+		desc.lower   = 0;
+		desc.upper   = 1;
+		desc.scale_points = std::make_shared<ScalePoints>();
+		desc.scale_points->insert (std::make_pair (_("Bypassed"), 0.0f));
+		desc.scale_points->insert (std::make_pair (_("Enabled"), 1.0f));
+
+		std::shared_ptr<AutomationList> list (new AutomationList (param, desc, *this));
+		std::shared_ptr<AutomationControl> c (new PlugInsertBase::HostBypassControl (_session, param, desc, list));
+		add_control (c);
+		_host_bypass_control = c;
+
+		c->Changed.connect_same_thread (_bypass_control_connection,
+			std::bind (&PluginInsert::host_bypass_control_changed, this));
+
+		ActiveChanged.connect_same_thread (_bypass_active_connection,
+			std::bind (&PluginInsert::sync_bypass_control, this));
 	}
 	plugin->PresetPortSetValue.connect_same_thread (*this, std::bind (&PluginInsert::preset_load_set_value, this, _1, _2));
 }
@@ -2891,6 +2914,14 @@ PluginInsert::set_state(const XMLNode& node, int version)
 		}
 	}
 
+	if (_host_bypass_control) {
+		std::shared_ptr<AutomationList> alist = _host_bypass_control->alist ();
+		if (alist && alist->empty ()) {
+			double new_val = enabled () ? 1.0 : 0.0;
+			_host_bypass_control->set_value_unchecked (new_val);
+		}
+	}
+
 	PluginConfigChanged (); /* EMIT SIGNAL */
 	return 0;
 }
@@ -2984,10 +3015,44 @@ PluginInsert::control_output (uint32_t num) const
 	}
 }
 
+std::shared_ptr<PBD::Controllable>
+PluginInsert::bypass_control () const
+{
+	if (_bypass_port != UINT32_MAX) {
+		/* Plugin exposes a native bypass/enable port – return it directly.
+		 * Ctrl+middle-click MIDI learn works through the AutomationControl. */
+		return std::const_pointer_cast<AutomationControl> (
+			automation_control (Evoral::Parameter (PluginAutomation, 0, _bypass_port)));
+	}
+	return _host_bypass_control;
+}
+
+void
+PluginInsert::sync_bypass_control ()
+{
+	if (_host_bypass_control) {
+		_host_bypass_control->set_value_unchecked (enabled () ? 1.0 : 0.0);
+	}
+}
+
+void
+PluginInsert::host_bypass_control_changed ()
+{
+	if (_host_bypass_control) {
+		bool want_enable = _host_bypass_control->get_value () >= 0.5;
+		if (enabled () != want_enable) {
+			enable (want_enable);
+		}
+	}
+}
+
 string
 PluginInsert::describe_parameter (Evoral::Parameter param)
 {
 	if (param.type() == PluginAutomation) {
+		if (param.id() == UINT32_MAX && _bypass_port == UINT32_MAX) {
+			return _("Plugin Enable");
+		}
 		return _plugins[0]->describe_parameter (param);
 	} else if (param.type() == PluginPropertyAutomation) {
 		std::shared_ptr<AutomationControl> c(automation_control(param));


### PR DESCRIPTION
Answer: https://discourse.ardour.org/t/use-midi-to-control-events-in-ardour/81124
> We do not have binding to plugin bypass buttons, but it would be relatively easy to do. You should add it as a feature request on the bug tracker.


PR is still in development, not fully tested.