### PR TITLE
Fix path to ytk .mo files

### DIFF
--- a/tools/osx_packaging/osx_build
+++ b/tools/osx_packaging/osx_build
@@ -274,7 +274,7 @@ if test x$WITH_NLS != x ; then
 	echo "I hope you remembered to run waf i18n"
 	LINGUAS=
 
-	for pkg in gtk2_ardour libs/ardour libs/gtkmm2ext lib/tk/ytk  ; do
+	for pkg in gtk2_ardour libs/ardour libs/gtkmm2ext libs/tk/ytk  ; do
 		files=`find ../../$pkg -not -path "*/appdata/*" -name "*.mo"`
 
 		#


### PR DESCRIPTION
Use correct path to `libs/tk/ytk` directory when searching for `.mo` files.