### PR TITLE
Piano roll window set size correctly to allow user resize

### DIFF
--- a/gtk2_ardour/cue_editor.cc
+++ b/gtk2_ardour/cue_editor.cc
@@ -1501,7 +1501,7 @@ CueEditor::set_from_rsu (RegionUISettings& rsu)
 		ArdourWindow* aw = dynamic_cast<ArdourWindow*> (toplevel);
 		if (aw) {
 			aw->move (rsu.x, rsu.y);
-			aw->set_size_request (rsu.width, rsu.height);
+			aw->set_default_size (rsu.width, rsu.height);
 		}
 	}
 }


### PR DESCRIPTION
Currently, the last size of the piano roll window (when it was open) gets set to the minimum size of the window when its opened again. This change just resets the size correctly from the saved size such that the user can still reduce its size.

**Before:**

https://github.com/user-attachments/assets/947bbe03-b616-475e-9bce-e1c1271d3eac


**After:**

https://github.com/user-attachments/assets/6ff6d2f2-fd86-4b26-9124-e70aeed9bfc3

