### PR TITLE
linux: Update appstream file to new standards

### DIFF
--- a/gtk2_ardour/ardour.appdata.xml.in.in
+++ b/gtk2_ardour/ardour.appdata.xml.in.in
@@ -18,6 +18,12 @@
       composers.
     </p>
   </description>
+  <content_rating type="oars-1.1" />
+  <launchable type="desktop-id">ardour9.desktop</launchable>
+  <developer id="org.ardour">
+    <name>Ardour Developers</name>
+  </developer>
+  <url type="vcs-browser">https://github.com/Ardour/ardour/</url>
   <url type="bugtracker">https://tracker.ardour.org/</url>
   <url type="contribute">https://ardour.org/development</url>
   <url type="homepage">https://ardour.org</url>


### PR DESCRIPTION
This pass appstream validation.

For the vcs-browser I sent to GitHub. If you prefer something else, let me know I'd be happy to change it.