### PR TITLE
Use natural sort for keyboard shortcuts

### DIFF
--- a/gtk2_ardour/keyeditor.cc
+++ b/gtk2_ardour/keyeditor.cc
@@ -52,6 +52,7 @@
 #include "pbd/openuri.h"
 #include "pbd/strsplit.h"
 #include "pbd/unwind.h"
+#include "pbd/natsort.h"
 
 #include "ardour/filesystem_paths.h"
 #include "ardour/profile.h"
@@ -270,6 +271,7 @@ KeyEditor::Tab::Tab (KeyEditor& ke, string const & str, Bindings* b)
 	view.get_column(2)->set_visible (false);
 	view.set_tooltip_column(2);
 	data_model->set_sort_column (owner.sort_column,  owner.sort_type);
+	data_model->set_sort_func(owner.sort_column, sigc::mem_fun(*this, &Tab::name_sorter));
 	data_model->signal_sort_column_changed().connect (sigc::mem_fun (*this, &Tab::sort_column_changed));
 
 	signal_map().connect (sigc::mem_fun (*this, &Tab::tab_mapped));
@@ -480,6 +482,15 @@ KeyEditor::Tab::sort_column_changed ()
 		owner.sort_column = column;
 		owner.sort_type = type;
 	}
+}
+
+int
+KeyEditor::Tab::name_sorter (Gtk::TreeModel::iterator a, Gtk::TreeModel::iterator b) const
+{
+	std::string const& n1 = (*a)[columns.name];
+	std::string const& n2 = (*b)[columns.name];
+
+	return natcmp (n1.c_str(), n2.c_str());
 }
 
 void

--- a/gtk2_ardour/keyeditor.h
+++ b/gtk2_ardour/keyeditor.h
@@ -65,6 +65,7 @@ private:
 		void bind (GdkEventKey* release_event, guint pressed_key);
 		void action_selected ();
 		void sort_column_changed ();
+		int name_sorter(Gtk::TreeModel::iterator a, Gtk::TreeModel::iterator b) const;
 		void tab_mapped ();
 		bool visible_func(const Gtk::TreeModel::const_iterator& iter) const;
 


### PR DESCRIPTION
Fix for issue #0010096

This code change extends the work done on https://github.com/Ardour/ardour/commit/9df77577997f3972dc5f0c044a649bf75047c52e with respect to region names.

<img width="726" height="499" alt="Screenshot at 2026-05-27 21-00-13" src="https://github.com/user-attachments/assets/a45b2bf5-f92e-4230-864d-0cceb45c09c4" />
