### PR TITLE
Fix MIDI chase droned note when playhead and note start are aligned

### DIFF
--- a/libs/ardour/disk_reader.cc
+++ b/libs/ardour/disk_reader.cc
@@ -220,7 +220,7 @@ DiskReader::midi_chase (samplepos_t spos)
 		return;
 	}
 
-	_locate_tracker.reset ();
+	clear_midi_chase ();
 
 	if (rtmb) {
 		for (size_t n = 0; n < rtmb->size(); ++n) {

--- a/libs/ardour/disk_reader.cc
+++ b/libs/ardour/disk_reader.cc
@@ -226,7 +226,7 @@ DiskReader::midi_chase (samplepos_t spos)
 		for (size_t n = 0; n < rtmb->size(); ++n) {
 			uint32_t sz;
 			RTMidiBuffer::Item const & item ((*rtmb)[n]);
-			if (item.timestamp > spos) {
+			if (item.timestamp >= spos) {
 				break;
 			}
 			uint8_t const * buf = rtmb->bytes (item, sz);


### PR DESCRIPTION
Fix for issue 0010348 in the tracker.

Using certain synths/presets, droned/stuck notes can occur during playback when the playhead and the note start are exactly aligned. See [video](https://www.youtube.com/watch?v=1BrDpH1Kv-U). This [session](https://drive.google.com/drive/folders/1ghedj25LNI-tXI7Ki-v4GLIhshxzwxd2
) reproduces the issue on releases 9.2 and 9.5 . 

Identified plugin instruments where this occurs are JX10 / MDA JX10 ("Monosynth" preset) and Dexed ("26. -WOBBLE 1-" preset). This also occurs on hardware synths, namely Roland SonicCell ("SC Unison Bs" preset).

Reproduction steps:

1. Create a MIDI track using any of the synth/presets mentioned above
3. Draw some notes that are aligned to the grid
4. Locate/align the playhead at the start of a note
5. Start playback with MIDI chase enabled

The proposed solution here is to prevent such notes from being added to `_active_notes`. With this fix, MIDI chase still works as expected when the playhead is located at the middle of a note.

There is a gratuitous refactor in a separate commit. Please ignore/skip if wrong.

@jean-emmanuel 