### PR TITLE
Resolved Issue 0010234: Improved Language of Dialog Box

### DIFF
--- a/gtk2_ardour/utils.cc
+++ b/gtk2_ardour/utils.cc
@@ -119,7 +119,7 @@ idle_notify_engine_stopped ()
 	Glib::RefPtr<ToggleAction> tact = ActionManager::get_toggle_action ("Window", "toggle-audio-midi-setup");
 
 	MessageDialog msg (
-	    _("The current operation is not possible because of an error communicating with the audio hardware."),
+	    _("The audio engine needs to be running for this operation. See Menu > Window > Audio/MIDI Setup"),
 	    false, Gtk::MESSAGE_WARNING, Gtk::BUTTONS_NONE, true);
 
 	msg.add_button (_("Cancel"), Gtk::RESPONSE_CANCEL);


### PR DESCRIPTION
Changed language of dialog box in idle_notify_engine_stopped() to better encompass the issues that may generate this dialog box (e.g. stopped Audio Engine)