### PR TITLE
Enable scrolling for route comments box

### DIFF
--- a/gtk2_ardour/route_comment_editor.cc
+++ b/gtk2_ardour/route_comment_editor.cc
@@ -44,6 +44,8 @@ RouteCommentEditor::RouteCommentEditor (std::shared_ptr<Route> r)
 
 	set_skip_taskbar_hint (true);
 
+	_scroller.add (_comment_area);
+	_scroller.set_policy (Gtk::POLICY_NEVER, Gtk::POLICY_AUTOMATIC);
 	_comment_area.set_name ("MixerTrackCommentArea");
 	_comment_area.set_wrap_mode (WRAP_WORD);
 	_comment_area.set_editable (true);
@@ -59,7 +61,7 @@ RouteCommentEditor::RouteCommentEditor (std::shared_ptr<Route> r)
 	_route->comment_changed.connect (_connections, invalidator (*this), std::bind (&RouteCommentEditor::comment_changed, this), gui_context ());
 
 	Gtkmm2ext::container_clear (_vbox, false);
-	_vbox.pack_start (_comment_area);
+	_vbox.pack_start (_scroller);
 
 	delete _bo;
 	if (_route->is_master ()) {

--- a/gtk2_ardour/route_comment_editor.h
+++ b/gtk2_ardour/route_comment_editor.h
@@ -22,6 +22,7 @@
 
 #include <ytkmm/box.h>
 #include <ytkmm/textview.h>
+#include <ytkmm/scrolledwindow.h>
 
 #include "ardour/route.h"
 
@@ -42,10 +43,11 @@ private:
 	void comment_changed ();
 	void commit_change ();
 
-	Gtk::TextView _comment_area;
-	Gtk::VBox     _vbox;
-	BoolOption*   _bo;
-	bool          _ignore_change;
+	Gtk::TextView       _comment_area;
+	Gtk::ScrolledWindow _scroller;
+	Gtk::VBox           _vbox;
+	BoolOption*         _bo;
+	bool                _ignore_change;
 
 	std::shared_ptr<ARDOUR::Route> _route;
 	PBD::ScopedConnectionList      _connections;


### PR DESCRIPTION
Fix for issue #0010376

**Current behavior**: When the text content grows past the size of the box, the box automatically resizes vertically.

**Proposed change**: A scroll bar appears when the text content grows past the size of the box.

<img width="520" height="274" alt="Screenshot at 2026-06-15 00-04-07" src="https://github.com/user-attachments/assets/e23b0ea6-c062-461e-9070-af83b5cdc1a9" />
