### PR TITLE
patchfiles: make manufacturer consistent across all E-mu midnams

### DIFF
--- a/share/patchfiles/E_mu_Systems_Orbit_3.midnam
+++ b/share/patchfiles/E_mu_Systems_Orbit_3.midnam
@@ -3,7 +3,7 @@
 <MIDINameDocument>
   <Author>Digidesign</Author>
   <MasterDeviceNames>
-    <Manufacturer>E-mu</Manufacturer>
+    <Manufacturer>E-mu Systems</Manufacturer>
     <Model>Orbit 3</Model>
     <CustomDeviceMode Name="Default">
       <ChannelNameSetAssignments>

--- a/share/patchfiles/E_mu_Systems_Phatt.midnam
+++ b/share/patchfiles/E_mu_Systems_Phatt.midnam
@@ -3,7 +3,7 @@
 <MIDINameDocument>
   <Author>Digidesign</Author>
   <MasterDeviceNames>
-    <Manufacturer>E-mu</Manufacturer>
+    <Manufacturer>E-mu Systems</Manufacturer>
     <Model>Mo Phatt</Model>
     <CustomDeviceMode Name="Default">
       <ChannelNameSetAssignments>

--- a/share/patchfiles/E_mu_Systems_Proteus_2000.midnam
+++ b/share/patchfiles/E_mu_Systems_Proteus_2000.midnam
@@ -3,7 +3,7 @@
 <MIDINameDocument>
   <Author>Digidesign</Author>
   <MasterDeviceNames>
-    <Manufacturer>E-mu</Manufacturer>
+    <Manufacturer>E-mu Systems</Manufacturer>
     <Model>Proteus 2000</Model>
     <CustomDeviceMode Name="Default">
       <ChannelNameSetAssignments>

--- a/share/patchfiles/E_mu_Systems_XL_1.midnam
+++ b/share/patchfiles/E_mu_Systems_XL_1.midnam
@@ -3,7 +3,7 @@
 <MIDINameDocument>
   <Author>Erik van den Hooven</Author>
   <MasterDeviceNames>
-    <Manufacturer>E-mu</Manufacturer>
+    <Manufacturer>E-mu Systems</Manufacturer>
     <Model>Xtream Lead 1</Model>
     <CustomDeviceMode Name="Default">
       <ChannelNameSetAssignments>


### PR DESCRIPTION
In a couple of E-mu midnams, the `<Manufacturer>` field is set to `E-mu`, while in the majority it is `E-mu Systems`. As an E-mu gear user, I find this inconvenient. I think it would be better to standardize them all to `E-mu Systems`.