### PR TITLE
Display relevant MIDI channel on show patch selector

### DIFF
--- a/gtk2_ardour/midi_time_axis.cc
+++ b/gtk2_ardour/midi_time_axis.cc
@@ -1762,25 +1762,7 @@ MidiTimeAxisView::get_preferred_midi_channel () const
 	}
 
 	uint16_t const chn_mask = midi_track()->get_playback_channel_mask();
-	int chn_cnt = 0;
-	uint8_t channel = 0;
-
-	/* pick the highest selected channel, unless all channels are selected,
-	 * which is interpreted to mean channel 1 (zero)
-	 */
-
-	for (uint16_t i = 0; i < 16; ++i) {
-		if (chn_mask & (1<<i)) {
-			channel = i;
-			chn_cnt++;
-		}
-	}
-
-	if (chn_cnt == 16) {
-		channel = 0;
-	}
-
-	return channel;
+	return get_preferred_midi_channel_from_chn_mask (chn_mask);
 }
 
 void

--- a/gtk2_ardour/midi_util.cc
+++ b/gtk2_ardour/midi_util.cc
@@ -45,6 +45,29 @@ using namespace PBD;
 using namespace Gtk;
 using namespace std;
 
+uint8_t
+get_preferred_midi_channel_from_chn_mask (uint16_t chn_mask)
+{
+	int chn_cnt = 0;
+	uint8_t channel = 0;
+
+	/* pick the highest selected channel, unless all channels are selected,
+	 * which is interpreted to mean channel 1 (zero)
+	 */
+
+	for (uint16_t i = 0; i < 16; ++i) {
+		if (chn_mask & (1<<i)) {
+			channel = i;
+			chn_cnt++;
+		}
+	}
+
+	if (chn_cnt == 16) {
+		channel = 0;
+	}
+
+	return channel;
+}
 
 void
 build_controller_menu (Gtk::Menu& menu, InstrumentInfo const & instrument_info, uint16_t channel_mask,

--- a/gtk2_ardour/midi_util.h
+++ b/gtk2_ardour/midi_util.h
@@ -42,6 +42,7 @@ inline static void clamp_to_0_127(uint8_t &val)
 	}
 }
 
+uint8_t get_preferred_midi_channel_from_chn_mask (uint16_t chn_mask);
 
 void
 build_controller_menu (Gtk::Menu& menu, ARDOUR::InstrumentInfo const & instrument_info, uint16_t channel_mask,

--- a/gtk2_ardour/patch_change_widget.cc
+++ b/gtk2_ardour/patch_change_widget.cc
@@ -41,6 +41,8 @@
 #include "patch_change_widget.h"
 #include "ui_config.h"
 
+#include "midi_util.h"
+
 #include "pbd/i18n.h"
 
 using namespace Gtk;
@@ -496,7 +498,7 @@ PatchChangeWidget::on_show ()
 {
 	Gtk::VBox::on_show ();
 	_channel = -1;
-	select_channel (0);
+	select_channel (get_preferred_midi_channel ());
 }
 
 void
@@ -545,6 +547,13 @@ PatchChangeWidget::select_channel (uint8_t chn)
 	}
 
 	refill_banks ();
+}
+
+uint8_t
+PatchChangeWidget::get_preferred_midi_channel () const
+{
+	uint16_t const chn_mask = (std::dynamic_pointer_cast<MidiTrack> (_route))->get_playback_channel_mask();
+	return get_preferred_midi_channel_from_chn_mask (chn_mask);
 }
 
 void

--- a/gtk2_ardour/patch_change_widget.h
+++ b/gtk2_ardour/patch_change_widget.h
@@ -119,7 +119,8 @@ protected:
 private:
 	void refill_banks ();
 
-	void select_channel (uint8_t);
+	void    select_channel (uint8_t);
+	uint8_t get_preferred_midi_channel () const;
 
 	/* Implement PatchBankList */
 	void select_bank (uint32_t);


### PR DESCRIPTION
**Context:**

Rather than virtual instruments, I rely more on external synthesizers for sound generation. To maximize the use of a mutli-timbral synth, the most logical setup for me is to have one Ardour MIDI track for each available channel on the synth via the channel selector "Inbound" and "Playback" settings. The MIDNAM selector and patch selector come in handy when deciding on which sounds to use, and the restore patch feature is convenient as it eliminates the need to save the settings into a scene/performance on the synth itself. 

**Issue:**

After selecting a patch on a particular track, closing and and then reopening the patch selector, it always defaults to displaying channel 1 even if the previously selected patch is on a different channel. From what I understand, there can be a program/patch change set per channel (1-16). However, given the setup described above, I'm only interested in one particular channel per MIDI track. As such, each time I reopen the patch selector, I have to recall which channel the MIDI track is "assigned" to, and then manually select that in the dropdown.

**Proposal:**

This code change makes it so that the patch selector displays the relevant MIDI channel, reusing part of the logic found in `MidiTimeAxisView::get_preferred_midi_channel`. I would have liked to call the method itself, but it doesn't seem possible to do it from `PatchChangeWidget` due to the inheritance setup.

Ideally, the patch selector view "remembers" the state it was in prior to closing, but at the same time I don't think it's efficient to do that for each MIDI track and I have yet to find a similar pattern in other parts of the code (I'm still pretty new, so I'm happy to take suggestions/improvements).

<img width="1080" height="608" alt="display_relevant_channel" src="https://github.com/user-attachments/assets/92dc752a-bfb6-4be9-bcc1-e346d561a35a" />
