### PR TITLE
Add references to US2400 shared data in build systems.

### DIFF
--- a/libs/surfaces/us2400/device_info.cc
+++ b/libs/surfaces/us2400/device_info.cc
@@ -292,7 +292,7 @@ DeviceInfo::has_touch_sense_faders () const
 }
 
 static const char * const devinfo_env_variable_name = "ARDOUR_MCP_PATH";
-static const char* const devinfo_dir_name = "mcp";
+static const char* const devinfo_dir_name = "us2400";
 static const char* const devinfo_suffix = ".device";
 
 static Searchpath

--- a/share/us2400/wscript
+++ b/share/us2400/wscript
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import os
+
+def configure(conf):
+    pass
+
+def build(bld):
+    devinfo = bld.path.ant_glob ('*.device')
+    profiles = bld.path.ant_glob ('*.profile')
+    bld.install_files (os.path.join(bld.env['DATADIR'], 'us2400'), devinfo)
+    bld.install_files (os.path.join(bld.env['DATADIR'], 'us2400'), profiles)
+
+def options(opt):
+    pass

--- a/tools/linux_packaging/build
+++ b/tools/linux_packaging/build
@@ -216,6 +216,7 @@ LuaScripts=$Shared/scripts
 MediaClips=$Shared/media
 WebSurfaces=$Shared/web_surfaces
 MackieControl=$Shared/mcp
+US2400=$Shared/us2400
 OSC=$Shared/osc
 
 if [ x$PRINT_SYSDEPS != x ] ; then
@@ -249,6 +250,7 @@ mkdir -p $Locale
 mkdir -p $Surfaces
 mkdir -p $MidiMaps
 mkdir -p $MackieControl
+mkdir -p $US2400
 mkdir -p $OSC
 mkdir -p $ExportFormats
 mkdir -p $Panners
@@ -416,6 +418,13 @@ rm $MediaClips/wscript
 for x in $BUILD_ROOT/../share/mcp/*.device $BUILD_ROOT/../share/mcp/*.profile ; do
     cp "$x" $MackieControl
 done
+
+# US2400 data
+# got to be careful with names here
+for x in $BUILD_ROOT/../share/us2400/*.device $BUILD_ROOT/../share/us2400/*.profile ; do
+    cp "$x" $US2400
+done
+
 
 # Chord data
 cp $BUILD_ROOT/../share/chords.txt $Shared

--- a/tools/osx_packaging/osx_build
+++ b/tools/osx_packaging/osx_build
@@ -155,6 +155,7 @@ LuaScripts=$Shared/scripts
 MediaClips=$Shared/media
 WebSurfaces=$Shared/web_surfaces
 MackieControl=$Shared/mcp
+US2400=$Shared/us2400
 OSC=$Shared/osc
 Themes=$Shared/themes
 
@@ -189,6 +190,7 @@ mkdir -p $MidiMaps
 mkdir -p $ExportFormats
 mkdir -p $Etc
 mkdir -p $MackieControl
+mkdir -p $US2400
 mkdir -p $OSC
 mkdir -p $Themes
 
@@ -405,6 +407,12 @@ rm $MediaClips/wscript
 # got to be careful with names here
 for x in $BUILD_ROOT/../share/mcp/*.device $BUILD_ROOT/../share/mcp/*.profile ; do
 	cp "$x" $MackieControl
+done
+
+# US2400 data
+# got to be careful with names here
+for x in $BUILD_ROOT/../share/us2400/*.device $BUILD_ROOT/../share/us2400/*.profile ; do
+	cp "$x" $US2400
 done
 
 # Chord data

--- a/wscript
+++ b/wscript
@@ -398,6 +398,7 @@ children = [
         'share/patchfiles',
         'share/plugin_metadata',
         'share/scripts',
+        'share/us2400',
         'share/web_surfaces',
         # frontends
         'gtk2_ardour',


### PR DESCRIPTION
Adds references to shared data for Tascam US2400 controller in the build systems.