### PR TITLE
Rethrow forced-unwind in MIDNAM loader to fix shutdown abort

### DIFF
--- a/libs/ardour/midi_patch_manager.cc
+++ b/libs/ardour/midi_patch_manager.cc
@@ -22,6 +22,8 @@
 
 #include <memory>
 
+#include <cxxabi.h>
+
 #include <glibmm/fileutils.h>
 
 #include "pbd/error.h"
@@ -170,6 +172,14 @@ MidiPatchManager::load_midi_name_document (const std::string& file_path)
 	std::shared_ptr<MIDINameDocument> document;
 	try {
 		document = std::shared_ptr<MIDINameDocument>(new MIDINameDocument(file_path));
+	}
+	catch (abi::__forced_unwind&) {
+		/* thread cancellation (e.g. pthread_cancel_all() at shutdown) unwinds
+		 * via this exception; it must be re-thrown so the unwind reaches the
+		 * thread's top frame. Swallowing it in the catch (...) below makes glibc
+		 * abort with "FATAL: exception not rethrown".
+		 */
+		throw;
 	}
 	catch (...) {
 		error << string_compose(_("Error parsing MIDI patch file %1"), file_path)


### PR DESCRIPTION
## Problem

At process exit, `pthread_cancel_all()` (called by `luasession`, the
session-utility tools, and the GUI in `gtk2_ardour/main.cc`) sends
`pthread_cancel` to every registered thread. `pthread_cancel` injects an
`abi::__forced_unwind` exception, which must propagate to the thread's top
frame for cancellation to complete.

The background **MIDNAMLoader** thread (`MidiPatchManager::load_midnams`)
parses `.midnam` files in `load_midi_name_document()` inside a
`try { new MIDINameDocument(file_path); } catch (...)`. When the thread is
cancelled mid-parse, that `catch (...)` swallows the forced-unwind instead of
rethrowing it, so glibc aborts the process:

```
FATAL: exception not rethrown
Aborted (core dumped)
```

This is a race (it disappears under a debugger or with extra logging, because
the perturbed timing lets the loader finish before the cancel), so it shows up
intermittently at shutdown -- most reliably right after importing MIDI files,
which keeps the MIDNAM loader busy.

## Fix

Catch and rethrow `abi::__forced_unwind` before the existing `catch (...)` so
thread cancellation unwinds cleanly. Genuine `.midnam` XML parse errors still
fall through to the existing handler. Zero-risk for normal operation: it only
affects the cancellation path.

## Testing

Reproduced reliably with a headless `ardour-lua` script that creates a session,
imports a multi-track MIDI file, and exits. Before: aborts on the majority of
runs. After: 0 aborts in 26 consecutive runs; unit tests still pass.
