### PR TITLE
Komplete Kontrol A-Series control surface, plus a hidapi O_CLOEXEC fix

### DIFF
--- a/gtk2_ardour/ardev_common.sh.in
+++ b/gtk2_ardour/ardev_common.sh.in
@@ -19,7 +19,7 @@ export GTK2_RC_FILES=/nonexistent
 # can find all the components.
 #
 
-export ARDOUR_SURFACES_PATH=$libs/surfaces/osc:$libs/surfaces/faderport8:$libs/surfaces/faderport:$libs/surfaces/generic_midi:$libs/surfaces/tranzport:$libs/surfaces/powermate:$libs/surfaces/mackie:$libs/surfaces/us2400:$libs/surfaces/wiimote:$libs/surfaces/push2:$libs/surfaces/maschine2:$libs/surfaces/cc121:$libs/surfaces/launch_control_xl:$libs/surfaces/contourdesign:$libs/surfaces/websockets:$libs/surfaces/mcp_http:$libs/surfaces/console1:$libs/surfaces/launchpad_pro:$libs/surfaces/launchpad_x:$libs/surfaces/launchkey_4
+export ARDOUR_SURFACES_PATH=$libs/surfaces/osc:$libs/surfaces/faderport8:$libs/surfaces/faderport:$libs/surfaces/generic_midi:$libs/surfaces/tranzport:$libs/surfaces/powermate:$libs/surfaces/mackie:$libs/surfaces/us2400:$libs/surfaces/wiimote:$libs/surfaces/push2:$libs/surfaces/maschine2:$libs/surfaces/cc121:$libs/surfaces/launch_control_xl:$libs/surfaces/contourdesign:$libs/surfaces/websockets:$libs/surfaces/mcp_http:$libs/surfaces/console1:$libs/surfaces/launchpad_pro:$libs/surfaces/launchpad_x:$libs/surfaces/launchkey_4:$libs/surfaces/komplete_kontrol_a
 export ARDOUR_PANNER_PATH=$libs/panners
 export ARDOUR_DATA_PATH=$TOP/share:$TOP/build:$TOP/gtk2_ardour:$TOP/build/gtk2_ardour
 export ARDOUR_MIDIMAPS_PATH=$TOP/share/midi_maps

--- a/libs/ardour/ardour/debug.h
+++ b/libs/ardour/ardour/debug.h
@@ -59,6 +59,7 @@ namespace PBD {
 		LIBARDOUR_API extern DebugBits GenericMidi;
 		LIBARDOUR_API extern DebugBits Graph;
 		LIBARDOUR_API extern DebugBits IOTaskList;
+		LIBARDOUR_API extern DebugBits KompleteKontrolA;
 		LIBARDOUR_API extern DebugBits LTC;
 		LIBARDOUR_API extern DebugBits LV2;
 		LIBARDOUR_API extern DebugBits LV2AtomToUI;

--- a/libs/ardour/debug.cc
+++ b/libs/ardour/debug.cc
@@ -55,6 +55,7 @@ PBD::DebugBits PBD::DEBUG::FaderPort8 = PBD::new_debug_bit ("faderport8");
 PBD::DebugBits PBD::DEBUG::GenericMidi = PBD::new_debug_bit ("genericmidi");
 PBD::DebugBits PBD::DEBUG::Graph = PBD::new_debug_bit ("graph");
 PBD::DebugBits PBD::DEBUG::IOTaskList = PBD::new_debug_bit ("iotasklist");
+PBD::DebugBits PBD::DEBUG::KompleteKontrolA = PBD::new_debug_bit ("kompletekontrola");
 PBD::DebugBits PBD::DEBUG::LTC = PBD::new_debug_bit ("ltc");
 PBD::DebugBits PBD::DEBUG::LV2 = PBD::new_debug_bit ("lv2");
 PBD::DebugBits PBD::DEBUG::LV2AtomToUI = PBD::new_debug_bit ("lv2atomtoui");

--- a/libs/hidapi/linux/hid.c
+++ b/libs/hidapi/linux/hid.c
@@ -416,7 +416,7 @@ static int get_hid_report_descriptor(const char *rpt_path, struct hidraw_report_
 	int rpt_handle;
 	ssize_t res;
 
-	rpt_handle = open(rpt_path, O_RDONLY | FD_CLOEXEC);
+	rpt_handle = open(rpt_path, O_RDONLY | O_CLOEXEC);
 	if (rpt_handle < 0) {
 		register_global_error_format("open failed (%s): %s", rpt_path, strerror(errno));
 		return -1;
@@ -505,7 +505,7 @@ static int parse_hid_vid_pid_from_uevent_path(const char *uevent_path, unsigned 
 	int handle;
 	ssize_t res;
 
-	handle = open(uevent_path, O_RDONLY | FD_CLOEXEC);
+	handle = open(uevent_path, O_RDONLY | O_CLOEXEC);
 	if (handle < 0) {
 		register_global_error_format("open failed (%s): %s", uevent_path, strerror(errno));
 		return 0;
@@ -1063,7 +1063,7 @@ hid_device * HID_API_EXPORT hid_open_path(const char *path)
 		return NULL;
 	}
 
-	dev->device_handle = open(path, O_RDWR | FD_CLOEXEC);
+	dev->device_handle = open(path, O_RDWR | O_CLOEXEC);
 
 	if (dev->device_handle >= 0) {
 		int res, desc_size = 0;

--- a/libs/surfaces/komplete_kontrol_a/interface.cc
+++ b/libs/surfaces/komplete_kontrol_a/interface.cc
@@ -56,18 +56,12 @@ new_komplete_kontrol_a (Session* s, std::string const& config)
 		return 0;
 	}
 
-	/* Honour the result.  Ardour's activate() calls set_active() again, and
-	 * our set_active() re-runs start() whenever the protocol is not already
-	 * active -- so handing back an object that failed to start means the
-	 * device is opened twice and every failure is logged twice.  Reporting
-	 * the failure here instead gives one error and lets activate() fail
-	 * cleanly, which is also what makes the GUI checkbox behave.
+	/* Deliberately inactive.  ControlProtocolManager::activate() runs
+	 * set_state() between here and set_active(), so anything that configures
+	 * the surface has to land before the hardware is touched; starting the
+	 * device here would open it against state that has not been restored yet.
+	 * Failure to start is reported by activate(), which tears us down.
 	 */
-	if (kka->set_active (true)) {
-		delete kka;
-		return 0;
-	}
-
 	return kka;
 }
 

--- a/libs/surfaces/komplete_kontrol_a/interface.cc
+++ b/libs/surfaces/komplete_kontrol_a/interface.cc
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2026 Ada <ada@6bit.com>
  * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/libs/surfaces/komplete_kontrol_a/interface.cc
+++ b/libs/surfaces/komplete_kontrol_a/interface.cc
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Ada <ada@6bit.com>
+ * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdexcept>
+
+#include "pbd/error.h"
+
+#include "ardour/rc_configuration.h"
+#include "control_protocol/control_protocol.h"
+
+#include "komplete_kontrol_a.h"
+
+using namespace ARDOUR;
+using namespace PBD;
+using namespace ArdourSurface;
+
+static ControlProtocol*
+new_komplete_kontrol_a (Session* s, std::string const& /* config */)
+{
+	KompleteKontrolA* kka = 0;
+
+	try {
+		kka = new KompleteKontrolA (*s);
+	} catch (std::exception& e) {
+		PBD::error << "Failed to instantiate Komplete Kontrol A-Series: " << e.what () << endmsg;
+		delete kka;
+		return 0;
+	}
+
+	kka->set_active (true);
+	return kka;
+}
+
+static void
+delete_komplete_kontrol_a (ControlProtocol* cp)
+{
+	delete cp;
+}
+
+static std::map<std::string, std::vector<std::string> >
+enumerate_komplete_kontrol_a ()
+{
+	return { { "Native Instruments", { "Komplete Kontrol A25",
+	                                   "Komplete Kontrol A49",
+	                                   "Komplete Kontrol A61" } } };
+}
+
+static ControlProtocolDescriptor komplete_kontrol_a_descriptor = {
+	/* name       */ "NI Komplete Kontrol A-Series",
+	/* id         */ "uri://ardour.org/surfaces/komplete_kontrol_a:0",
+	/* module     */ 0,
+	/* available  */ KompleteKontrolA::available,
+	/* probe_port */ 0,
+	/* match usb  */ 0,
+	/* initialize */ new_komplete_kontrol_a,
+	/* destroy    */ delete_komplete_kontrol_a,
+	/* enumerate  */ enumerate_komplete_kontrol_a,
+};
+
+extern "C" ARDOURSURFACE_API ControlProtocolDescriptor* protocol_descriptor () { return &komplete_kontrol_a_descriptor; }

--- a/libs/surfaces/komplete_kontrol_a/interface.cc
+++ b/libs/surfaces/komplete_kontrol_a/interface.cc
@@ -31,12 +31,25 @@ using namespace PBD;
 using namespace ArdourSurface;
 
 static ControlProtocol*
-new_komplete_kontrol_a (Session* s, std::string const& /* config */)
+new_komplete_kontrol_a (Session* s, std::string const& config)
 {
 	KompleteKontrolA* kka = 0;
 
+	/* `config` is the model the user selected, and enumerate() offered no name
+	 * that is not in this table, so the only way to arrive with an unknown one
+	 * is a session naming a model this build does not have.  There is nothing
+	 * sensible to open in that case -- the configured device is precisely the
+	 * one we cannot drive -- so decline rather than substituting another.
+	 */
+	const KKA::Variant* variant = KKA::variant_for_model (config.c_str ());
+
+	if (!variant) {
+		PBD::error << "Komplete Kontrol A-Series: unknown model \"" << config << "\"" << endmsg;
+		return 0;
+	}
+
 	try {
-		kka = new KompleteKontrolA (*s);
+		kka = new KompleteKontrolA (*s, *variant);
 	} catch (std::exception& e) {
 		PBD::error << "Failed to instantiate Komplete Kontrol A-Series: " << e.what () << endmsg;
 		delete kka;
@@ -64,12 +77,20 @@ delete_komplete_kontrol_a (ControlProtocol* cp)
 	delete cp;
 }
 
+/* Built from the variant table rather than written out again, so the names
+ * offered here and the names the surface can resolve are the same list by
+ * construction and cannot drift apart.
+ */
 static std::map<std::string, std::vector<std::string> >
 enumerate_komplete_kontrol_a ()
 {
-	return { { "Native Instruments", { "Komplete Kontrol A25",
-	                                   "Komplete Kontrol A49",
-	                                   "Komplete Kontrol A61" } } };
+	std::vector<std::string> models;
+
+	for (size_t i = 0; i < KKA::NumVariants; ++i) {
+		models.push_back (KKA::Variants[i].model);
+	}
+
+	return { { "Native Instruments", models } };
 }
 
 static ControlProtocolDescriptor komplete_kontrol_a_descriptor = {

--- a/libs/surfaces/komplete_kontrol_a/interface.cc
+++ b/libs/surfaces/komplete_kontrol_a/interface.cc
@@ -43,7 +43,18 @@ new_komplete_kontrol_a (Session* s, std::string const& /* config */)
 		return 0;
 	}
 
-	kka->set_active (true);
+	/* Honour the result.  Ardour's activate() calls set_active() again, and
+	 * our set_active() re-runs start() whenever the protocol is not already
+	 * active -- so handing back an object that failed to start means the
+	 * device is opened twice and every failure is logged twice.  Reporting
+	 * the failure here instead gives one error and lets activate() fail
+	 * cleanly, which is also what makes the GUI checkbox behave.
+	 */
+	if (kka->set_active (true)) {
+		delete kka;
+		return 0;
+	}
+
 	return kka;
 }
 

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.cc
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.cc
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2026 Ada <ada@6bit.com>
  * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.cc
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.cc
@@ -17,11 +17,17 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <string.h>
+
 #include "kka_protocol.h"
 
 namespace ArdourSurface { namespace KKA {
 
-/* Ordered widest-first so the most likely device is probed first. */
+/* The surface list in the GUI is generated from this table, in this order, so
+ * adding a model here is all it takes to offer it -- and nothing can be
+ * offered that the surface would then fail to recognise.  Widest first,
+ * because the A61 is the most common of the three.
+ */
 const Variant Variants[] = {
 	{ 0x1750, 61, "Komplete Kontrol A61", true  },
 	{ 0x1740, 49, "Komplete Kontrol A49", false },
@@ -35,6 +41,20 @@ variant_for_pid (uint16_t pid)
 {
 	for (size_t i = 0; i < NumVariants; ++i) {
 		if (Variants[i].pid == pid) {
+			return &Variants[i];
+		}
+	}
+	return 0;
+}
+
+const Variant*
+variant_for_model (const char* model)
+{
+	if (!model) {
+		return 0;
+	}
+	for (size_t i = 0; i < NumVariants; ++i) {
+		if (!strcmp (Variants[i].model, model)) {
 			return &Variants[i];
 		}
 	}

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.cc
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 Ada <ada@6bit.com>
+ * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include "kka_protocol.h"
+
+namespace ArdourSurface { namespace KKA {
+
+/* Ordered widest-first so the most likely device is probed first. */
+const Variant Variants[] = {
+	{ 0x1750, 61, "Komplete Kontrol A61", true  },
+	{ 0x1740, 49, "Komplete Kontrol A49", false },
+	{ 0x1730, 25, "Komplete Kontrol A25", false },
+};
+
+const size_t NumVariants = sizeof (Variants) / sizeof (Variants[0]);
+
+const Variant*
+variant_for_pid (uint16_t pid)
+{
+	for (size_t i = 0; i < NumVariants; ++i) {
+		if (Variants[i].pid == pid) {
+			return &Variants[i];
+		}
+	}
+	return 0;
+}
+
+const char*
+control_name (ControlID c)
+{
+	/* Indexed by ControlID, which is the button bit index. */
+	static const char* const names[NumControls] = {
+		"Shift",
+		"Scale",
+		"Arp",
+		"Undo",
+		"Quantize",
+		"Ideas",
+		"Loop",
+		"Metro",
+		"Tempo",
+		"Play",
+		"Rec",
+		"Stop",
+		"Preset Up",
+		"Preset Down",
+		"M / Page Left",
+		"S / Page Right",
+		"Browser",
+		"Plug-In",
+		"Track",
+		"Octave Down",
+		"Octave Up",
+		"4-D Up",
+		"4-D Left",
+		"4-D Right",
+		"4-D Down",
+		"Knob 1 Touch",
+		"Knob 2 Touch",
+		"Knob 3 Touch",
+		"Knob 4 Touch",
+		"Knob 5 Touch",
+		"Knob 6 Touch",
+		"Knob 7 Touch",
+		"Knob 8 Touch",
+		"4-D Press",
+	};
+
+	if ((int) c < 0 || (int) c >= NumControls) {
+		return "?";
+	}
+	return names[c];
+}
+
+} } /* namespace ArdourSurface::KKA */

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -77,6 +77,12 @@ extern const size_t  NumVariants;
 
 const Variant* variant_for_pid (uint16_t pid);
 
+/* Matched against Variant::model.  enumerate() offers the GUI exactly these
+ * names, so the string that comes back always resolves; null means a session
+ * naming a model this build does not have, which is the caller's to refuse.
+ */
+const Variant* variant_for_model (const char* model);
+
 /* --------------------------------------------------------- HID reports */
 
 enum ReportID {

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2026 Ada <ada@6bit.com>
  * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -24,6 +24,19 @@
  * from any GPL-3 source; where a third-party project's published findings
  * agree they are cited as corroboration only.
  *
+ * Every constant below has a documented derivation, including the captures
+ * behind it, the experiments that settled the ambiguous cases and the two
+ * places where a published third-party map is demonstrably wrong:
+ *
+ *	https://github.com/nuketownada/ardourkomplete
+ *	  docs/a61-hid-map.md	the protocol map itself
+ *	  tools/		Python probes that talk to the device directly,
+ *				which is how most of this was measured
+ *
+ * Worth reaching for before changing anything here: a value that looks
+ * arbitrary usually is not, and several of them cost a hardware session to
+ * pin down.
+ *
  * This header is protocol description, deliberately free of Ardour types, so
  * it can be read and checked against a capture on its own.
  */

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -161,21 +161,33 @@ static inline bool control_has_led (ControlID c)
 	return (size_t) c < LEDCount;
 }
 
-/* LED brightness.  The descriptor declares a full 0..127 range, so this is
- * plausibly a continuum, but only off and full have been exercised.
+/* LED brightness: three states, not the continuum the declared 0..127 range
+ * implies.  Measured on an A61 by lighting all 21 lamps at once with 21
+ * different values, which shows the whole space at a glance
+ * (`tools/a61led.py ramp` in the ardourkomplete repo):
+ *
+ *	value < 4	off, whatever bit 1 says
+ *	bit 1 clear	dim
+ *	bit 1 set	bright
+ *
+ * Bits 2..6 change nothing beyond lighting the lamp at all: 0x04, 0x40 and
+ * 0x7c are indistinguishable from one another, as are 0x06, 0x42 and 0x7e.
+ * Which is exactly why upstream ships LED_ON 0x7c and LED_BRIGHT 0x7e as its
+ * two levels -- they differ in bit 1 and in nothing else that matters.
+ *
+ * Consistent with NI's usual (colour << 2) | brightness LED byte, where colour
+ * index 0 means "no colour" and so reads as off, and where a monochrome button
+ * has no hue to pick and ignores the index. The firmware's own power-on
+ * animation sweeps roughly sixteen visibly distinct levels, so the panel can
+ * do far more than this -- but report 0x80 is not the road to it.
+ *
+ * Upstream's byte values are kept in preference to the equivalent 0x04 / 0x06
+ * because these are the ones also exercised on an A25, and the A25 and A49
+ * remain untested here.
  */
 static const uint8_t LEDOff    = 0x00;
-static const uint8_t LEDOn     = 0x7c;
+static const uint8_t LEDDim    = 0x7c;
 static const uint8_t LEDBright = 0x7e;
-
-/* Deliberately far from the others, because it is also the experiment that
- * answers open question 1 -- whether brightness is a continuum or a handful of
- * quantised steps. LEDOn and LEDBright differ by 2 out of 127 and would look
- * identical whatever the answer, so they cannot tell us. If this reads as
- * visibly dimmer than LEDOn the range is usable for signalling intensity; if
- * it reads as off or as full brightness, it is not.
- */
-static const uint8_t LEDDim    = 0x20;
 
 /* ------------------------------------------------------------ encoders */
 

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -176,12 +176,18 @@ static inline int encoder_delta (uint8_t prev, uint8_t cur)
 	return (((int) cur - (int) prev + 8) & 0x0f) - 8;
 }
 
-/* Each knob is a wrapping counter, 8 units per detent, modulo KnobRange.
+/* Each knob is a wrapping counter modulo KnobRange, moving KnobUnitsPerStep at
+ * a time.  The knobs turn freely and have no physical detent, so a "step" here
+ * is the device's reporting quantum and not something the user can feel.
  * Reports coalesce during a fast spin, so a single report can carry several
- * detents; never assume one.
+ * steps; never assume one.
+ *
+ * Both constants are measured on an A61.  Successive reports through a slow
+ * turn differ by exactly 8, and turning down through zero reports 991 -- which
+ * is 999 - 8, so the modulus is 999 rather than the 1000 one would guess.
  */
-static const int KnobRange          = 999;
-static const int KnobUnitsPerDetent = 8;
+static const int KnobRange        = 999;
+static const int KnobUnitsPerStep = 8;
 
 static inline int knob_delta (uint16_t prev, uint16_t cur)
 {

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -168,6 +168,15 @@ static const uint8_t LEDOff    = 0x00;
 static const uint8_t LEDOn     = 0x7c;
 static const uint8_t LEDBright = 0x7e;
 
+/* Deliberately far from the others, because it is also the experiment that
+ * answers open question 1 -- whether brightness is a continuum or a handful of
+ * quantised steps. LEDOn and LEDBright differ by 2 out of 127 and would look
+ * identical whatever the answer, so they cannot tell us. If this reads as
+ * visibly dimmer than LEDOn the range is usable for signalling intensity; if
+ * it reads as off or as full brightness, it is not.
+ */
+static const uint8_t LEDDim    = 0x20;
+
 /* ------------------------------------------------------------ encoders */
 
 /* The 4-D encoder is a 4-bit wrapping absolute position, not a delta. */

--- a/libs/surfaces/komplete_kontrol_a/kka_protocol.h
+++ b/libs/surfaces/komplete_kontrol_a/kka_protocol.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2026 Ada <ada@6bit.com>
+ * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/* Wire protocol for the Native Instruments Komplete Kontrol A-Series.
+ *
+ * Established by observing the device's own HID report descriptor and by
+ * capture on an A61 (firmware build 2022-01-05).  No code or data was taken
+ * from any GPL-3 source; where a third-party project's published findings
+ * agree they are cited as corroboration only.
+ *
+ * This header is protocol description, deliberately free of Ardour types, so
+ * it can be read and checked against a capture on its own.
+ */
+
+#ifndef _ardour_surfaces_kka_protocol_h_
+#define _ardour_surfaces_kka_protocol_h_
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace ArdourSurface { namespace KKA {
+
+/* ------------------------------------------------------------------ USB */
+
+static const uint16_t VendorID = 0x17cc;
+
+/* The three A-Series keyboards are one device with three keybeds; NI's own
+ * manual states "beyond the keybed, all keyboards come with identical
+ * features".  Only the A61 has been tested here.  The A49's report descriptor
+ * is 502 bytes, matching the A61's exactly; the A25's is unmeasured -- no
+ * public capture of one exists -- which is why open_device() checks the
+ * descriptor length and warns rather than assuming.
+ *
+ * The M32 (0x1860) is the same family but NOT the same device: identical
+ * button bitfield, LED report and display protocol, but a 526-byte descriptor
+ * and a different analog block (touch strips in place of pitch/mod wheels,
+ * encoder at payload[23]).  It needs a variant, not just another PID here.
+ */
+struct Variant {
+	uint16_t    pid;
+	int         keys;
+	const char* model;
+	bool        tested;
+};
+
+extern const Variant Variants[];
+extern const size_t  NumVariants;
+
+const Variant* variant_for_pid (uint16_t pid);
+
+/* --------------------------------------------------------- HID reports */
+
+enum ReportID {
+	ReportInput   = 0x01, /* IN,  29 byte payload, sent on change only */
+	ReportLEDs    = 0x80, /* OUT, 21 bytes, each 0..127                */
+	ReportMode    = 0xa0, /* OUT, 2 bytes                              */
+	ReportDisplay = 0xe0, /* OUT, 8 byte header + 256 byte bitmap      */
+};
+
+static const size_t InputPayloadSize = 29;
+static const size_t InputReportSize  = 1 + InputPayloadSize; /* 30 */
+
+static const size_t LEDCount      = 21;
+static const size_t LEDReportSize = 1 + LEDCount; /* 22 */
+
+static const size_t DisplayHeaderSize  = 8;
+static const size_t DisplayPayloadSize = 256;
+static const size_t DisplayReportSize  = 1 + DisplayHeaderSize + DisplayPayloadSize; /* 265 */
+
+/* Report descriptor length, verified identical on A61 and A49. */
+static const size_t ExpectedDescriptorSize = 502;
+
+/* ---------------------------------------------------------------- modes */
+
+/* Payload for ReportMode.  Interactive mode moves knob rotation off the MIDI
+ * port and into HID as endless encoders, and hands the display to the host.
+ * It does NOT survive a replug, so the surface must re-assert it and must
+ * restore MIDI mode on teardown or the user is left with a half-owned device.
+ */
+static const uint8_t ModeMIDI[2]        = { 0x07, 0x00 };
+static const uint8_t ModeInteractive[2] = { 0x03, 0x04 };
+
+/* ------------------------------------------------- input report layout */
+
+/* Offsets are into the payload, i.e. with the report ID already stripped. */
+static const size_t ButtonsOffset = 0;  /* 5 bytes, 40 declared bits       */
+static const size_t ButtonsBytes  = 5;
+static const size_t KnobsOffset   = 5;  /* 8 x uint16 little-endian        */
+static const size_t EncoderOffset = 27; /* low nibble only                 */
+
+/* payload[21:27] declare pitch bend, mod wheel and a third analog input.
+ * All three read 0 in both modes on the A61 -- they are presumably
+ * provisioned for another model in the family.  Do not plan around them.
+ * payload[28] is a constant 36 in every capture; purpose unknown.
+ */
+
+static const int NumKnobs = 8;
+
+/* Every control's identity is its bit index in the button bitfield, and for
+ * the first LEDCount of them that is also its index in the LED report.  There
+ * is no mapping table to write in either direction.
+ */
+enum ControlID {
+	Shift = 0,       /* swallowed by the firmware in MIDI mode */
+	Scale,
+	Arp,
+	Undo,
+	Quantize,
+	Ideas,
+	Loop,
+	Metro,
+	Tempo,
+	Play,
+	Rec,
+	Stop,
+	PresetUp,
+	PresetDown,
+	PageLeft,
+	PageRight,
+	Browser,
+	PlugIn,
+	Track,
+	OctaveDown,
+	OctaveUp,        /* == LEDCount - 1; nothing below here has an LED */
+	Encoder4DUp,
+	Encoder4DLeft,
+	Encoder4DRight,
+	Encoder4DDown,
+	Knob1Touch,
+	Knob2Touch,
+	Knob3Touch,
+	Knob4Touch,
+	Knob5Touch,
+	Knob6Touch,
+	Knob7Touch,
+	Knob8Touch,
+	Encoder4DPress,
+	NumControls      /* 34; declared bits 34..39 are unused padding */
+};
+
+const char* control_name (ControlID);
+
+static inline bool control_has_led (ControlID c)
+{
+	return (size_t) c < LEDCount;
+}
+
+/* LED brightness.  The descriptor declares a full 0..127 range, so this is
+ * plausibly a continuum, but only off and full have been exercised.
+ */
+static const uint8_t LEDOff    = 0x00;
+static const uint8_t LEDOn     = 0x7c;
+static const uint8_t LEDBright = 0x7e;
+
+/* ------------------------------------------------------------ encoders */
+
+/* The 4-D encoder is a 4-bit wrapping absolute position, not a delta. */
+static inline int encoder_delta (uint8_t prev, uint8_t cur)
+{
+	return (((int) cur - (int) prev + 8) & 0x0f) - 8;
+}
+
+/* Each knob is a wrapping counter, 8 units per detent, modulo KnobRange.
+ * Reports coalesce during a fast spin, so a single report can carry several
+ * detents; never assume one.
+ */
+static const int KnobRange          = 999;
+static const int KnobUnitsPerDetent = 8;
+
+static inline int knob_delta (uint16_t prev, uint16_t cur)
+{
+	int raw = (int) cur - (int) prev;
+	if (raw >  KnobRange / 2) { raw -= KnobRange; }
+	if (raw < -KnobRange / 2) { raw += KnobRange; }
+	return raw;
+}
+
+/* ------------------------------------------------------------- display */
+
+/* 128x32 monochrome, read from feature report 0xf8.
+ *
+ * The header is four uint16 little-endian fields, and the trap is that they
+ * are in mixed units: x and width are pixels, y and height are 8-row pages.
+ * The firmware validates the header and silently drops anything off-panel, so
+ * a wrong guess is indistinguishable from a dead device.
+ *
+ * Payload is SSD1306-style page-major -- data[page * width + col], each byte
+ * eight vertical pixels with bit 0 the TOP row -- and the polarity is
+ * INVERTED: a set bit renders dark.  So an all-zero payload lights the whole
+ * panel and an all-ones payload blanks it.
+ *
+ * Short reports do not work: the device appears to consume 256 payload bytes
+ * regardless of what was sent, so every report costs a fixed 265 bytes no
+ * matter how small the rectangle in its header.
+ */
+static const int DisplayWidth  = 128;
+static const int DisplayHeight = 32;
+static const int DisplayPages  = DisplayHeight / 8; /* 4 */
+
+} } /* namespace ArdourSurface::KKA */
+
+#endif /* _ardour_surfaces_kka_protocol_h_ */

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -1,0 +1,473 @@
+/*
+ * Copyright (C) 2026 Ada <ada@6bit.com>
+ * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <glibmm/main.h>
+
+#include "pbd/compose.h"
+#include "pbd/error.h"
+
+#include "ardour/debug.h"
+#include "ardour/session.h"
+
+#include "komplete_kontrol_a.h"
+
+#include "pbd/abstract_ui.inc.cc" // instantiate template, includes i18n
+
+using namespace ARDOUR;
+using namespace PBD;
+using namespace ArdourSurface;
+
+/* The device reports on change only, so this is a poll for "did anything
+ * happen", not a sample clock -- it costs a syscall that almost always
+ * returns nothing.  1ms matches maschine2, which is the in-tree precedent.
+ */
+static const unsigned int read_interval_ms = 1;
+
+bool
+KompleteKontrolA::available ()
+{
+	if (hid_init ()) {
+		return false;
+	}
+	hid_exit ();
+	return true;
+}
+
+KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s)
+	: ControlProtocol (s, std::string (X_("NI Komplete Kontrol A-Series")))
+	, AbstractUI<KompleteKontrolARequest> (name ())
+	, _handle (0)
+	, _variant (0)
+	, _seeded (false)
+	, _buttons (0)
+	, _encoder_pos (0)
+	, _warned_short_report (false)
+	, _warned_read_error (false)
+{
+	memset (_knob_raw, 0, sizeof (_knob_raw));
+	memset (_knob_accum, 0, sizeof (_knob_accum));
+
+	if (hid_init ()) {
+		throw KompleteKontrolAException ("HIDAPI initialization failed");
+	}
+
+	BaseUI::run ();
+}
+
+KompleteKontrolA::~KompleteKontrolA ()
+{
+	stop ();
+	hid_exit ();
+}
+
+void
+KompleteKontrolA::do_request (KompleteKontrolARequest* req)
+{
+	if (req->type == CallSlot) {
+		call_slot (MISSING_INVALIDATOR, req->the_slot);
+	} else if (req->type == Quit) {
+		stop ();
+	}
+}
+
+int
+KompleteKontrolA::set_active (bool yn)
+{
+	if (yn == active ()) {
+		return 0;
+	}
+
+	if (yn) {
+		if (start ()) {
+			return -1;
+		}
+	} else {
+		if (stop ()) {
+			return -1;
+		}
+	}
+
+	ControlProtocol::set_active (yn);
+	return 0;
+}
+
+XMLNode&
+KompleteKontrolA::get_state () const
+{
+	XMLNode& node (ControlProtocol::get_state ());
+	return node;
+}
+
+int
+KompleteKontrolA::set_state (const XMLNode& node, int version)
+{
+	if (ControlProtocol::set_state (node, version)) {
+		return -1;
+	}
+	return 0;
+}
+
+/* ------------------------------------------------------------------------ */
+
+int
+KompleteKontrolA::open_device ()
+{
+	for (size_t i = 0; i < KKA::NumVariants; ++i) {
+		_handle = hid_open (KKA::VendorID, KKA::Variants[i].pid, NULL);
+		if (_handle) {
+			_variant = &KKA::Variants[i];
+			break;
+		}
+	}
+
+	if (!_handle) {
+		error << _("Komplete Kontrol A-Series: no device found") << endmsg;
+		return -1;
+	}
+
+	char usbid[16];
+	snprintf (usbid, sizeof (usbid), "%04x:%04x", KKA::VendorID, _variant->pid);
+
+	info << string_compose (_("Komplete Kontrol A-Series: found %1 (%2), %3 keys"),
+	                        _variant->model, usbid, _variant->keys)
+	     << endmsg;
+
+	/* The A25 and A49 are believed identical to the A61 apart from the
+	 * keybed, but only the A61 has been tested.  Rather than assume, check
+	 * the one thing that would actually break parsing -- the shape of the
+	 * report descriptor -- and say so loudly if it differs.  That turns the
+	 * first A25 user into a useful bug report instead of a silent misdecode.
+	 */
+	if (!_variant->tested) {
+		unsigned char desc[4096];
+		int n = hid_get_report_descriptor (_handle, desc, sizeof (desc));
+
+		if (n < 0) {
+			info << string_compose (_("Komplete Kontrol A-Series: %1 is untested; "
+			                          "please report any misbehaviour."),
+			                        _variant->model)
+			     << endmsg;
+		} else if ((size_t) n != KKA::ExpectedDescriptorSize) {
+			warning << string_compose (_("Komplete Kontrol A-Series: %1 reports a %2 byte HID "
+			                             "descriptor, expected %3. This model is untested and "
+			                             "controls may be misread. Please report this, with the "
+			                             "output of `lsusb -v -d %4`."),
+			                           _variant->model, n, KKA::ExpectedDescriptorSize, usbid)
+			        << endmsg;
+		} else {
+			info << string_compose (_("Komplete Kontrol A-Series: %1 is untested, but its HID "
+			                          "descriptor matches the A61. Proceeding."),
+			                        _variant->model)
+			     << endmsg;
+		}
+	}
+
+	hid_set_nonblocking (_handle, 1);
+	return 0;
+}
+
+void
+KompleteKontrolA::close_device ()
+{
+	if (!_handle) {
+		return;
+	}
+
+	/* Once interactive mode has been entered the firmware stops drawing the
+	 * panel and never resumes -- not even on a switch back to MIDI mode. So
+	 * leaving without blanking strands the user's last frame on the screen
+	 * until they replug.
+	 */
+	clear_leds ();
+	blank_display ();
+	set_device_mode (KKA::ModeMIDI);
+
+	hid_close (_handle);
+	_handle = 0;
+	_variant = 0;
+}
+
+int
+KompleteKontrolA::start ()
+{
+	if (open_device ()) {
+		return -1;
+	}
+
+	/* Interactive mode takes the knobs off the MIDI port and hands us the
+	 * display. It does not survive a replug, so a user who reconnects
+	 * mid-session silently gets a device sending CC 14-21 at their tracks
+	 * again; re-asserting on hotplug is Phase 3 work.
+	 */
+	if (set_device_mode (KKA::ModeInteractive)) {
+		error << _("Komplete Kontrol A-Series: failed to enter interactive mode") << endmsg;
+		close_device ();
+		return -1;
+	}
+
+	clear_leds ();
+	blank_display ();
+
+	_seeded = false;
+	_buttons = 0;
+	_encoder_pos = 0;
+	memset (_knob_raw, 0, sizeof (_knob_raw));
+	memset (_knob_accum, 0, sizeof (_knob_accum));
+
+	Glib::RefPtr<Glib::TimeoutSource> read_timeout = Glib::TimeoutSource::create (read_interval_ms);
+	_read_connection = read_timeout->connect (sigc::mem_fun (*this, &KompleteKontrolA::dev_read));
+	read_timeout->attach (main_loop ()->get_context ());
+
+	return 0;
+}
+
+int
+KompleteKontrolA::stop ()
+{
+	_read_connection.disconnect ();
+
+	close_device ();
+
+	BaseUI::quit ();
+	return 0;
+}
+
+void
+KompleteKontrolA::thread_init ()
+{
+	ARDOUR::SessionEvent::create_per_thread_pool (event_loop_name (), 1024);
+	PBD::notify_event_loops_about_thread_creation (pthread_self (), event_loop_name (), 1024);
+	set_thread_priority ();
+}
+
+/* --------------------------------------------------------------- output */
+
+int
+KompleteKontrolA::set_device_mode (const uint8_t mode[2])
+{
+	if (!_handle) {
+		return -1;
+	}
+
+	uint8_t buf[3] = { KKA::ReportMode, mode[0], mode[1] };
+	return hid_write (_handle, buf, sizeof (buf)) < 0 ? -1 : 0;
+}
+
+int
+KompleteKontrolA::clear_leds ()
+{
+	if (!_handle) {
+		return -1;
+	}
+
+	uint8_t buf[KKA::LEDReportSize];
+	memset (buf, KKA::LEDOff, sizeof (buf));
+	buf[0] = KKA::ReportLEDs;
+
+	return hid_write (_handle, buf, sizeof (buf)) < 0 ? -1 : 0;
+}
+
+int
+KompleteKontrolA::blank_display ()
+{
+	if (!_handle) {
+		return -1;
+	}
+
+	int rv = 0;
+
+	/* Two full-width two-page bands cover the panel. A band costs exactly
+	 * what a single page costs -- the report is a fixed 265 bytes either
+	 * way -- so this is the cheapest possible full-panel write.
+	 */
+	for (int page = 0; page < KKA::DisplayPages; page += 2) {
+		uint8_t buf[KKA::DisplayReportSize];
+
+		/* Polarity is inverted: a set bit renders dark, so all-ones blanks. */
+		memset (buf, 0xff, sizeof (buf));
+
+		buf[0] = KKA::ReportDisplay;
+		buf[1] = 0;                                  /* x offset, pixels     */
+		buf[2] = 0;
+		buf[3] = page;                               /* y offset, pages      */
+		buf[4] = 0;
+		buf[5] = KKA::DisplayWidth & 0xff;           /* width, pixels        */
+		buf[6] = (KKA::DisplayWidth >> 8) & 0xff;
+		buf[7] = 2;                                  /* height, pages        */
+		buf[8] = 0;
+
+		if (hid_write (_handle, buf, sizeof (buf)) < 0) {
+			rv = -1;
+		}
+	}
+
+	return rv;
+}
+
+/* ---------------------------------------------------------------- input */
+
+bool
+KompleteKontrolA::dev_read ()
+{
+	if (!_handle) {
+		return false;
+	}
+
+	uint8_t buf[KKA::InputReportSize];
+
+	/* Reports are emitted on change only, but a fast knob spin coalesces
+	 * several between wakeups, so drain rather than taking one per tick.
+	 * The bound is a safety valve against a device that never goes quiet.
+	 */
+	for (int i = 0; i < 32; ++i) {
+		int n = hid_read (_handle, buf, sizeof (buf));
+
+		if (n == 0) {
+			break;
+		}
+
+		if (n < 0) {
+			if (!_warned_read_error) {
+				_warned_read_error = true;
+				error << _("Komplete Kontrol A-Series: HID read failed; was the device unplugged?")
+				      << endmsg;
+			}
+			break;
+		}
+
+		if (buf[0] != KKA::ReportInput) {
+			continue;
+		}
+
+		if ((size_t) n != KKA::InputReportSize) {
+			if (!_warned_short_report) {
+				_warned_short_report = true;
+				warning << string_compose (_("Komplete Kontrol A-Series: %1 byte input report, "
+				                             "expected %2. Controls may be misread."),
+				                           n, KKA::InputReportSize)
+				        << endmsg;
+			}
+			continue;
+		}
+
+		decode (buf + 1, n - 1);
+	}
+
+	return true;
+}
+
+void
+KompleteKontrolA::decode (const uint8_t* p, size_t len)
+{
+	if (len < KKA::InputPayloadSize) {
+		return;
+	}
+
+	uint64_t buttons = 0;
+	for (size_t i = 0; i < KKA::ButtonsBytes; ++i) {
+		buttons |= (uint64_t) p[KKA::ButtonsOffset + i] << (8 * i);
+	}
+
+	uint16_t knobs[KKA::NumKnobs];
+	for (int k = 0; k < KKA::NumKnobs; ++k) {
+		size_t o = KKA::KnobsOffset + 2 * k;
+		knobs[k] = (uint16_t) (p[o] | (p[o + 1] << 8));
+	}
+
+	uint8_t encoder = p[KKA::EncoderOffset] & 0x0f;
+
+	if (!_seeded) {
+		_buttons = buttons;
+		memcpy (_knob_raw, knobs, sizeof (_knob_raw));
+		_encoder_pos = encoder;
+		_seeded = true;
+		return;
+	}
+
+	uint64_t changed = buttons ^ _buttons;
+	_buttons = buttons;
+
+	/* Declared bits 34..39 are padding on this hardware and are deliberately
+	 * not dispatched.
+	 */
+	for (int b = 0; b < KKA::NumControls; ++b) {
+		if (changed & (1ULL << b)) {
+			handle_button ((KKA::ControlID) b, (buttons >> b) & 1);
+		}
+	}
+
+	for (int k = 0; k < KKA::NumKnobs; ++k) {
+		int raw = KKA::knob_delta (_knob_raw[k], knobs[k]);
+		_knob_raw[k] = knobs[k];
+
+		if (!raw) {
+			continue;
+		}
+
+		/* Carry the remainder rather than truncating it. Every delta seen on
+		 * this hardware is an exact multiple of the detent size, so today
+		 * this is a no-op -- but a dropped report would otherwise silently
+		 * discard the fraction.
+		 */
+		_knob_accum[k] += raw;
+		int detents = _knob_accum[k] / KKA::KnobUnitsPerDetent;
+		_knob_accum[k] -= detents * KKA::KnobUnitsPerDetent;
+
+		if (detents) {
+			handle_knob (k, detents);
+		}
+	}
+
+	int ed = KKA::encoder_delta (_encoder_pos, encoder);
+	_encoder_pos = encoder;
+	if (ed) {
+		handle_encoder (ed);
+	}
+}
+
+/* Phase 2 stops here: decode and trace. Phase 3 binds these to Ardour. */
+
+void
+KompleteKontrolA::handle_button (KKA::ControlID c, bool pressed)
+{
+	DEBUG_TRACE (DEBUG::KompleteKontrolA,
+	             string_compose ("KKA button %1 (bit %2) %3\n",
+	                             KKA::control_name (c), (int) c,
+	                             pressed ? "pressed" : "released"));
+}
+
+void
+KompleteKontrolA::handle_knob (int knob, int detents)
+{
+	DEBUG_TRACE (DEBUG::KompleteKontrolA,
+	             string_compose ("KKA knob %1 %2%3\n",
+	                             knob + 1, detents > 0 ? "+" : "", detents));
+}
+
+void
+KompleteKontrolA::handle_encoder (int detents)
+{
+	DEBUG_TRACE (DEBUG::KompleteKontrolA,
+	             string_compose ("KKA 4-D encoder %1%2\n",
+	                             detents > 0 ? "+" : "", detents));
+}

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2026 Ada <ada@6bit.com>
  * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -487,16 +487,16 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 		}
 
 		/* Carry the remainder rather than truncating it. Every delta seen on
-		 * this hardware is an exact multiple of the detent size, so today
-		 * this is a no-op -- but a dropped report would otherwise silently
-		 * discard the fraction.
+		 * this hardware is an exact multiple of the step size, so today this
+		 * is a no-op -- but a dropped report would otherwise silently discard
+		 * the fraction.
 		 */
 		_knob_accum[k] += raw;
-		int detents = _knob_accum[k] / KKA::KnobUnitsPerDetent;
-		_knob_accum[k] -= detents * KKA::KnobUnitsPerDetent;
+		int steps = _knob_accum[k] / KKA::KnobUnitsPerStep;
+		_knob_accum[k] -= steps * KKA::KnobUnitsPerStep;
 
-		if (detents) {
-			handle_knob (k, detents);
+		if (steps) {
+			handle_knob (k, steps);
 		}
 	}
 
@@ -535,17 +535,17 @@ KompleteKontrolA::handle_button (KKA::ControlID c, bool pressed)
 }
 
 void
-KompleteKontrolA::handle_knob (int knob, int detents)
+KompleteKontrolA::handle_knob (int knob, int steps)
 {
 	DEBUG_TRACE (DEBUG::KompleteKontrolA,
 	             string_compose ("KKA knob %1 %2%3\n",
-	                             knob + 1, detents > 0 ? "+" : "", detents));
+	                             knob + 1, steps > 0 ? "+" : "", steps));
 }
 
 void
-KompleteKontrolA::handle_encoder (int detents)
+KompleteKontrolA::handle_encoder (int steps)
 {
 	DEBUG_TRACE (DEBUG::KompleteKontrolA,
 	             string_compose ("KKA 4-D encoder %1%2\n",
-	                             detents > 0 ? "+" : "", detents));
+	                             steps > 0 ? "+" : "", steps));
 }

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -382,8 +382,10 @@ KompleteKontrolA::start ()
 		return -1;
 	}
 
+	/* No refresh needed here -- take_over_device() has just done one, and the
+	 * lamps cannot have gone stale between there and here.
+	 */
 	connect_session_signals ();
-	refresh_transport_leds ();
 
 	/* Attached here rather than in start_read_poll(), which reconnection calls
 	 * again -- the blink belongs to the surface being active, not to the

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -68,11 +68,11 @@ KompleteKontrolA::available ()
 	return true;
 }
 
-KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s)
+KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s, const KKA::Variant& variant)
 	: ControlProtocol (s, std::string (X_("NI Komplete Kontrol A-Series")))
 	, AbstractUI<KompleteKontrolARequest> (name ())
 	, _handle (0)
-	, _variant (0)
+	, _variant (variant)
 	, _blink_on (false)
 	, _seeded (false)
 	, _buttons (0)
@@ -167,15 +167,12 @@ KompleteKontrolA::open_device (bool quiet_if_absent)
 
 	struct hid_device_info* devs = hid_enumerate (0x0, 0x0);
 
-	for (size_t i = 0; i < KKA::NumVariants && !_handle; ++i) {
-		for (struct hid_device_info* d = devs; d; d = d->next) {
-			if (d->vendor_id != KKA::VendorID || d->product_id != KKA::Variants[i].pid) {
-				continue;
-			}
-			if ((_handle = hid_open_path (d->path)) != 0) {
-				_variant = &KKA::Variants[i];
-				break;
-			}
+	for (struct hid_device_info* d = devs; d; d = d->next) {
+		if (d->vendor_id != KKA::VendorID || d->product_id != _variant.pid) {
+			continue;
+		}
+		if ((_handle = hid_open_path (d->path)) != 0) {
+			break;
 		}
 	}
 
@@ -187,16 +184,21 @@ KompleteKontrolA::open_device (bool quiet_if_absent)
 		 * long as the user leaves it unplugged.
 		 */
 		if (!quiet_if_absent) {
-			error << _("Komplete Kontrol A-Series: no device found") << endmsg;
+			/* Naming the model matters here: the likely mistake is a user
+			 * who picked the wrong row for the keyboard on their desk, and
+			 * "no device found" would not tell them that.
+			 */
+			error << string_compose (_("Komplete Kontrol A-Series: no %1 found"), _variant.model)
+			      << endmsg;
 		}
 		return -1;
 	}
 
 	char usbid[16];
-	snprintf (usbid, sizeof (usbid), "%04x:%04x", KKA::VendorID, _variant->pid);
+	snprintf (usbid, sizeof (usbid), "%04x:%04x", KKA::VendorID, _variant.pid);
 
 	info << string_compose (_("Komplete Kontrol A-Series: found %1 (%2), %3 keys"),
-	                        _variant->model, usbid, _variant->keys)
+	                        _variant.model, usbid, _variant.keys)
 	     << endmsg;
 
 	/* The A25 and A49 are believed identical to the A61 apart from the
@@ -205,26 +207,26 @@ KompleteKontrolA::open_device (bool quiet_if_absent)
 	 * report descriptor -- and say so loudly if it differs.  That turns the
 	 * first A25 user into a useful bug report instead of a silent misdecode.
 	 */
-	if (!_variant->tested) {
+	if (!_variant.tested) {
 		unsigned char desc[4096];
 		int n = hid_get_report_descriptor (_handle, desc, sizeof (desc));
 
 		if (n < 0) {
 			info << string_compose (_("Komplete Kontrol A-Series: %1 is untested; "
 			                          "please report any misbehaviour."),
-			                        _variant->model)
+			                        _variant.model)
 			     << endmsg;
 		} else if ((size_t) n != KKA::ExpectedDescriptorSize) {
 			warning << string_compose (_("Komplete Kontrol A-Series: %1 reports a %2 byte HID "
 			                             "descriptor, expected %3. This model is untested and "
 			                             "controls may be misread. Please report this, with the "
 			                             "output of `lsusb -v -d %4`."),
-			                           _variant->model, n, KKA::ExpectedDescriptorSize, usbid)
+			                           _variant.model, n, KKA::ExpectedDescriptorSize, usbid)
 			        << endmsg;
 		} else {
 			info << string_compose (_("Komplete Kontrol A-Series: %1 is untested, but its HID "
 			                          "descriptor matches the A61. Proceeding."),
-			                        _variant->model)
+			                        _variant.model)
 			     << endmsg;
 		}
 	}
@@ -279,7 +281,6 @@ KompleteKontrolA::close_device (bool graceful)
 
 	hid_close (_handle);
 	_handle = 0;
-	_variant = 0;
 }
 
 /* Everything that has to happen against a device we have just opened, whether

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -66,6 +66,7 @@ KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s)
 {
 	memset (_knob_raw, 0, sizeof (_knob_raw));
 	memset (_knob_accum, 0, sizeof (_knob_accum));
+	memset (_payload_prev, 0, sizeof (_payload_prev));
 
 	if (hid_init ()) {
 		throw KompleteKontrolAException ("HIDAPI initialization failed");
@@ -254,6 +255,7 @@ KompleteKontrolA::start ()
 	_encoder_pos = 0;
 	memset (_knob_raw, 0, sizeof (_knob_raw));
 	memset (_knob_accum, 0, sizeof (_knob_accum));
+	memset (_payload_prev, 0, sizeof (_payload_prev));
 
 	Glib::RefPtr<Glib::TimeoutSource> read_timeout = Glib::TimeoutSource::create (read_interval_ms);
 	_read_connection = read_timeout->connect (sigc::mem_fun (*this, &KompleteKontrolA::dev_read));
@@ -404,6 +406,23 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 		return;
 	}
 
+	/* The whole payload, so that a session at the hardware can settle what
+	 * this decode does not explain -- payload[28] above all, a constant 36 in
+	 * every capture so far, and the field free-m32 calls "keyshift" on the
+	 * M32.  Guarded rather than merely gated: this runs on a 1ms poll, and
+	 * formatting 29 bytes we then throw away would not be free.
+	 */
+	if (DEBUG_ENABLED (DEBUG::KompleteKontrolA)) {
+		std::string hex;
+		for (size_t i = 0; i < KKA::InputPayloadSize; ++i) {
+			char b[4];
+			snprintf (b, sizeof (b), "%02x ", p[i]);
+			hex += b;
+		}
+		DEBUG_TRACE (DEBUG::KompleteKontrolA,
+		             string_compose ("KKA raw %1%2\n", hex, _seeded ? "" : "(seed, not dispatched)"));
+	}
+
 	uint64_t buttons = 0;
 	for (size_t i = 0; i < KKA::ButtonsBytes; ++i) {
 		buttons |= (uint64_t) p[KKA::ButtonsOffset + i] << (8 * i);
@@ -421,6 +440,7 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 		_buttons = buttons;
 		memcpy (_knob_raw, knobs, sizeof (_knob_raw));
 		_encoder_pos = encoder;
+		memcpy (_payload_prev, p, KKA::InputPayloadSize);
 		_seeded = true;
 		return;
 	}
@@ -429,8 +449,17 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 	_buttons = buttons;
 
 	/* Declared bits 34..39 are padding on this hardware and are deliberately
-	 * not dispatched.
+	 * not dispatched.  Say so loudly if they ever move: that would mean a
+	 * control exists which the map does not know about.
 	 */
+	uint64_t undeclared = changed >> KKA::NumControls;
+	if (undeclared) {
+		char b[32];
+		snprintf (b, sizeof (b), "0x%llx", (unsigned long long) undeclared);
+		DEBUG_TRACE (DEBUG::KompleteKontrolA,
+		             string_compose ("KKA *** bits 34..39 changed (%1) -- the map is incomplete\n", b));
+	}
+
 	for (int b = 0; b < KKA::NumControls; ++b) {
 		if (changed & (1ULL << b)) {
 			handle_button ((KKA::ControlID) b, (buttons >> b) & 1);
@@ -464,6 +493,22 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 	if (ed) {
 		handle_encoder (ed);
 	}
+
+	/* Everything from the end of the knob block onwards: the analog fields
+	 * that read constant zero on this unit, the encoder byte, and payload[28].
+	 * Only the encoder's low nibble means anything to us, so any other
+	 * movement here is a fact the map does not yet account for -- report it
+	 * instead of dropping it on the floor.
+	 */
+	for (size_t i = KKA::KnobsOffset + 2 * KKA::NumKnobs; i < KKA::InputPayloadSize; ++i) {
+		if (p[i] != _payload_prev[i]) {
+			DEBUG_TRACE (DEBUG::KompleteKontrolA,
+			             string_compose ("KKA payload[%1] %2 -> %3\n",
+			                             i, (int) _payload_prev[i], (int) p[i]));
+		}
+	}
+
+	memcpy (_payload_prev, p, KKA::InputPayloadSize);
 }
 
 /* Phase 2 stops here: decode and trace. Phase 3 binds these to Ardour. */

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -759,17 +759,17 @@ KompleteKontrolA::refresh_transport_leds ()
 
 	bool rolling = session->transport_rolling ();
 
-	set_led (KKA::Play, rolling ? KKA::LEDOn : KKA::LEDOff);
-	set_led (KKA::Stop, rolling ? KKA::LEDOff : KKA::LEDOn);
-	set_led (KKA::Loop, session->get_play_loop () ? KKA::LEDOn : KKA::LEDOff);
-	set_led (KKA::Metro, Config->get_clicking () ? KKA::LEDOn : KKA::LEDOff);
+	set_led (KKA::Play, rolling ? KKA::LEDBright : KKA::LEDOff);
+	set_led (KKA::Stop, rolling ? KKA::LEDOff : KKA::LEDBright);
+	set_led (KKA::Loop, session->get_play_loop () ? KKA::LEDBright : KKA::LEDOff);
+	set_led (KKA::Metro, Config->get_clicking () ? KKA::LEDBright : KKA::LEDOff);
 
 	/* Armed and actually capturing are different states and the panel has the
 	 * range to say so. LEDDim is also the probe for open question 1 -- see
 	 * kka_protocol.h.
 	 */
 	if (session->actively_recording ()) {
-		set_led (KKA::Rec, KKA::LEDOn);
+		set_led (KKA::Rec, KKA::LEDBright);
 	} else if (session->record_status () != ARDOUR::Disabled) {
 		set_led (KKA::Rec, KKA::LEDDim);
 	} else {

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -43,6 +43,13 @@ using namespace ArdourSurface;
  */
 static const unsigned int read_interval_ms = 1;
 
+/* Reconnect polling, used only while the device is absent.  hid_enumerate()
+ * walks every hidraw node in sysfs and reads a file per node, so this must not
+ * run anywhere near the read poll's rate.  A second is imperceptible to
+ * somebody who has just pushed a plug in.
+ */
+static const unsigned int reconnect_interval_ms = 1000;
+
 bool
 KompleteKontrolA::available ()
 {
@@ -62,7 +69,6 @@ KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s)
 	, _buttons (0)
 	, _encoder_pos (0)
 	, _warned_short_report (false)
-	, _warned_read_error (false)
 {
 	memset (_knob_raw, 0, sizeof (_knob_raw));
 	memset (_knob_accum, 0, sizeof (_knob_accum));
@@ -131,7 +137,7 @@ KompleteKontrolA::set_state (const XMLNode& node, int version)
 /* ------------------------------------------------------------------------ */
 
 int
-KompleteKontrolA::open_device ()
+KompleteKontrolA::open_device (bool quiet_if_absent)
 {
 	/* Deliberately not hid_open (vid, pid, NULL).  To filter by ids, hidapi's
 	 * Linux backend re-reads each candidate's sysfs uevent with
@@ -163,7 +169,13 @@ KompleteKontrolA::open_device ()
 	hid_free_enumeration (devs);
 
 	if (!_handle) {
-		error << _("Komplete Kontrol A-Series: no device found") << endmsg;
+		/* Silent when polling for a replug: the whole point of that loop is
+		 * that the device is expected to be absent, most of the time, for as
+		 * long as the user leaves it unplugged.
+		 */
+		if (!quiet_if_absent) {
+			error << _("Komplete Kontrol A-Series: no device found") << endmsg;
+		}
 		return -1;
 	}
 
@@ -204,12 +216,20 @@ KompleteKontrolA::open_device ()
 		}
 	}
 
+	/* Load-bearing for hotplug, not just for latency. This does not set
+	 * O_NONBLOCK; it makes hid_read() run hid_read_timeout() with a zero
+	 * timeout, which polls first and returns -1 when revents carries
+	 * POLLERR/POLLHUP/POLLNVAL. That is how a disconnect is detected -- and
+	 * hidapi works that way precisely because some kernels will not report
+	 * disconnection through a bare non-blocking read(). Drop this call and
+	 * reads would block the event loop forever instead.
+	 */
 	hid_set_nonblocking (_handle, 1);
 	return 0;
 }
 
 void
-KompleteKontrolA::close_device ()
+KompleteKontrolA::close_device (bool graceful)
 {
 	if (!_handle) {
 		return;
@@ -219,57 +239,131 @@ KompleteKontrolA::close_device ()
 	 * panel and never resumes -- not even on a switch back to MIDI mode. So
 	 * leaving without blanking strands the user's last frame on the screen
 	 * until they replug.
+	 *
+	 * Skipped when the device has vanished, where none of these writes can
+	 * land anyway and there is nothing to be polite to: a replugged device
+	 * comes back power-on clean, in MIDI mode, with the firmware drawing its
+	 * own panel again.
 	 */
-	clear_leds ();
-	blank_display ();
-	set_device_mode (KKA::ModeMIDI);
+	if (graceful) {
+		clear_leds ();
+		blank_display ();
+		set_device_mode (KKA::ModeMIDI);
+	}
 
 	hid_close (_handle);
 	_handle = 0;
 	_variant = 0;
 }
 
+/* Everything that has to happen against a device we have just opened, whether
+ * at startup or after a replug.  Interactive mode does not survive a power
+ * cycle, so a returning device is back in MIDI mode -- sending CC 14-21 at
+ * whatever the user has armed -- and has to be taken over from scratch.
+ */
 int
-KompleteKontrolA::start ()
+KompleteKontrolA::take_over_device ()
 {
-	if (open_device ()) {
-		return -1;
-	}
-
-	/* Interactive mode takes the knobs off the MIDI port and hands us the
-	 * display. It does not survive a replug, so a user who reconnects
-	 * mid-session silently gets a device sending CC 14-21 at their tracks
-	 * again; re-asserting on hotplug is Phase 3 work.
-	 */
 	if (set_device_mode (KKA::ModeInteractive)) {
-		error << _("Komplete Kontrol A-Series: failed to enter interactive mode") << endmsg;
-		close_device ();
 		return -1;
 	}
 
 	clear_leds ();
 	blank_display ();
 
+	/* A returning device is a different device as far as this state is
+	 * concerned: its knob counters start wherever they start.
+	 */
 	_seeded = false;
 	_buttons = 0;
 	_encoder_pos = 0;
 	memset (_knob_raw, 0, sizeof (_knob_raw));
 	memset (_knob_accum, 0, sizeof (_knob_accum));
 	memset (_payload_prev, 0, sizeof (_payload_prev));
+	_warned_short_report = false;
 
-	Glib::RefPtr<Glib::TimeoutSource> read_timeout = Glib::TimeoutSource::create (read_interval_ms);
-	_read_connection = read_timeout->connect (sigc::mem_fun (*this, &KompleteKontrolA::dev_read));
-	read_timeout->attach (main_loop ()->get_context ());
+	return 0;
+}
 
+void
+KompleteKontrolA::device_vanished ()
+{
+	info << _("Komplete Kontrol A-Series: device disconnected, watching for its return")
+	     << endmsg;
+
+	close_device (false);
+	start_reconnect_poll ();
+}
+
+void
+KompleteKontrolA::start_read_poll ()
+{
+	Glib::RefPtr<Glib::TimeoutSource> t = Glib::TimeoutSource::create (read_interval_ms);
+	_read_connection = t->connect (sigc::mem_fun (*this, &KompleteKontrolA::dev_read));
+	t->attach (main_loop ()->get_context ());
+}
+
+void
+KompleteKontrolA::start_reconnect_poll ()
+{
+	Glib::RefPtr<Glib::TimeoutSource> t = Glib::TimeoutSource::create (reconnect_interval_ms);
+	_reconnect_connection = t->connect (sigc::mem_fun (*this, &KompleteKontrolA::dev_reconnect));
+	t->attach (main_loop ()->get_context ());
+}
+
+bool
+KompleteKontrolA::dev_reconnect ()
+{
+	if (open_device (true)) {
+		return true; /* still gone; keep watching */
+	}
+
+	if (take_over_device ()) {
+		/* Present but not yet talking to us -- udev may still be applying
+		 * permissions to the new node. Drop it and come back in a second
+		 * rather than holding a handle we cannot drive.
+		 */
+		close_device (false);
+		return true;
+	}
+
+	info << _("Komplete Kontrol A-Series: device reconnected, interactive mode re-asserted")
+	     << endmsg;
+
+	start_read_poll ();
+	return false; /* hand over to the read poll */
+}
+
+int
+KompleteKontrolA::start ()
+{
+	if (open_device (false)) {
+		return -1;
+	}
+
+	if (take_over_device ()) {
+		error << _("Komplete Kontrol A-Series: failed to enter interactive mode") << endmsg;
+		/* Nothing was taken over, so there is nothing to hand back; a
+		 * graceful close here would only add three more failing writes.
+		 */
+		close_device (false);
+		return -1;
+	}
+
+	start_read_poll ();
 	return 0;
 }
 
 int
 KompleteKontrolA::stop ()
 {
+	/* Whichever of the two is live -- disconnecting an already-finished
+	 * connection is a no-op, so there is no need to know which.
+	 */
 	_read_connection.disconnect ();
+	_reconnect_connection.disconnect ();
 
-	close_device ();
+	close_device (true);
 
 	BaseUI::quit ();
 	return 0;
@@ -370,12 +464,14 @@ KompleteKontrolA::dev_read ()
 		}
 
 		if (n < 0) {
-			if (!_warned_read_error) {
-				_warned_read_error = true;
-				error << _("Komplete Kontrol A-Series: HID read failed; was the device unplugged?")
-				      << endmsg;
-			}
-			break;
+			/* In non-blocking mode "nothing to read" is 0, so a negative
+			 * return is a real failure and in practice always means the
+			 * device is gone. Hand over to the reconnect poll rather than
+			 * hammering a dead handle every millisecond for the rest of the
+			 * session, which is what the previous warn-once-and-carry-on did.
+			 */
+			device_vanished ();
+			return false;
 		}
 
 		if (buf[0] != KKA::ReportInput) {

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -102,9 +102,15 @@ KompleteKontrolA::do_request (KompleteKontrolARequest* req)
 {
 	if (req->type == CallSlot) {
 		call_slot (MISSING_INVALIDATOR, req->the_slot);
-	} else if (req->type == Quit) {
-		stop ();
 	}
+
+	/* No Quit case, deliberately, though every other surface carries one.
+	 * Nothing in the tree ever posts such a request -- BaseUI::Quit is only
+	 * ever compared against, never assigned -- so the branch is dead in all of
+	 * them. Here it would be worse than dead: it is the only way stop() could
+	 * be reached on this surface's own thread, and stop() joins that thread.
+	 * Omitting it keeps "stop() runs on the GUI thread" true by construction.
+	 */
 }
 
 int
@@ -409,6 +415,19 @@ KompleteKontrolA::blink ()
 int
 KompleteKontrolA::stop ()
 {
+	/* First, because it ends the surface's event loop and *joins* its thread.
+	 * Everything below then runs with no other thread left to race against.
+	 *
+	 * That ordering is the whole point. The three timeouts are attached to
+	 * this surface's own main context, so their callbacks run on that thread,
+	 * while stop() is reached from the GUI thread -- and sigc::connection has
+	 * no internal locking, so disconnecting one whose callback is executing is
+	 * a race that no amount of care around _handle would fix. Removing the
+	 * other thread is simpler and stronger than trying to lock against it.
+	 * push2 tears down in this order for the same reason.
+	 */
+	BaseUI::quit ();
+
 	/* Whichever of the two is live -- disconnecting an already-finished
 	 * connection is a no-op, so there is no need to know which.
 	 */
@@ -416,14 +435,16 @@ KompleteKontrolA::stop ()
 	_reconnect_connection.disconnect ();
 	_blink_connection.disconnect ();
 
-	/* Before the device goes, so nothing can arrive mid-teardown and try to
-	 * light a lamp on a handle that is being closed.
+	/* These were never part of that race: PBD's signals take their own lock
+	 * and ScopedConnectionList guards its list, which is why they could be
+	 * dropped from either thread. They come down here with everything else.
 	 */
 	_session_connections.drop_connections ();
 
+	/* Last, so the goodbye writes cannot collide with a blink or a read that
+	 * is still in flight -- by now neither can be.
+	 */
 	close_device (true);
-
-	BaseUI::quit ();
 	return 0;
 }
 

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -132,13 +132,34 @@ KompleteKontrolA::set_state (const XMLNode& node, int version)
 int
 KompleteKontrolA::open_device ()
 {
-	for (size_t i = 0; i < KKA::NumVariants; ++i) {
-		_handle = hid_open (KKA::VendorID, KKA::Variants[i].pid, NULL);
-		if (_handle) {
-			_variant = &KKA::Variants[i];
-			break;
+	/* Deliberately not hid_open (vid, pid, NULL).  To filter by ids, hidapi's
+	 * Linux backend re-reads each candidate's sysfs uevent with
+	 *
+	 *	open (path, O_RDONLY | FD_CLOEXEC)
+	 *
+	 * but FD_CLOEXEC is a descriptor flag rather than an open() flag, and its
+	 * value is 1 -- which is O_WRONLY.  Opening a root-owned sysfs attribute
+	 * write-only is refused for any ordinary user, so the parse fails and the
+	 * device is skipped without comment.  Every device is skipped, so
+	 * hid_open() by ids cannot match at all unless we are root.  Unfiltered
+	 * enumeration never takes that path, so matching the ids here and opening
+	 * by path is both a fix and cheaper than the call it replaces.
+	 */
+	struct hid_device_info* devs = hid_enumerate (0x0, 0x0);
+
+	for (size_t i = 0; i < KKA::NumVariants && !_handle; ++i) {
+		for (struct hid_device_info* d = devs; d; d = d->next) {
+			if (d->vendor_id != KKA::VendorID || d->product_id != KKA::Variants[i].pid) {
+				continue;
+			}
+			if ((_handle = hid_open_path (d->path)) != 0) {
+				_variant = &KKA::Variants[i];
+				break;
+			}
 		}
 	}
+
+	hid_free_enumeration (devs);
 
 	if (!_handle) {
 		error << _("Komplete Kontrol A-Series: no device found") << endmsg;

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -420,7 +420,8 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 			hex += b;
 		}
 		DEBUG_TRACE (DEBUG::KompleteKontrolA,
-		             string_compose ("KKA raw %1%2\n", hex, _seeded ? "" : "(seed, not dispatched)"));
+		             string_compose ("KKA raw %1%2\n", hex,
+		                             _seeded ? "" : "(first report -- analog baseline)"));
 	}
 
 	uint64_t buttons = 0;
@@ -436,13 +437,24 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 
 	uint8_t encoder = p[KKA::EncoderOffset] & 0x0f;
 
+	/* The knobs and the 4-D encoder are wrapping counters, so a delta against
+	 * them means nothing until there is a baseline; take it from the first
+	 * report.
+	 *
+	 * Buttons are not like that, and seeding them was a mistake.  They are
+	 * absolute, and the device reports only on change -- so it stays silent
+	 * until the user does something, and the first report to arrive after
+	 * start() is already a user action rather than a resting state.  Seeding
+	 * buttons from it therefore swallows that action every time: the first
+	 * hardware trace ate a Shift press and reported only the release.
+	 * "Nothing is held" is the correct opening assumption, and it is the safe
+	 * one, so buttons dispatch from the very first report.
+	 */
 	if (!_seeded) {
-		_buttons = buttons;
 		memcpy (_knob_raw, knobs, sizeof (_knob_raw));
 		_encoder_pos = encoder;
 		memcpy (_payload_prev, p, KKA::InputPayloadSize);
 		_seeded = true;
-		return;
 	}
 
 	uint64_t changed = buttons ^ _buttons;

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -50,6 +50,14 @@ static const unsigned int read_interval_ms = 1;
  */
 static const unsigned int reconnect_interval_ms = 1000;
 
+/* The panel has three states and Rec has three meanings, but two of them --
+ * armed, and actually capturing -- are the pair a player most needs to tell
+ * apart. Blinking the armed one is how Ardour's own transport solves this.
+ * The timer runs whenever the surface does: when nothing is armed the toggle
+ * changes no lamp, refresh finds nothing dirty, and no report is written.
+ */
+static const unsigned int blink_interval_ms = 200;
+
 bool
 KompleteKontrolA::available ()
 {
@@ -65,6 +73,7 @@ KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s)
 	, AbstractUI<KompleteKontrolARequest> (name ())
 	, _handle (0)
 	, _variant (0)
+	, _blink_on (false)
 	, _seeded (false)
 	, _buttons (0)
 	, _encoder_pos (0)
@@ -375,8 +384,24 @@ KompleteKontrolA::start ()
 	connect_session_signals ();
 	refresh_transport_leds ();
 
+	/* Attached here rather than in start_read_poll(), which reconnection calls
+	 * again -- the blink belongs to the surface being active, not to the
+	 * device being present, and a second copy would fight the first.
+	 */
+	Glib::RefPtr<Glib::TimeoutSource> b = Glib::TimeoutSource::create (blink_interval_ms);
+	_blink_connection = b->connect (sigc::mem_fun (*this, &KompleteKontrolA::blink));
+	b->attach (main_loop ()->get_context ());
+
 	start_read_poll ();
 	return 0;
+}
+
+bool
+KompleteKontrolA::blink ()
+{
+	_blink_on = !_blink_on;
+	refresh_transport_leds ();
+	return true;
 }
 
 int
@@ -387,6 +412,7 @@ KompleteKontrolA::stop ()
 	 */
 	_read_connection.disconnect ();
 	_reconnect_connection.disconnect ();
+	_blink_connection.disconnect ();
 
 	/* Before the device goes, so nothing can arrive mid-teardown and try to
 	 * light a lamp on a handle that is being closed.
@@ -759,21 +785,28 @@ KompleteKontrolA::refresh_transport_leds ()
 
 	bool rolling = session->transport_rolling ();
 
-	set_led (KKA::Play, rolling ? KKA::LEDBright : KKA::LEDOff);
-	set_led (KKA::Stop, rolling ? KKA::LEDOff : KKA::LEDBright);
-	set_led (KKA::Loop, session->get_play_loop () ? KKA::LEDBright : KKA::LEDOff);
-	set_led (KKA::Metro, Config->get_clicking () ? KKA::LEDBright : KKA::LEDOff);
+	/* Dim when idle rather than dark, because it is the legend that the LED
+	 * lights: an unlit button is not a button with its lamp off, it is a black
+	 * rectangle you cannot read in a dim room. Dark is therefore reserved to
+	 * mean "this button does nothing", which is honest while most of the panel
+	 * is still unbound, and stops the surface claiming more than it does.
+	 */
+	set_led (KKA::Play,  rolling ? KKA::LEDBright : KKA::LEDDim);
+	set_led (KKA::Stop,  rolling ? KKA::LEDDim : KKA::LEDBright);
+	set_led (KKA::Loop,  session->get_play_loop () ? KKA::LEDBright : KKA::LEDDim);
+	set_led (KKA::Metro, Config->get_clicking () ? KKA::LEDBright : KKA::LEDDim);
 
-	/* Armed and actually capturing are different states and the panel has the
-	 * range to say so. LEDDim is also the probe for open question 1 -- see
-	 * kka_protocol.h.
+	/* Rec has three states and the panel only has two brightnesses, so armed
+	 * blinks. Solid bright is capturing; a blinking lamp cannot be mistaken
+	 * for it at a glance, which is the distinction that actually matters when
+	 * the transport is about to roll.
 	 */
 	if (session->actively_recording ()) {
 		set_led (KKA::Rec, KKA::LEDBright);
 	} else if (session->record_status () != ARDOUR::Disabled) {
-		set_led (KKA::Rec, KKA::LEDDim);
+		set_led (KKA::Rec, _blink_on ? KKA::LEDBright : KKA::LEDDim);
 	} else {
-		set_led (KKA::Rec, KKA::LEDOff);
+		set_led (KKA::Rec, KKA::LEDDim);
 	}
 
 	flush_leds ();

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.cc
@@ -69,10 +69,12 @@ KompleteKontrolA::KompleteKontrolA (ARDOUR::Session& s)
 	, _buttons (0)
 	, _encoder_pos (0)
 	, _warned_short_report (false)
+	, _leds_dirty (false)
 {
 	memset (_knob_raw, 0, sizeof (_knob_raw));
 	memset (_knob_accum, 0, sizeof (_knob_accum));
 	memset (_payload_prev, 0, sizeof (_payload_prev));
+	memset (_led, KKA::LEDOff, sizeof (_led));
 
 	if (hid_init ()) {
 		throw KompleteKontrolAException ("HIDAPI initialization failed");
@@ -152,6 +154,8 @@ KompleteKontrolA::open_device (bool quiet_if_absent)
 	 * enumeration never takes that path, so matching the ids here and opening
 	 * by path is both a fix and cheaper than the call it replaces.
 	 */
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+
 	struct hid_device_info* devs = hid_enumerate (0x0, 0x0);
 
 	for (size_t i = 0; i < KKA::NumVariants && !_handle; ++i) {
@@ -231,8 +235,15 @@ KompleteKontrolA::open_device (bool quiet_if_absent)
 void
 KompleteKontrolA::close_device (bool graceful)
 {
-	if (!_handle) {
-		return;
+	/* The goodbye writes take the lock individually, so it cannot be held
+	 * across them; taking it only for the close itself is enough, because
+	 * every other path rechecks _handle under it.
+	 */
+	{
+		Glib::Threads::Mutex::Lock lm (_device_mutex);
+		if (!_handle) {
+			return;
+		}
 	}
 
 	/* Once interactive mode has been entered the firmware stops drawing the
@@ -249,6 +260,12 @@ KompleteKontrolA::close_device (bool graceful)
 		clear_leds ();
 		blank_display ();
 		set_device_mode (KKA::ModeMIDI);
+	}
+
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+
+	if (!_handle) {
+		return; /* raced with another close */
 	}
 
 	hid_close (_handle);
@@ -270,6 +287,11 @@ KompleteKontrolA::take_over_device ()
 
 	clear_leds ();
 	blank_display ();
+
+	/* Whatever the transport was doing while the device was away, the panel
+	 * now has to agree with it.
+	 */
+	refresh_transport_leds ();
 
 	/* A returning device is a different device as far as this state is
 	 * concerned: its knob counters start wherever they start.
@@ -350,6 +372,9 @@ KompleteKontrolA::start ()
 		return -1;
 	}
 
+	connect_session_signals ();
+	refresh_transport_leds ();
+
 	start_read_poll ();
 	return 0;
 }
@@ -362,6 +387,11 @@ KompleteKontrolA::stop ()
 	 */
 	_read_connection.disconnect ();
 	_reconnect_connection.disconnect ();
+
+	/* Before the device goes, so nothing can arrive mid-teardown and try to
+	 * light a lamp on a handle that is being closed.
+	 */
+	_session_connections.drop_connections ();
 
 	close_device (true);
 
@@ -382,6 +412,8 @@ KompleteKontrolA::thread_init ()
 int
 KompleteKontrolA::set_device_mode (const uint8_t mode[2])
 {
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+
 	if (!_handle) {
 		return -1;
 	}
@@ -390,23 +422,70 @@ KompleteKontrolA::set_device_mode (const uint8_t mode[2])
 	return hid_write (_handle, buf, sizeof (buf)) < 0 ? -1 : 0;
 }
 
-int
-KompleteKontrolA::clear_leds ()
+void
+KompleteKontrolA::set_led (KKA::ControlID c, uint8_t brightness)
 {
+	if (!KKA::control_has_led (c)) {
+		return;
+	}
+
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+
+	if (_led[c] != brightness) {
+		_led[c] = brightness;
+		_leds_dirty = true;
+	}
+}
+
+int
+KompleteKontrolA::flush_leds ()
+{
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+	return flush_leds_locked ();
+}
+
+int
+KompleteKontrolA::flush_leds_locked ()
+{
+	if (!_leds_dirty) {
+		return 0;
+	}
+
 	if (!_handle) {
 		return -1;
 	}
 
+	/* All 21 go out together -- there is no partial LED write -- so a single
+	 * changed lamp costs the same 22 bytes as all of them.
+	 */
 	uint8_t buf[KKA::LEDReportSize];
-	memset (buf, KKA::LEDOff, sizeof (buf));
 	buf[0] = KKA::ReportLEDs;
+	memcpy (buf + 1, _led, KKA::LEDCount);
 
-	return hid_write (_handle, buf, sizeof (buf)) < 0 ? -1 : 0;
+	if (hid_write (_handle, buf, sizeof (buf)) < 0) {
+		return -1;
+	}
+
+	_leds_dirty = false;
+	return 0;
+}
+
+int
+KompleteKontrolA::clear_leds ()
+{
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+
+	memset (_led, KKA::LEDOff, sizeof (_led));
+	_leds_dirty = true;
+
+	return flush_leds_locked ();
 }
 
 int
 KompleteKontrolA::blank_display ()
 {
+	Glib::Threads::Mutex::Lock lm (_device_mutex);
+
 	if (!_handle) {
 		return -1;
 	}
@@ -446,10 +525,6 @@ KompleteKontrolA::blank_display ()
 bool
 KompleteKontrolA::dev_read ()
 {
-	if (!_handle) {
-		return false;
-	}
-
 	uint8_t buf[KKA::InputReportSize];
 
 	/* Reports are emitted on change only, but a fast knob spin coalesces
@@ -457,7 +532,21 @@ KompleteKontrolA::dev_read ()
 	 * The bound is a safety valve against a device that never goes quiet.
 	 */
 	for (int i = 0; i < 32; ++i) {
-		int n = hid_read (_handle, buf, sizeof (buf));
+		int n;
+
+		{
+			/* Held across the read alone. decode() reaches into Ardour from
+			 * here, and holding a device lock across that is how a deadlock
+			 * gets invented later.
+			 */
+			Glib::Threads::Mutex::Lock lm (_device_mutex);
+
+			if (!_handle) {
+				return false;
+			}
+
+			n = hid_read (_handle, buf, sizeof (buf));
+		}
 
 		if (n == 0) {
 			break;
@@ -619,7 +708,76 @@ KompleteKontrolA::decode (const uint8_t* p, size_t len)
 	memcpy (_payload_prev, p, KKA::InputPayloadSize);
 }
 
-/* Phase 2 stops here: decode and trace. Phase 3 binds these to Ardour. */
+/* ------------------------------------------------------- Ardour bindings */
+
+void
+KompleteKontrolA::connect_session_signals ()
+{
+	if (!session) {
+		return;
+	}
+
+	/* The trailing `this` is the PBD::EventLoop these are delivered on. We are
+	 * an AbstractUI, so passing ourselves marshals every callback onto this
+	 * surface's own thread -- the same thread as the read poll. That is what
+	 * makes it safe for these handlers to write to the device directly.
+	 */
+	session->TransportStateChange.connect (_session_connections, MISSING_INVALIDATOR,
+	                                       std::bind (&KompleteKontrolA::transport_state_changed, this), this);
+	session->RecordStateChanged.connect (_session_connections, MISSING_INVALIDATOR,
+	                                     std::bind (&KompleteKontrolA::transport_state_changed, this), this);
+	session->TransportLooped.connect (_session_connections, MISSING_INVALIDATOR,
+	                                  std::bind (&KompleteKontrolA::transport_state_changed, this), this);
+
+	/* The metronome is a global config item rather than session transport
+	 * state, so it arrives by a different road.
+	 */
+	Config->ParameterChanged.connect (_session_connections, MISSING_INVALIDATOR,
+	                                  std::bind (&KompleteKontrolA::parameter_changed, this, _1), this);
+}
+
+void
+KompleteKontrolA::transport_state_changed ()
+{
+	refresh_transport_leds ();
+}
+
+void
+KompleteKontrolA::parameter_changed (std::string p)
+{
+	if (p == "clicking") {
+		refresh_transport_leds ();
+	}
+}
+
+void
+KompleteKontrolA::refresh_transport_leds ()
+{
+	if (!session) {
+		return;
+	}
+
+	bool rolling = session->transport_rolling ();
+
+	set_led (KKA::Play, rolling ? KKA::LEDOn : KKA::LEDOff);
+	set_led (KKA::Stop, rolling ? KKA::LEDOff : KKA::LEDOn);
+	set_led (KKA::Loop, session->get_play_loop () ? KKA::LEDOn : KKA::LEDOff);
+	set_led (KKA::Metro, Config->get_clicking () ? KKA::LEDOn : KKA::LEDOff);
+
+	/* Armed and actually capturing are different states and the panel has the
+	 * range to say so. LEDDim is also the probe for open question 1 -- see
+	 * kka_protocol.h.
+	 */
+	if (session->actively_recording ()) {
+		set_led (KKA::Rec, KKA::LEDOn);
+	} else if (session->record_status () != ARDOUR::Disabled) {
+		set_led (KKA::Rec, KKA::LEDDim);
+	} else {
+		set_led (KKA::Rec, KKA::LEDOff);
+	}
+
+	flush_leds ();
+}
 
 void
 KompleteKontrolA::handle_button (KKA::ControlID c, bool pressed)
@@ -628,6 +786,43 @@ KompleteKontrolA::handle_button (KKA::ControlID c, bool pressed)
 	             string_compose ("KKA button %1 (bit %2) %3\n",
 	                             KKA::control_name (c), (int) c,
 	                             pressed ? "pressed" : "released"));
+
+	/* Act on press. Release matters only for controls used as modifiers, and
+	 * none of the transport buttons are.
+	 */
+	if (!pressed) {
+		return;
+	}
+
+	/* These go straight through BasicUI, which reaches the session by its
+	 * request queue rather than by touching transport state here, so calling
+	 * them from this thread is correct. The LEDs are not updated here either:
+	 * the session tells us what actually happened, and a button that lit
+	 * because it was pressed rather than because the transport moved would be
+	 * lying whenever the request was refused.
+	 */
+	switch (c) {
+	case KKA::Play:
+		/* Same behaviour as the spacebar, which is what a player expects; the
+		 * comment on transport_play() says toggle_roll is preferred.
+		 */
+		toggle_roll (false, true);
+		break;
+	case KKA::Stop:
+		transport_stop ();
+		break;
+	case KKA::Rec:
+		rec_enable_toggle ();
+		break;
+	case KKA::Loop:
+		loop_toggle ();
+		break;
+	case KKA::Metro:
+		toggle_click ();
+		break;
+	default:
+		break;
+	}
 }
 
 void

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -1,5 +1,4 @@
 /*
- * Copyright (C) 2026 Ada <ada@6bit.com>
  * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
  *
  * This program is free software; you can redistribute it and/or modify

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -66,7 +66,7 @@ public:
 class KompleteKontrolA : public ARDOUR::ControlProtocol, public AbstractUI<KompleteKontrolARequest>
 {
 public:
-	KompleteKontrolA (ARDOUR::Session&);
+	KompleteKontrolA (ARDOUR::Session&, const KKA::Variant& variant);
 	~KompleteKontrolA ();
 
 	static bool available ();
@@ -124,8 +124,16 @@ private:
 	void handle_knob (int knob, int steps);
 	void handle_encoder (int steps);
 
-	hid_device*         _handle;
-	const KKA::Variant* _variant;
+	hid_device* _handle;
+
+	/* The model the user ticked in the surface list, resolved before the
+	 * surface was constructed and fixed for its lifetime.  Only this model is
+	 * ever opened: a user who selected an A25 has told us which device they
+	 * have, and silently driving an A61 instead makes the selection a lie.
+	 * Unlike _handle it survives a replug, because which keyboard is
+	 * configured does not change when the cable is pulled.
+	 */
+	const KKA::Variant& _variant;
 
 	/* Exactly one of these is live at a time: the fast input poll while the
 	 * device is present, the slow reconnect poll while it is not.  Each hands

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -100,8 +100,8 @@ private:
 
 	/* Phase 3 binds these; for now they trace. */
 	void handle_button (KKA::ControlID, bool pressed);
-	void handle_knob (int knob, int detents);
-	void handle_encoder (int detents);
+	void handle_knob (int knob, int steps);
+	void handle_encoder (int steps);
 
 	hid_device*         _handle;
 	const KKA::Variant* _variant;

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 Ada <ada@6bit.com>
+ * Copyright (C) 2026 Joshua Perry <josh@6bit.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef _ardour_surfaces_komplete_kontrol_a_h_
+#define _ardour_surfaces_komplete_kontrol_a_h_
+
+#ifdef PLATFORM_WINDOWS
+#include <windows.h>
+#endif
+
+#include <exception>
+#include <string>
+
+#include <hidapi.h>
+
+#define ABSTRACT_UI_EXPORTS
+#include "pbd/abstract_ui.h"
+
+#include "ardour/types.h"
+#include "control_protocol/control_protocol.h"
+
+#include "kka_protocol.h"
+
+namespace ArdourSurface {
+
+class KompleteKontrolAException : public std::exception
+{
+public:
+	KompleteKontrolAException (const std::string& msg) : _msg (msg) {}
+	virtual ~KompleteKontrolAException () throw () {}
+	const char* what () const throw () { return _msg.c_str (); }
+
+private:
+	std::string _msg;
+};
+
+struct KompleteKontrolARequest : public BaseUI::BaseRequestObject {
+public:
+	KompleteKontrolARequest () {}
+	~KompleteKontrolARequest () {}
+};
+
+/* One class for the A25, A49 and A61.  They are the same device with three
+ * keybeds, and the keybed is not ours -- it leaves over the device's own MIDI
+ * port -- so the only per-model state is a name and a key count.  See
+ * KKA::Variants in kka_protocol.cc.
+ */
+class KompleteKontrolA : public ARDOUR::ControlProtocol, public AbstractUI<KompleteKontrolARequest>
+{
+public:
+	KompleteKontrolA (ARDOUR::Session&);
+	~KompleteKontrolA ();
+
+	static bool available ();
+
+	int set_active (bool yn);
+
+	XMLNode& get_state () const;
+	int      set_state (const XMLNode&, int version);
+
+	CONTROL_PROTOCOL_THREADS_NEED_TEMPO_MAP_DECL();
+
+private:
+	void do_request (KompleteKontrolARequest*);
+	void stripable_selection_changed () {}
+
+	int start ();
+	int stop ();
+
+	void thread_init ();
+
+	/* device lifecycle */
+	int  open_device ();
+	void close_device ();
+
+	/* output paths */
+	int set_device_mode (const uint8_t mode[2]);
+	int clear_leds ();
+	int blank_display ();
+
+	/* input path */
+	bool dev_read ();
+	void decode (const uint8_t* payload, size_t len);
+
+	/* Phase 3 binds these; for now they trace. */
+	void handle_button (KKA::ControlID, bool pressed);
+	void handle_knob (int knob, int detents);
+	void handle_encoder (int detents);
+
+	hid_device*         _handle;
+	const KKA::Variant* _variant;
+	sigc::connection    _read_connection;
+
+	/* Input state.  The first report seeds it without emitting events: the
+	 * device reports on change only, so whatever position it happens to be
+	 * sitting in must not read as a burst of user input at startup.
+	 */
+	bool     _seeded;
+	uint64_t _buttons;
+	uint16_t _knob_raw[KKA::NumKnobs];
+	int      _knob_accum[KKA::NumKnobs];
+	uint8_t  _encoder_pos;
+
+	bool _warned_short_report;
+	bool _warned_read_error;
+};
+
+} /* namespace ArdourSurface */
+
+#endif /* _ardour_surfaces_komplete_kontrol_a_h_ */

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -86,8 +86,10 @@ private:
 	void thread_init ();
 
 	/* device lifecycle */
-	int  open_device ();
-	void close_device ();
+	int  open_device (bool quiet_if_absent);
+	void close_device (bool graceful);
+	int  take_over_device ();
+	void device_vanished ();
 
 	/* output paths */
 	int set_device_mode (const uint8_t mode[2]);
@@ -96,6 +98,9 @@ private:
 
 	/* input path */
 	bool dev_read ();
+	bool dev_reconnect ();
+	void start_read_poll ();
+	void start_reconnect_poll ();
 	void decode (const uint8_t* payload, size_t len);
 
 	/* Phase 3 binds these; for now they trace. */
@@ -105,7 +110,14 @@ private:
 
 	hid_device*         _handle;
 	const KKA::Variant* _variant;
+
+	/* Exactly one of these is live at a time: the fast input poll while the
+	 * device is present, the slow reconnect poll while it is not.  Each hands
+	 * over by attaching the other and then returning false, so neither ever
+	 * disconnects the source it is running inside.
+	 */
 	sigc::connection    _read_connection;
+	sigc::connection    _reconnect_connection;
 
 	/* Input state.  _seeded covers the analog fields only -- the knobs and the
 	 * encoder are wrapping counters needing a baseline before a delta means
@@ -124,7 +136,6 @@ private:
 	uint8_t  _payload_prev[KKA::InputPayloadSize];
 
 	bool _warned_short_report;
-	bool _warned_read_error;
 };
 
 } /* namespace ArdourSurface */

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -114,6 +114,7 @@ private:
 	/* input path */
 	bool dev_read ();
 	bool dev_reconnect ();
+	bool blink ();
 	void start_read_poll ();
 	void start_reconnect_poll ();
 	void decode (const uint8_t* payload, size_t len);
@@ -133,6 +134,12 @@ private:
 	 */
 	sigc::connection    _read_connection;
 	sigc::connection    _reconnect_connection;
+
+	/* Belongs to the surface being active rather than to the device being
+	 * present, so unlike the two above it is attached once and stays.
+	 */
+	sigc::connection    _blink_connection;
+	bool                _blink_on;
 
 	/* Input state.  _seeded covers the analog fields only -- the knobs and the
 	 * encoder are wrapping counters needing a baseline before a delta means

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -27,6 +27,8 @@
 #include <exception>
 #include <string>
 
+#include <glibmm/threads.h>
+
 #include <hidapi.h>
 
 #define ABSTRACT_UI_EXPORTS
@@ -96,6 +98,19 @@ private:
 	int clear_leds ();
 	int blank_display ();
 
+	/* LEDs.  The report is all 21 at once, so callers set what they want and
+	 * flush once; flush_leds() writes only when something actually changed.
+	 */
+	void set_led (KKA::ControlID, uint8_t brightness);
+	int  flush_leds ();
+	int  flush_leds_locked (); /* caller holds _device_mutex */
+
+	/* Ardour bindings */
+	void connect_session_signals ();
+	void transport_state_changed ();
+	void parameter_changed (std::string);
+	void refresh_transport_leds ();
+
 	/* input path */
 	bool dev_read ();
 	bool dev_reconnect ();
@@ -136,6 +151,24 @@ private:
 	uint8_t  _payload_prev[KKA::InputPayloadSize];
 
 	bool _warned_short_report;
+
+	/* Session signals are connected with this surface as their event loop, so
+	 * they arrive on our thread rather than Ardour's -- which is what lets the
+	 * LED writes below share a thread with the read poll.
+	 */
+	PBD::ScopedConnectionList _session_connections;
+
+	/* Desired LED state, indexed by ControlID, which for 0..LEDCount-1 is also
+	 * the index in the LED report. No mapping table in either direction.
+	 */
+	uint8_t _led[KKA::LEDCount];
+	bool    _leds_dirty;
+
+	/* Guards _handle. Everything else touching the device runs on this
+	 * surface's event loop, but stop() arrives on Ardour's GUI thread and
+	 * closes the handle out from under it.
+	 */
+	Glib::Threads::Mutex _device_mutex;
 };
 
 } /* namespace ArdourSurface */

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -107,9 +107,10 @@ private:
 	const KKA::Variant* _variant;
 	sigc::connection    _read_connection;
 
-	/* Input state.  The first report seeds it without emitting events: the
-	 * device reports on change only, so whatever position it happens to be
-	 * sitting in must not read as a burst of user input at startup.
+	/* Input state.  _seeded covers the analog fields only -- the knobs and the
+	 * encoder are wrapping counters needing a baseline before a delta means
+	 * anything.  Buttons are absolute and are dispatched from the first report
+	 * onwards; see decode() for why seeding them was wrong.
 	 */
 	bool     _seeded;
 	uint64_t _buttons;

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -117,6 +117,11 @@ private:
 	int      _knob_accum[KKA::NumKnobs];
 	uint8_t  _encoder_pos;
 
+	/* Whole previous payload, so that movement in the bytes this decode does
+	 * not interpret is reported rather than discarded.  See decode().
+	 */
+	uint8_t  _payload_prev[KKA::InputPayloadSize];
+
 	bool _warned_short_report;
 	bool _warned_read_error;
 };

--- a/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
+++ b/libs/surfaces/komplete_kontrol_a/komplete_kontrol_a.h
@@ -178,9 +178,12 @@ private:
 	uint8_t _led[KKA::LEDCount];
 	bool    _leds_dirty;
 
-	/* Guards _handle. Everything else touching the device runs on this
-	 * surface's event loop, but stop() arrives on Ardour's GUI thread and
-	 * closes the handle out from under it.
+	/* Guards _handle and the LED state above it.  The device is driven from
+	 * this surface's event loop, but start() runs on Ardour's GUI thread and
+	 * connects the session signals partway through, so a transport change can
+	 * be lighting lamps on the surface thread while start() is still finishing
+	 * over here.  stop() is not a party to this: it joins the surface thread
+	 * before it touches anything.
 	 */
 	Glib::Threads::Mutex _device_mutex;
 };

--- a/libs/surfaces/komplete_kontrol_a/wscript
+++ b/libs/surfaces/komplete_kontrol_a/wscript
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import os
+
+def options(opt):
+    pass
+
+def configure(conf):
+    pass
+
+def build(bld):
+    obj = bld(features = 'cxx cxxshlib')
+    obj.source = '''
+            komplete_kontrol_a.cc
+            kka_protocol.cc
+            interface.cc
+    '''
+    obj.defines      = [ 'PACKAGE="ardour_komplete_kontrol_a"' ]
+    obj.defines     += [ 'ARDOURSURFACE_DLL_EXPORTS' ]
+    obj.includes     = [ '.' ]
+    obj.name         = 'libardour_komplete_kontrol_a'
+    obj.target       = 'ardour_komplete_kontrol_a'
+    obj.uselib       = 'XML OSX GLIBMM GIOMM'
+    obj.use          = 'libardour libardour_cp libpbd hidapi'
+    obj.install_path = os.path.join(bld.env['LIBDIR'], 'surfaces')

--- a/libs/surfaces/wscript
+++ b/libs/surfaces/wscript
@@ -41,6 +41,11 @@ def configure(conf):
     else:
         print ('You are missing the libusb-1.0 development package needed to compile Push2 and ContourDesign support')
 
+    if conf.is_defined('HAVE_HIDAPI'):
+        children += [ 'komplete_kontrol_a' ]
+    else:
+        print ('You are missing the hidapi dependency needed to compile Komplete Kontrol A-Series support')
+
     if conf.is_defined('HAVE_HIDAPI') and Options.options.maschine:
         children += [ 'maschine2' ]
         conf.define('BUILD_MASCHINE', 1)
@@ -87,6 +92,8 @@ def build(bld):
         bld.recurse('launchpad_pro')
         bld.recurse('launchpad_x')
         bld.recurse('launchkey_4')
+    if bld.is_defined('HAVE_HIDAPI'):
+        bld.recurse('komplete_kontrol_a')
     if bld.is_defined('BUILD_MASCHINE'):
         bld.recurse('maschine2')
     if bld.is_defined ('HAVE_WEBSOCKETS'):


### PR DESCRIPTION
**Protocol research, captures and probe tooling:** <https://github.com/nuketownada/ardourkomplete> — `docs/a61-hid-map.md` is the map every constant here derives from, and `tools/` holds the Python probes that measured it. `kka_protocol.h` points there too, so it stays findable from the tree rather than only from this description.

Draft, for feedback rather than merge. The surface works on real hardware but is deliberately incomplete, and I would rather learn now that the shape is wrong than after binding the rest of it.

## The hidapi commit is independent and I am happy to split it out

`hidapi: use O_CLOEXEC, not FD_CLOEXEC, in the Linux backend` has nothing to do with this surface and fixes something that affects **maschine2** equally. `libs/hidapi/linux/hid.c` passes `FD_CLOEXEC` to `open()` in three places. It is an `fcntl()` descriptor flag, not an `open()` flag, and its value is 1:

| line | written | actually means |
|---|---|---|
| 419 | `O_RDONLY \| FD_CLOEXEC` | `O_WRONLY` |
| 508 | `O_RDONLY \| FD_CLOEXEC` | `O_WRONLY` |
| 1066 | `O_RDWR \| FD_CLOEXEC` | access mode `3` |

Line 508 is how `hid_enumerate()` reads a candidate's ids in order to filter on them, so it fails for any non-root process and every candidate is skipped — `hid_open(vid, pid, ...)` cannot match anything. Line 1066 is worse because it looks like it works: access mode 3 yields a descriptor with neither `FMODE_READ` nor `FMODE_WRITE`, so `open()` succeeds and `ioctl()` still works, while every `read()`/`write()` returns `EBADF`.

Measured here on Linux 6.18: `hid_enumerate(0, 0)` returned 10 devices while `hid_enumerate(vid, 0)` returned **0 for all seven vendor ids present**; with the fix, 1–6 each.

This restores the file to the upstream snapshot it came from. `8fea1ea42e` vendored libusb/hidapi at `4578ea24`, which uses `O_CLOEXEC` at all three sites and is otherwise byte-identical to the copy here — these three lines are the entire difference. hidapi has used `O_CLOEXEC` there since 2022.

Say the word and it becomes its own PR.

## The surface

One module for the **A25, A49 and A61**. They are one device with three keybeds, and the keybed is not the surface's concern — keys leave over the device's own MIDI port, while knobs, buttons, the 4-D encoder and the display arrive over HID. The entire per-model difference is a name and a key count, so it is a table rather than a class hierarchy. Only the A61 is tested; the other two are probed and checked against the expected HID report-descriptor length, warning loudly on mismatch so the first A25 user files a bug rather than silently misreading controls.

Working: interactive mode (`a0 03 04`, which takes the knobs off the MIDI port and hands over the display), full input decode, transport bound with LED feedback, and hotplug with mode re-assertion.

## Points I would particularly like an opinion on

1. **`available()` reports only whether hidapi initialises** and deliberately does not check for a present device, since returning false unloads the module permanently and a user who plugs in later would never get it back. Correct reading of that contract?
2. **`enumerate()` returns three device names under one manufacturer**, so the GUI shows three rows and the chosen name lands in `cpi->config`, which the factory ignores. `contourdesign` does exactly the same with its three ShuttlePRO variants, so I followed it — but is that the intended use?
3. **Threading.** Session signals are connected with `this` as the trailing `PBD::EventLoop`, so they marshal onto the surface's own thread alongside the read poll; the only lock covers `_handle` and LED state, because `stop()` arrives on the GUI thread. maschine2 has the same GUI-thread teardown race without the lock, so I may have misread the intended pattern.
4. **`hid_open()` by ids is avoided** in favour of enumerating unfiltered and opening by path, even with the hidapi fix in place, so the module still works against an unpatched system hidapi under `USE_EXTERNAL_LIBS`.
5. **Builds by default under `HAVE_HIDAPI`** rather than behind an opt-in flag like `--maschine`, matching the other USB surfaces.

## Not done

Knobs are decoded but unbound, pending a decision on whether they should follow the selected strip or act as a bank across tracks. Banking, mute/solo and 4-D jog are likewise unbound. The display protocol is solved and the surface blanks the panel, but nothing renders glyphs yet.

## Testing

An A61, firmware build 2022-01-05, on Linux 6.18. Every control was exercised individually against the protocol map and checked report by report; transport was verified in both directions against the GUI; unplug/replug was verified to re-assert interactive mode and restore lamp state. Teardown restores MIDI mode and blanks the panel, which matters because once interactive mode is entered the firmware stops drawing the panel and never resumes.

No code or data was taken from `hugovangalen/komplementary-kontrol` (GPL-3); where its published findings agree they are cited as corroboration only, and in two places the map above documents where it is wrong.
