### PR TITLE
Use natural sort for clips sidebar

### DIFF
--- a/gtk2_ardour/chord_dialog.cc
+++ b/gtk2_ardour/chord_dialog.cc
@@ -49,7 +49,9 @@ ChordDialog::ChordDialog (EditingContext& ec, ChordProvider& cp, int chord_size)
 		}
 	}
 
-	sort (names.begin(), names.end(), PBD::naturally_less);
+	sort (names.begin(), names.end(), [](const char* a, const char* b) {
+		return PBD::naturally_less(a, b);
+	});
 
 	for (auto & n : names) {
 		chord_list.append_text (n);

--- a/gtk2_ardour/trigger_clip_picker.cc
+++ b/gtk2_ardour/trigger_clip_picker.cc
@@ -23,6 +23,7 @@
 
 #include "pbd/basename.h"
 #include "pbd/file_utils.h"
+#include "pbd/natsort.h"
 #include "pbd/openuri.h"
 #include "pbd/pathexpand.h"
 #include "pbd/search_path.h"
@@ -780,8 +781,12 @@ TriggerClipPicker::list_dir (std::string const& path, Gtk::TreeNodeChildren cons
 	} catch (Glib::FileError const& err) {
 	}
 
-	std::sort (dirs.begin (), dirs.end ());
-	std::sort (files.begin (), files.end ());
+	std::sort (dirs.begin (), dirs.end (), [](const std::string a, const std::string b) {
+		return naturally_less (a, b);
+	});
+	std::sort (files.begin (), files.end (), [](const std::string a, const std::string b) {
+		return naturally_less (a, b);
+	});
 
 	if (!pc) {
 		if (_root_paths.find (_current_path) == _root_paths.end ()) {

--- a/libs/pbd/pbd/natsort.h
+++ b/libs/pbd/pbd/natsort.h
@@ -22,6 +22,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string>
 
 namespace PBD {
 
@@ -174,6 +175,15 @@ inline bool
 naturally_less (const char* a, const char* b)
 {
 	return natcmp (a, b) < 0;
+}
+
+inline bool
+naturally_less (const std::string a, const std::string b)
+{
+	const char* cstr_a = a.data();
+	const char* cstr_b = b.data();
+
+	return naturally_less (cstr_a, cstr_b);
 }
 
 } // namespace PBD

--- a/libs/pbd/test/natsort_test.cc
+++ b/libs/pbd/test/natsort_test.cc
@@ -18,3 +18,17 @@ NatSortTest::testBasic ()
 	CPPUNIT_ASSERT ( PBD::naturally_less ("abc", "abcd"));
 	CPPUNIT_ASSERT (!PBD::naturally_less ("abc", "abc"));
 }
+
+void
+NatSortTest::testStringLiteral ()
+{
+
+	CPPUNIT_ASSERT (!PBD::naturally_less ("a32"s, "a4"s));
+	CPPUNIT_ASSERT (!PBD::naturally_less ("a32"s, "a04"s));
+	CPPUNIT_ASSERT ( PBD::naturally_less ("a32"s, "a40"s));
+	CPPUNIT_ASSERT ( PBD::naturally_less ("a32a"s, "a32b"s));
+	CPPUNIT_ASSERT (!PBD::naturally_less ("a32b"s, "a32a"s));
+	CPPUNIT_ASSERT (!PBD::naturally_less ("abcd"s, "abc"s));
+	CPPUNIT_ASSERT ( PBD::naturally_less ("abc"s, "abcd"s));
+	CPPUNIT_ASSERT (!PBD::naturally_less ("abc"s, "abc"s));
+}

--- a/libs/pbd/test/natsort_test.h
+++ b/libs/pbd/test/natsort_test.h
@@ -5,11 +5,13 @@ class NatSortTest : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE (NatSortTest);
 	CPPUNIT_TEST (testBasic);
+	CPPUNIT_TEST (testStringLiteral);
 	CPPUNIT_TEST_SUITE_END ();
 
 public:
 	NatSortTest () { }
 	void testBasic ();
+	void testStringLiteral ();
 
 private:
 };


### PR DESCRIPTION
Fix for issue #0010374

Related PR: https://github.com/Ardour/ardour/pull/1118

<img width="360" height="244" alt="Screenshot at 2026-05-31 01-11-12" src="https://github.com/user-attachments/assets/571852cd-13e6-498e-9648-ed83e1f35c1d" />

**Note**: In this PR, the function `naturally_less` is overloaded to accept `std::string` params. When passing as a callback to `std::sort`, the function has to be wrapped in a lambda since the compiler cannot differentiate between overloaded functions when used in a callback in this case. An alternative is to not overload/use a different function name to avoid the lambda wrapping.