### PR TITLE
Grab focus on new group dialog

### DIFF
--- a/gtk2_ardour/route_group_dialog.cc
+++ b/gtk2_ardour/route_group_dialog.cc
@@ -188,6 +188,15 @@ RouteGroupDialog::RouteGroupDialog (std::shared_ptr<RouteGroup> g, bool creating
 	show_all_children ();
 }
 
+void
+RouteGroupDialog::on_show ()
+{
+	ArdourDialog::on_show ();
+	present ();
+	set_focus (_name);
+	_name.grab_focus ();
+}
+
 bool
 RouteGroupDialog::name_check () const
 {

--- a/gtk2_ardour/route_group_dialog.h
+++ b/gtk2_ardour/route_group_dialog.h
@@ -39,6 +39,7 @@ public:
 
 	std::shared_ptr<ARDOUR::RouteGroup> group() const { return _group; }
 	bool name_check () const;
+	void on_show() override;
 
 private:
 	std::shared_ptr<ARDOUR::RouteGroup> _group;


### PR DESCRIPTION
The new track group creation dialog does not grab focus when opened. This means the user has to click on the dialog first and then type in the name.

Fix: added present call on show for the dialog.


https://github.com/user-attachments/assets/118b6762-a287-4f84-a1ea-4a0bbd75881f

