### PR TITLE
Use pixel based logic to determine ends lengths for resizing midi notes

### DIFF
--- a/gtk2_ardour/midi_view.cc
+++ b/gtk2_ardour/midi_view.cc
@@ -4503,14 +4503,14 @@ MidiView::sysex_left (SysEx *)
 }
 
 void
-MidiView::note_mouse_position (float x_fraction, float /*y_fraction*/, bool can_set_cursor)
+MidiView::note_mouse_position (float /*x_fraction*/, float /*y_fraction*/, bool can_set_cursor)
 {
-	bool trimmable = _editing_context.allow_trim_cursors ();
+	bool trimmable = _editing_context.allow_trim_cursors () && _entered_note && _entered_note->big_enough_to_trim ();
 
 	if (can_set_cursor) {
-		if (trimmable && x_fraction > 0.0 && x_fraction < 0.2) {
+		if (trimmable && _entered_note->mouse_near_start ()) {
 			_editing_context.set_canvas_cursor (_editing_context.cursors()->left_side_trim);
-		} else if (trimmable && x_fraction >= 0.8 && x_fraction < 1.0) {
+		} else if (trimmable && _entered_note->mouse_near_end ()) {
 			_editing_context.set_canvas_cursor (_editing_context.cursors()->right_side_trim);
 		} else {
 			_editing_context.set_canvas_cursor (_editing_context.cursors()->grabber_note);

--- a/gtk2_ardour/note_base.cc
+++ b/gtk2_ardour/note_base.cc
@@ -19,6 +19,7 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <algorithm>
 #include <iostream>
 
 #include "pbd/strsplit.h"
@@ -50,6 +51,19 @@ using namespace std;
 using namespace Gtkmm2ext;
 using ARDOUR::MidiModel;
 using namespace ArdourCanvas;
+
+namespace {
+
+constexpr double max_note_trim_handle_pixels = 8.0;
+
+double
+note_trim_edge_width (NoteBase const& note)
+{
+	const double width = std::max (0.0, note.x1 () - note.x0 ());
+	return std::min (max_note_trim_handle_pixels, std::max (0.0, (width * 0.5) - 1.0));
+}
+
+}
 
 /// dividing the hue circle in 16 parts, hand adjusted for equal look, courtesy Thorsten Wilms
 const uint32_t NoteBase::midi_channel_colors[16] = {
@@ -372,10 +386,31 @@ NoteBase::event_handler (GdkEvent* ev)
 }
 
 bool
+NoteBase::mouse_near_start () const
+{
+	if (_mouse_x_fraction < 0.0 || _mouse_x_fraction >= 1.0) {
+		return false;
+	}
+
+	const double width = std::max (0.0, x1 () - x0 ());
+	return (_mouse_x_fraction * width) < note_trim_edge_width (*this);
+}
+
+bool
+NoteBase::mouse_near_end () const
+{
+	if (_mouse_x_fraction < 0.0 || _mouse_x_fraction >= 1.0) {
+		return false;
+	}
+
+	const double width = std::max (0.0, x1 () - x0 ());
+	return (_mouse_x_fraction * width) >= (width - note_trim_edge_width (*this));
+}
+
+bool
 NoteBase::mouse_near_ends () const
 {
-	return (_mouse_x_fraction >= 0.0 && _mouse_x_fraction < 0.25) ||
-		(_mouse_x_fraction >= 0.75 && _mouse_x_fraction < 1.0);
+	return mouse_near_start () || mouse_near_end ();
 }
 
 bool

--- a/gtk2_ardour/note_base.h
+++ b/gtk2_ardour/note_base.h
@@ -133,6 +133,8 @@ class NoteBase : public sigc::trackable
 	static std::vector<uint32_t> pitch_colors;
 	static void save_colors ();
 
+	bool mouse_near_start () const;
+	bool mouse_near_end () const;
 	bool mouse_near_ends () const;
 	virtual bool big_enough_to_trim () const;
 


### PR DESCRIPTION
I observed that the midi notes have very large length of the region in the midi note where the resize boundary begins. This leads to the note not even being resizable if the note is long and zoomed in enough.
Implemented a pixel length based logic where only a 8px length will be considered as the max length of the region for resizing in the note. This will be applicable even if the note is long and zoomed in. 
Also made the mouse cursor icon limits and the actual resize limits consistent.

**Before:**

https://github.com/user-attachments/assets/43c7ee35-787d-48ab-bd14-b128be770a72


**After:**

https://github.com/user-attachments/assets/362eb220-7e53-41c6-95fd-3869f6f57650


