### PR TITLE
Fix issue with point trim on region/clip end

### DIFF
--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -1878,9 +1878,6 @@ private:
 	void start_canvas_autoscroll (bool allow_horiz, bool allow_vert, const ArdourCanvas::Rect& boundary);
 	void stop_canvas_autoscroll ();
 
-	/* trimming */
-	void point_trim (GdkEvent*, Temporal::timepos_t const &);
-
 	void trim_region_front();
 	void trim_region_back();
 	void trim_region (bool front);

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -1879,7 +1879,7 @@ private:
 	void stop_canvas_autoscroll ();
 
 	/* trimming */
-	void point_trim (GdkEvent*, Temporal::timepos_t const &);
+	void point_trim (GdkEvent*, Temporal::timepos_t const &, bool is_start);
 
 	void trim_region_front();
 	void trim_region_back();

--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -3014,10 +3014,7 @@ TrimDrag::finished (GdkEvent* event, bool movement_occurred)
 		editing_context.commit_reversible_command ();
 
 	} else {
-		/* no mouse movement */
-		if (adjusted_current_time (event) != adjusted_time (_drags->current_pointer_time (), event, false)) {
-			_editor.point_trim (event, adjusted_current_time (event));
-		}
+		/* no mouse movement. do nothing*/
 	}
 
 	for (list<DraggingView>::const_iterator i = _views.begin (); i != _views.end (); ++i) {

--- a/gtk2_ardour/editor_drag.cc
+++ b/gtk2_ardour/editor_drag.cc
@@ -3016,7 +3016,7 @@ TrimDrag::finished (GdkEvent* event, bool movement_occurred)
 	} else {
 		/* no mouse movement */
 		if (adjusted_current_time (event) != adjusted_time (_drags->current_pointer_time (), event, false)) {
-			_editor.point_trim (event, adjusted_current_time (event));
+			_editor.point_trim (event, adjusted_current_time (event), _operation == StartTrim);
 		}
 	}
 

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -2053,69 +2053,6 @@ Editor::cancel_time_selection ()
 }
 
 void
-Editor::point_trim (GdkEvent* event, timepos_t const & new_bound)
-{
-	RegionView* rv = clicked_regionview;
-
-	/* Choose action dependent on which button was pressed */
-	switch (event->button.button) {
-	case 1:
-		begin_reversible_command (_("start point trim"));
-
-		if (selection->selected (rv)) {
-			for (list<RegionView*>::const_iterator i = selection->regions.by_layer().begin();
-			     i != selection->regions.by_layer().end(); ++i)
-			{
-				if (!(*i)->region()->locked()) {
-					(*i)->region()->clear_changes ();
-					(*i)->region()->trim_front (new_bound);
-					_session->add_command(new StatefulDiffCommand ((*i)->region()));
-				}
-			}
-
-		} else {
-			if (!rv->region()->locked()) {
-				rv->region()->clear_changes ();
-				rv->region()->trim_front (new_bound);
-				_session->add_command(new StatefulDiffCommand (rv->region()));
-			}
-		}
-
-		commit_reversible_command();
-
-		break;
-	case 2:
-		begin_reversible_command (_("end point trim"));
-
-		if (selection->selected (rv)) {
-
-			for (list<RegionView*>::const_iterator i = selection->regions.by_layer().begin(); i != selection->regions.by_layer().end(); ++i)
-			{
-				if (!(*i)->region()->locked()) {
-					(*i)->region()->clear_changes();
-					(*i)->region()->trim_end (new_bound);
-					_session->add_command(new StatefulDiffCommand ((*i)->region()));
-				}
-			}
-
-		} else {
-
-			if (!rv->region()->locked()) {
-				rv->region()->clear_changes ();
-				rv->region()->trim_end (new_bound);
-				_session->add_command (new StatefulDiffCommand (rv->region()));
-			}
-		}
-
-		commit_reversible_command();
-
-		break;
-	default:
-		break;
-	}
-}
-
-void
 Editor::hide_marker (ArdourCanvas::Item* item, GdkEvent* /*event*/)
 {
 	ArdourMarker* marker;

--- a/gtk2_ardour/editor_mouse.cc
+++ b/gtk2_ardour/editor_mouse.cc
@@ -2053,65 +2053,62 @@ Editor::cancel_time_selection ()
 }
 
 void
-Editor::point_trim (GdkEvent* event, timepos_t const & new_bound)
+Editor::point_trim (GdkEvent* event, timepos_t const & new_bound, bool is_start)
 {
 	RegionView* rv = clicked_regionview;
 
 	/* Choose action dependent on which button was pressed */
-	switch (event->button.button) {
-	case 1:
-		begin_reversible_command (_("start point trim"));
+	if (event->button.button == 1) {
+		if (is_start) {
+			begin_reversible_command (_("start point trim"));
 
-		if (selection->selected (rv)) {
-			for (list<RegionView*>::const_iterator i = selection->regions.by_layer().begin();
-			     i != selection->regions.by_layer().end(); ++i)
-			{
-				if (!(*i)->region()->locked()) {
-					(*i)->region()->clear_changes ();
-					(*i)->region()->trim_front (new_bound);
-					_session->add_command(new StatefulDiffCommand ((*i)->region()));
+			if (selection->selected (rv)) {
+				for (list<RegionView*>::const_iterator i = selection->regions.by_layer().begin();
+					i != selection->regions.by_layer().end(); ++i)
+				{
+					if (!(*i)->region()->locked()) {
+						(*i)->region()->clear_changes ();
+						(*i)->region()->trim_front (new_bound);
+						_session->add_command(new StatefulDiffCommand ((*i)->region()));
+					}
+				}
+
+			} else {
+				if (!rv->region()->locked()) {
+					rv->region()->clear_changes ();
+					rv->region()->trim_front (new_bound);
+					_session->add_command(new StatefulDiffCommand (rv->region()));
 				}
 			}
 
+			commit_reversible_command();
+
 		} else {
-			if (!rv->region()->locked()) {
-				rv->region()->clear_changes ();
-				rv->region()->trim_front (new_bound);
-				_session->add_command(new StatefulDiffCommand (rv->region()));
-			}
-		}
+			begin_reversible_command (_("end point trim"));
 
-		commit_reversible_command();
+			if (selection->selected (rv)) {
 
-		break;
-	case 2:
-		begin_reversible_command (_("end point trim"));
+				for (list<RegionView*>::const_iterator i = selection->regions.by_layer().begin(); i != selection->regions.by_layer().end(); ++i)
+				{
+					if (!(*i)->region()->locked()) {
+						(*i)->region()->clear_changes();
+						(*i)->region()->trim_end (new_bound);
+						_session->add_command(new StatefulDiffCommand ((*i)->region()));
+					}
+				}
 
-		if (selection->selected (rv)) {
+			} else {
 
-			for (list<RegionView*>::const_iterator i = selection->regions.by_layer().begin(); i != selection->regions.by_layer().end(); ++i)
-			{
-				if (!(*i)->region()->locked()) {
-					(*i)->region()->clear_changes();
-					(*i)->region()->trim_end (new_bound);
-					_session->add_command(new StatefulDiffCommand ((*i)->region()));
+				if (!rv->region()->locked()) {
+					rv->region()->clear_changes ();
+					rv->region()->trim_end (new_bound);
+					_session->add_command (new StatefulDiffCommand (rv->region()));
 				}
 			}
 
-		} else {
+			commit_reversible_command();
 
-			if (!rv->region()->locked()) {
-				rv->region()->clear_changes ();
-				rv->region()->trim_end (new_bound);
-				_session->add_command (new StatefulDiffCommand (rv->region()));
-			}
 		}
-
-		commit_reversible_command();
-
-		break;
-	default:
-		break;
 	}
 }
 


### PR DESCRIPTION
When a click action is performed (not drag) at the end of a midi region or clip, it trims the clip from the start to a nearby snap point when snapping is on.
The issue is that start/end trimming for point trim was being decided by the mouse button being clicked which is incorrect. It should be decided by the operation being performed (StartTrim/EndTrim).

**Before:**

https://github.com/user-attachments/assets/7800e05d-3162-4fc7-9caa-04c8c42b367c


**After:**

https://github.com/user-attachments/assets/78ff139d-b1fb-4005-9699-51c1e7895c90


