### PR TITLE
Zoom to 2 times the length of region/source in bottom pianoroll

### DIFF
--- a/gtk2_ardour/cue_editor.cc
+++ b/gtk2_ardour/cue_editor.cc
@@ -1237,6 +1237,33 @@ CueEditor::max_zoom_extent() const
 	EC_LOCAL_TEMPO_SCOPE;
 
 	if (_region) {
+		int ZOOM_LEVEL = 2; /* zoom out to 2x the length of the region, so that we can see the whole region and some context around it */
+
+		Temporal::Beats len;
+
+		if (show_source) {
+			len = _region->source()->length().beats() * ZOOM_LEVEL;
+			if (len != Temporal::Beats()) {
+				return std::make_pair (timepos_t (Temporal::Beats()), timepos_t (len));
+			}
+		} else {
+			len = _region->length().beats() * ZOOM_LEVEL;
+			if (len != Temporal::Beats()) {
+				return std::make_pair (timepos_t (_region->start().beats()), timepos_t (_region->start().beats() + len));
+			}
+		}
+	}
+
+	// default
+	return std::make_pair (Temporal::timepos_t (Temporal::Beats()), Temporal::timepos_t (Temporal::Beats (32, 0)));
+}
+
+std::pair<Temporal::timepos_t,Temporal::timepos_t>
+CueEditor::get_context_extent() const
+{
+	EC_LOCAL_TEMPO_SCOPE;
+
+	if (_region) {
 
 		Temporal::Beats len;
 
@@ -1277,7 +1304,7 @@ CueEditor::full_zoom_clicked()
 
 	/* XXXX NEED LOCAL TEMPO MAP */
 
-	std::pair<Temporal::timepos_t,Temporal::timepos_t> dur (max_zoom_extent());
+	std::pair<Temporal::timepos_t,Temporal::timepos_t> dur (get_context_extent());
 	samplecnt_t s = dur.second.samples() - dur.first.samples();
 	reposition_and_zoom (0,  (s / (double) _visible_canvas_width));
 }

--- a/gtk2_ardour/cue_editor.h
+++ b/gtk2_ardour/cue_editor.h
@@ -116,6 +116,7 @@ class CueEditor : public EditingContext, public PBD::HistoryOwner
 	void catch_pending_show_region ();
 
 	std::pair<Temporal::timepos_t,Temporal::timepos_t> max_zoom_extent() const;
+	std::pair<Temporal::timepos_t,Temporal::timepos_t> get_context_extent() const;
 
 	void full_zoom_clicked();
 	void zoom_to_show (std::pair<Temporal::timepos_t,Temporal::timepos_t> const &);

--- a/gtk2_ardour/pianoroll.cc
+++ b/gtk2_ardour/pianoroll.cc
@@ -942,7 +942,7 @@ Pianoroll::canvas_allocate (Gtk::Allocation alloc)
 	if (zoom_in_allocate) {
 
 		if (!_active_view || !maybe_set_from_rsu (_active_view->midi_region()->id())) {
-			zoom_to_show (max_zoom_extent());
+			zoom_to_show (get_context_extent());
 		}
 		if (_region) {
 			/* XXXX */
@@ -1905,7 +1905,7 @@ Pianoroll::set_region (std::shared_ptr<ARDOUR::Region> region)
 
 	if (!_active_view || !maybe_set_from_rsu (_active_view->midi_region()->id())) {
 		/* Compute zoom level to show entire source plus some margin if possible */
-		zoom_to_show (max_zoom_extent());
+		zoom_to_show (get_context_extent());
 	}
 
 	if (region_view_map.size() > 1) {
@@ -2583,7 +2583,7 @@ Pianoroll::set_session (ARDOUR::Session* s)
 	}
 
 	if (_session) {
-		zoom_to_show (max_zoom_extent());
+		zoom_to_show (get_context_extent());
 	}
 }
 


### PR DESCRIPTION
Currently, the maximum zoom out level is set to the length of the midi region or the source clip. I want to be able to zoom out further so that its easier to view the whole region with boundaries and to also be able to easily resize it.

**Before**: 

https://github.com/user-attachments/assets/2d080ccd-81fd-41c5-82b2-cc13263ce3c0


**After**:

https://github.com/user-attachments/assets/965621e4-96ab-4c64-98d2-f64fe3a35dcc

