### PR TITLE
Fix USB surface compile when libusb-dev is not installed

### DIFF
--- a/libs/surfaces/wscript
+++ b/libs/surfaces/wscript
@@ -78,15 +78,15 @@ def build(bld):
     bld.recurse('launch_control_xl')
     bld.recurse('osc')
     bld.recurse('console1')
-    bld.recurse('launchpad_pro')
-    bld.recurse('launchpad_x')
-    bld.recurse('launchkey_4')
 
     if bld.is_defined('BUILD_WIIMOTE'):
         bld.recurse('wiimote')
     if bld.is_defined('HAVE_USB'):
         bld.recurse('push2')
         bld.recurse('contourdesign')
+        bld.recurse('launchpad_pro')
+        bld.recurse('launchpad_x')
+        bld.recurse('launchkey_4')
     if bld.is_defined('BUILD_MASCHINE'):
         bld.recurse('maschine2')
     if bld.is_defined ('HAVE_WEBSOCKETS'):


### PR DESCRIPTION
libusb is not a required dependency for Ardour, and this change allows Ardour to compile successfully even when libusb-dev is not installed on the system.

The usage of HAVE_USB was not consistent across configure() and build().

I have tested the change in an Ubuntu 26 environment (clean build) and the build was successful.