### PR TITLE
Replace source for audio regions

### DIFF
--- a/gtk2_ardour/ardour.menus.in
+++ b/gtk2_ardour/ardour.menus.in
@@ -935,6 +935,7 @@
       <menuitem action='split-region'/>
       <menuitem action='split-region-at-transients'/>
       <menuitem action='split-multichannel-region'/>
+      <menuitem action='replace-region-source'/>
       <menuitem action='close-region-gaps'/>
       <menuitem action='place-transient' />
       <menuitem action='show-rhythm-ferret'/>

--- a/gtk2_ardour/editor.h
+++ b/gtk2_ardour/editor.h
@@ -1171,6 +1171,7 @@ private:
 	void region_fill_track ();
 	void audition_playlist_region_standalone (std::shared_ptr<ARDOUR::Region>);
 	void split_multichannel_region();
+	void replace_source_for_selected_regions ();
 	void reverse_region ();
 	void strip_region_silence ();
 	void normalize_region ();

--- a/gtk2_ardour/editor_actions.cc
+++ b/gtk2_ardour/editor_actions.cc
@@ -1372,6 +1372,9 @@ Editor::register_region_actions ()
 	/* Open the pitch shift dialogue for any selected audio regions */
 	register_region_action (_region_actions, RegionActionTarget (SelectedRegions|EnteredRegions), "pitch-shift-region", _("Pitch Shift..."), sigc::mem_fun (*this, &Editor::pitch_shift_region));
 
+	/* Replace source clip for selected audio regions */
+	register_region_action (_region_actions, RegionActionTarget (SelectedRegions|EnteredRegions), "replace-region-source", _("Replace Source Clip"), sigc::mem_fun (*this, &Editor::replace_source_for_selected_regions));
+
 	/* Open the transpose dialogue for any selected MIDI regions */
 	register_region_action (_region_actions, RegionActionTarget (SelectedRegions|EnteredRegions), "transpose-region", _("Transpose..."), sigc::mem_fun (*this, &Editor::transpose_region));
 

--- a/gtk2_ardour/editor_ops.cc
+++ b/gtk2_ardour/editor_ops.cc
@@ -59,6 +59,7 @@
 
 #include "ardour/audioengine.h"
 #include "ardour/audio_track.h"
+#include "ardour/audiofilesource.h"
 #include "ardour/audioregion.h"
 #include "ardour/boost_debug.h"
 #include "ardour/clip_library.h"
@@ -75,6 +76,8 @@
 #include "ardour/reverse.h"
 #include "ardour/selection.h"
 #include "ardour/session.h"
+#include "ardour/smf_source.h"
+#include "ardour/source_factory.h"
 #include "ardour/session_playlists.h"
 #include "ardour/source.h"
 #include "ardour/strip_silence.h"
@@ -145,6 +148,113 @@ using namespace Editing;
 using namespace Temporal;
 
 using Gtkmm2ext::Keyboard;
+
+namespace {
+
+class ReplaceRegionSourceCommand : public PBD::Command
+{
+public:
+	ReplaceRegionSourceCommand (std::shared_ptr<ARDOUR::Playlist> playlist,
+	                               std::shared_ptr<ARDOUR::Region> original,
+	                               std::shared_ptr<ARDOUR::Region> replacement,
+	                               timepos_t const & position)
+		: _playlist (playlist)
+		, _original (original)
+		, _replacement (replacement)
+		, _position (position)
+	{
+		if (_playlist) {
+			_playlist_id = _playlist->id();
+		}
+		if (_original) {
+			_original_id = _original->id();
+		}
+		if (_replacement) {
+			_replacement_id = _replacement->id();
+		}
+		set_name (_("replace source clip"));
+	}
+
+	void operator() () override
+	{
+		if (_playlist && _original && _replacement) {
+			_playlist->replace_region (_original, _replacement, _position);
+		}
+	}
+
+	void undo () override
+	{
+		if (_playlist && _original && _replacement) {
+			_playlist->replace_region (_replacement, _original, _position);
+		}
+	}
+
+	XMLNode& get_state () const override
+	{
+		XMLNode* node = new XMLNode (X_("ReplaceRegionSourceCommand"));
+
+		PBD::ID playlist_id (_playlist_id);
+		PBD::ID original_id (_original_id);
+		PBD::ID replacement_id (_replacement_id);
+
+		if (_playlist) {
+			playlist_id = _playlist->id();
+		}
+		if (_original) {
+			original_id = _original->id();
+		}
+		if (_replacement) {
+			replacement_id = _replacement->id();
+		}
+
+		node->set_property (X_("name"), name());
+		node->set_property (X_("position"), _position.samples());
+		node->set_property (X_("playlist-id"), playlist_id.to_s());
+		node->set_property (X_("original-id"), original_id.to_s());
+		node->set_property (X_("replacement-id"), replacement_id.to_s());
+
+		return *node;
+	}
+
+	int set_state (const XMLNode& node, int /*version*/) override
+	{
+		std::string command_name;
+		int64_t position_val = 0;
+
+		node.get_property (X_("name"), command_name);
+		if (!command_name.empty()) {
+			set_name (command_name);
+		}
+
+		std::string playlist_id_str;
+		std::string original_id_str;
+		std::string replacement_id_str;
+
+		if (!node.get_property (X_("playlist-id"), playlist_id_str) ||
+		    !node.get_property (X_("original-id"), original_id_str) ||
+		    !node.get_property (X_("replacement-id"), replacement_id_str) ||
+		    !node.get_property (X_("position"), position_val)) {
+			return -1;
+		}
+
+		_playlist_id = PBD::ID (playlist_id_str);
+		_original_id = PBD::ID (original_id_str);
+		_replacement_id = PBD::ID (replacement_id_str);
+		_position = timepos_t (position_val);
+		return 0;
+	}
+
+private:
+	std::shared_ptr<ARDOUR::Playlist> _playlist;
+	std::shared_ptr<ARDOUR::Region> _original;
+	std::shared_ptr<ARDOUR::Region> _replacement;
+	timepos_t _position;
+	PBD::ID _playlist_id;
+	PBD::ID _original_id;
+	PBD::ID _replacement_id;
+};
+
+}
 
 /***********************************************************************
   Editor operations
@@ -5766,6 +5876,160 @@ Editor::reverse_region ()
 
 	Reverse rev (*_session);
 	apply_filter (rev, _("reverse regions"));
+}
+
+void
+Editor::replace_source_for_selected_regions ()
+{
+	if (!_session) {
+		return;
+	}
+
+	RegionSelection rs = get_regions_from_selection_and_entered ();
+	if (rs.empty()) {
+		return;
+	}
+
+	Gtk::Dialog dialog (_("Replace Source Clip"), true);
+	dialog.set_default_size (520, 420);
+	dialog.set_border_width (6);
+
+	TriggerClipPicker picker;
+	picker.set_session (_session);
+	picker.set_selection_mode (Gtk::SELECTION_SINGLE);
+	dialog.get_vbox ()->pack_start (picker, true, true, 6);
+	dialog.add_button (Stock::CANCEL, Gtk::RESPONSE_CANCEL);
+	Gtk::Button* replaceButton = dialog.add_button (_("Replace"), Gtk::RESPONSE_OK);
+	replaceButton->set_sensitive(false);
+	picker.selectionChanged.connect ([replaceButton, &picker] () {
+		replaceButton->set_sensitive (picker.get_selected_file_path().has_value());
+	});
+	dialog.set_default_response (Gtk::RESPONSE_OK);
+	picker.show_all ();
+
+	int result = dialog.run ();
+	picker.stop_audition();
+	dialog.hide ();
+	if (result != Gtk::RESPONSE_OK) {
+		return;
+	}
+
+	auto clip_path = picker.get_selected_file_path ();
+	if (!clip_path.has_value() || clip_path->empty()) {
+		return;
+	}
+
+	if (SMFSource::safe_midi_file_extension (*clip_path)) {
+		ArdourMessageDialog msg (_("Only audio clips can replace audio regions."), true);
+		msg.run ();
+		return;
+	}
+
+	SoundFileInfo info;
+	std::string error;
+	if (!AudioFileSource::get_soundfile_info (*clip_path, info, error)) {
+		ArdourMessageDialog msg (string_compose (_("Could not read clip: %1"), error.empty () ? *clip_path : error), true);
+		msg.run ();
+		return;
+	}
+
+	if (info.channels == 0) {
+		ArdourMessageDialog msg (_("The selected clip contains no audio channels."), true);
+		msg.run ();
+		return;
+	}
+
+	SourceList replacement_sources;
+	for (uint32_t channel = 0; channel < info.channels; ++channel) {
+		std::shared_ptr<Source> source;
+		try {
+			source = SourceFactory::createExternal (DataType::AUDIO, *_session, *clip_path, channel, Source::Flag (0), true, true);
+		} catch (failed_constructor&) {
+			continue;
+		}
+		if (source) {
+			replacement_sources.push_back (source);
+		}
+	}
+
+	if (replacement_sources.empty ()) {
+		ArdourMessageDialog msg (_("The selected clip could not be opened as audio."), true);
+		msg.run ();
+		return;
+	}
+
+	uint32_t replacement_channels = replacement_sources.size ();
+	for (RegionSelection::iterator i = rs.begin(); i != rs.end(); ++i) {
+		std::shared_ptr<AudioRegion> region = std::dynamic_pointer_cast<AudioRegion> ((*i)->region());
+		if (!region || region->n_channels() < replacement_channels) {
+			ArdourMessageDialog msg (string_compose (_("Selected regions do not have enough channels (%1 channels)."), replacement_channels), true);
+			msg.run ();
+			return;
+		}
+	}
+
+	struct PendingReplacement {
+		std::shared_ptr<Playlist> playlist;
+		std::shared_ptr<AudioRegion> region;
+		std::shared_ptr<Region> replacement;
+	};
+
+	std::vector<PendingReplacement> pending_replacements;
+	pending_replacements.reserve (rs.size ());
+
+	for (RegionSelection::iterator i = rs.begin(); i != rs.end(); ++i) {
+		std::shared_ptr<AudioRegion> region = std::dynamic_pointer_cast<AudioRegion> ((*i)->region());
+		if (!region || region->n_channels() < replacement_channels) {
+			continue;
+		}
+
+		std::shared_ptr<Playlist> playlist = region->playlist();
+		if (!playlist) {
+			continue;
+		}
+
+		std::shared_ptr<Region> replacement = RegionFactory::create (region, replacement_sources, region->derive_properties ());
+		if (!replacement) {
+			continue;
+		}
+
+		pending_replacements.push_back (PendingReplacement { playlist, region, replacement });
+	}
+
+	if (pending_replacements.empty()) {
+		return;
+	}
+
+	ArdourDialog progress_dialog (_("Replace Source Clip"), true);
+	Gtk::Label label (_("Replacing Source Clips..."));
+	Gtk::ProgressBar bar;
+	progress_dialog.get_vbox()->pack_start (label, false, false);
+	progress_dialog.get_vbox()->pack_start (bar, false, false);
+	progress_dialog.set_default_size (320, -1);
+	progress_dialog.show_all ();
+
+	uint32_t const total = pending_replacements.size();
+	uint32_t count = 0;
+
+	begin_reversible_command (_("replace source clip"));
+
+	for (std::vector<PendingReplacement>::iterator i = pending_replacements.begin(); i != pending_replacements.end(); ++i) {
+		_session->add_command (new ReplaceRegionSourceCommand (i->playlist, i->region, i->replacement, i->region->position()));
+		i->playlist->replace_region (i->region, i->replacement, i->region->position());
+
+		++count;
+
+		if ((count % 10 == 0) || (count == total)) {
+			bar.set_fraction (static_cast<double> (count) / static_cast<double> (total));
+			bar.set_text (string_compose ("%1 / %2", count, total));
+			while (Gtk::Main::events_pending()) {
+				Gtk::Main::iteration();
+			}
+		}
+	}
+
+	commit_reversible_command ();
+	progress_dialog.hide ();
 }
 
 void

--- a/gtk2_ardour/editor_selection.cc
+++ b/gtk2_ardour/editor_selection.cc
@@ -1447,6 +1447,7 @@ Editor::sensitize_the_right_region_actions (bool because_canvas_crossing)
 	bool have_transients = false;
 	bool have_inverted_polarity = false;
 	bool have_non_inverted_polarity = false;
+	bool have_non_audio = false;
 
 	for (list<RegionView*>::const_iterator i = rs.begin(); i != rs.end(); ++i) {
 
@@ -1458,6 +1459,8 @@ Editor::sensitize_the_right_region_actions (bool because_canvas_crossing)
 			if (ar->n_channels() > 1) {
 				have_multichannel_audio = true;
 			}
+		} else {
+			have_non_audio = true;
 		}
 
 		if (std::dynamic_pointer_cast<MidiRegion> (r)) {
@@ -1590,6 +1593,7 @@ Editor::sensitize_the_right_region_actions (bool because_canvas_crossing)
 			// Glib::RefPtr<ToggleAction>::cast_dynamic (_region_actions->get_action("toggle-region-polarity"))->set_inconsistent (); // N/A
 			Glib::RefPtr<ToggleAction>::cast_dynamic (_region_actions->get_action("toggle-region-polarity"))->set_sensitive (false);
 		}
+		_region_actions->get_action("replace-region-source")->set_sensitive (!have_non_audio);
 
 	} else {
 

--- a/gtk2_ardour/trigger_clip_picker.cc
+++ b/gtk2_ardour/trigger_clip_picker.cc
@@ -64,6 +64,8 @@ using namespace ARDOUR;
 
 #define PX_SCALE(px) std::max((float)px, rintf((float)px * UIConfiguration::instance().get_ui_scale()))
 
+std::string TriggerClipPicker::_last_clip_dir_selection;
+
 TriggerClipPicker::TriggerClipPicker ()
 	: _fcd (_("Select clip folder"), FILE_CHOOSER_ACTION_SELECT_FOLDER)
 	, _seek_slider (0, 1000, 1)
@@ -71,6 +73,7 @@ TriggerClipPicker::TriggerClipPicker ()
 	, _auditioner_combo (InstrumentSelector::ForAuditioner)
 	, _clip_library_listed (false)
 	, _ignore_list_dir (false)
+	, _autoplay_from_click (false)
 	, _seeking (false)
 	, _audition_plugnui (0)
 {
@@ -202,6 +205,7 @@ TriggerClipPicker::TriggerClipPicker ()
 	dnd.push_back (TargetEntry ("text/uri-list"));
 	_view.drag_source_set (dnd, Gdk::MODIFIER_MASK, Gdk::ACTION_COPY);
 	_view.get_selection ()->signal_changed ().connect (sigc::mem_fun (*this, &TriggerClipPicker::row_selected));
+	_view.signal_button_press_event ().connect (sigc::mem_fun (*this, &TriggerClipPicker::view_button_press), false);
 	_view.signal_row_activated ().connect (sigc::mem_fun (*this, &TriggerClipPicker::row_activated));
 	_view.signal_test_expand_row ().connect (sigc::mem_fun (*this, &TriggerClipPicker::test_expand));
 	_view.signal_row_collapsed ().connect (sigc::mem_fun (*this, &TriggerClipPicker::row_collapsed));
@@ -229,11 +233,16 @@ TriggerClipPicker::TriggerClipPicker ()
 	/* show off */
 	_scroller.show ();
 	_view.show ();
+	dir_table->show ();
 	_clip_dir_menu.show ();
 	_auditable.show ();
 
 	/* fill treeview with data */
-	_clip_dir_menu.items ().front ().activate ();
+	if (!_last_clip_dir_selection.empty () && Glib::file_test (_last_clip_dir_selection, Glib::FILE_TEST_IS_DIR | Glib::FILE_TEST_EXISTS)) {
+		clip_dir_selected (_last_clip_dir_selection);
+	} else {
+		_clip_dir_menu.items ().front ().activate ();
+	}
 }
 
 TriggerClipPicker::~TriggerClipPicker ()
@@ -337,6 +346,13 @@ TriggerClipPicker::refill_dropdown ()
 	return false;
 }
 
+void
+TriggerClipPicker::clip_dir_selected (std::string const& path)
+{
+	_last_clip_dir_selection = path;
+	list_dir (path);
+}
+
 static bool
 is_subfolder (std::string const& parent, std::string dir)
 {
@@ -407,7 +423,7 @@ TriggerClipPicker::maybe_add_dir (std::string const& dir)
 		return false;
 	}
 
-	_clip_dir_menu.add_menu_elem (Gtkmm2ext::MenuElemNoMnemonic (display_name (dir), sigc::bind (sigc::mem_fun (*this, &TriggerClipPicker::list_dir), dir, (Gtk::TreeNodeChildren*)0)));
+	_clip_dir_menu.add_menu_elem (Gtkmm2ext::MenuElemNoMnemonic (display_name (dir), sigc::bind (sigc::mem_fun (*this, &TriggerClipPicker::clip_dir_selected), dir)));
 
 	/* check if a parent path of the given dir already exists,
 	 * or if this new path is parent to any existing ones.
@@ -464,9 +480,11 @@ TriggerClipPicker::drag_end (Glib::RefPtr<Gdk::DragContext> const&)
 void
 TriggerClipPicker::cursor_changed ()
 {
-	if (!_session || !_autoplay_btn.get_active ()) {
+	if (!_session || !_autoplay_btn.get_active () || !_autoplay_from_click) {
 		return;
 	}
+
+	_autoplay_from_click = false;
 
 	_session->cancel_audition ();
 
@@ -483,9 +501,39 @@ TriggerClipPicker::cursor_changed ()
 	}
 }
 
+bool
+TriggerClipPicker::view_button_press (GdkEventButton*)
+{
+	_autoplay_from_click = true;
+	return false;
+}
+
+void
+TriggerClipPicker::set_selection_mode (Gtk::SelectionMode mode)
+{
+	_view.get_selection ()->set_mode (mode);
+}
+
+std::optional<std::string>
+TriggerClipPicker::get_selected_file_path ()
+{
+	if (_view.get_selection ()->count_selected_rows () != 1) {
+		return std::nullopt;
+	}
+
+	TreeView::Selection::ListHandle_Path rows = _view.get_selection ()->get_selected_rows ();
+	TreeIter i = _model->get_iter (*rows.begin ());
+	if (!i || !(*i)[_columns.file]) {
+		return std::nullopt;
+	}
+
+	return (*i)[_columns.path];
+}
+
 void
 TriggerClipPicker::row_selected ()
 {
+	selectionChanged.emit ();
 	if (!_session) {
 		return;
 	}

--- a/gtk2_ardour/trigger_clip_picker.h
+++ b/gtk2_ardour/trigger_clip_picker.h
@@ -48,6 +48,10 @@ public:
 	~TriggerClipPicker ();
 
 	void set_session (ARDOUR::Session*);
+	void stop_audition ();
+	void set_selection_mode (Gtk::SelectionMode mode);
+	std::optional<std::string> get_selected_file_path ();
+	sigc::signal<void> selectionChanged;
 
 	ARDOUR::PluginInfoPtr instrument_plugin () const {
 		return _auditioner_combo.selected_instrument ();
@@ -58,10 +62,12 @@ private:
 	void open_dir ();
 	void open_downloader ();
 	void edit_path ();
+	void clip_dir_selected (std::string const&);
 	bool refill_dropdown ();
 	void parameter_changed (std::string const&);
 	void clip_added (std::string const&, void*);
 	void row_selected ();
+	bool view_button_press (GdkEventButton*);
 	void cursor_changed ();
 	void row_activated (Gtk::TreeModel::Path const&, Gtk::TreeViewColumn*);
 	bool test_expand (Gtk::TreeModel::iterator const&, Gtk::TreeModel::Path const&);
@@ -81,7 +87,6 @@ private:
 	void audition_processor_idle ();
 	bool audition_processor_viz (bool);
 	void audition_show_plugin_ui ();
-	void stop_audition ();
 	void autoplay_toggled ();
 	void refresh_library ();
 	void open_library ();
@@ -137,9 +142,11 @@ private:
 	InstrumentSelector           _auditioner_combo;
 
 	std::string _current_path;
+	static std::string _last_clip_dir_selection;
 	std::string _clip_library_dir;
 	bool        _clip_library_listed;
 	bool        _ignore_list_dir;
+	bool        _autoplay_from_click;
 
 	std::set<std::string> _root_paths;
 

--- a/libs/ardour/ardour/session.h
+++ b/libs/ardour/ardour/session.h
@@ -1161,6 +1161,7 @@ public:
 	// these commands are implemented in libs/ardour/session_command.cc
 	PBD::Command* memento_command_factory(XMLNode* n);
 	PBD::Command* stateful_diff_command_factory (XMLNode *);
+	PBD::Command* replace_region_source_command_factory (XMLNode *);
 	void register_with_memento_command_factory(PBD::ID, PBD::StatefulDestructible*);
 
 	/* clicking */

--- a/libs/ardour/audioregion.cc
+++ b/libs/ardour/audioregion.cc
@@ -2758,6 +2758,12 @@ void
 AudioRegion::ensure_length_sanity ()
 {
 	if (_type == DataType::AUDIO) {
+		/* Make sure length of the region is not greater than the source length*/
+		for (SourceList::const_iterator i = _sources.begin(); i != _sources.end(); ++i) {
+			if (_length.val().distance() > (*i)->length()) {
+				_length = timecnt_t (timepos_t((*i)->length().samples()), _length.val().position());
+			}
+		}
 		/* Force audio regions to have a length that is the
 		   rounded-down integer number of samples. No other value makes
 		   any sort of logical sense. We tried to fix this at a lower

--- a/libs/ardour/session_command.cc
+++ b/libs/ardour/session_command.cc
@@ -51,6 +51,57 @@ using namespace Temporal;
 
 #include "pbd/i18n.h"
 
+namespace {
+
+class ReplaceRegionSourceCommand : public PBD::Command
+{
+public:
+	ReplaceRegionSourceCommand (std::shared_ptr<ARDOUR::Playlist> playlist,
+	                           std::shared_ptr<ARDOUR::Region> original,
+	                           std::shared_ptr<ARDOUR::Region> replacement,
+	                           timepos_t const& position)
+		: _playlist (playlist)
+		, _original (original)
+		, _replacement (replacement)
+		, _position (position)
+	{
+		set_name (_("replace source clip"));
+	}
+
+	void operator() () override
+	{
+		if (_playlist && _original && _replacement) {
+			_playlist->replace_region (_original, _replacement, _position);
+		}
+	}
+
+	void undo () override
+	{
+		if (_playlist && _original && _replacement) {
+			_playlist->replace_region (_replacement, _original, _position);
+		}
+	}
+
+	XMLNode& get_state () const override
+	{
+		XMLNode* node = new XMLNode (X_("ReplaceRegionSourceCommand"));
+		node->set_property (X_("name"), name());
+		node->set_property (X_("position"), _position.samples());
+		node->set_property (X_("playlist-id"), _playlist->id());
+		node->set_property (X_("original-id"), _original->id());
+		node->set_property (X_("replacement-id"), _replacement->id());
+		return *node;
+	}
+
+private:
+	std::shared_ptr<ARDOUR::Playlist> _playlist;
+	std::shared_ptr<ARDOUR::Region> _original;
+	std::shared_ptr<ARDOUR::Region> _replacement;
+	timepos_t _position;
+};
+
+}
+
 void Session::register_with_memento_command_factory(PBD::ID id, PBD::StatefulDestructible *ptr)
 {
     registry[id] = ptr;
@@ -186,4 +237,41 @@ Session::stateful_diff_command_factory (XMLNode* n)
 	      << endmsg;
 
 	return 0;
+}
+
+PBD::Command *
+Session::replace_region_source_command_factory (XMLNode* n)
+{
+	PBD::ID playlist_id;
+	PBD::ID original_id;
+	PBD::ID replacement_id;
+	int64_t position_val = 0;
+
+	if (!n->get_property (X_("playlist-id"), playlist_id) ||
+	    !n->get_property (X_("original-id"), original_id) ||
+	    !n->get_property (X_("replacement-id"), replacement_id) ||
+	    !n->get_property (X_("position"), position_val)) {
+		info << _("Could not reconstitute ReplaceRegionSourceCommand: missing serialized properties") << endmsg;
+		return 0;
+	}
+
+	std::shared_ptr<Playlist> playlist = _playlists->by_id (playlist_id);
+	std::shared_ptr<Region> original = RegionFactory::region_by_id (original_id);
+	std::shared_ptr<Region> replacement = RegionFactory::region_by_id (replacement_id);
+
+	if (!playlist || !original || !replacement) {
+		info << string_compose (_("Could not reconstitute ReplaceRegionSourceCommand. playlist=%1 original=%2 replacement=%3"),
+		                       playlist_id.to_s(), original_id.to_s(), replacement_id.to_s())
+		     << endmsg;
+		return 0;
+	}
+
+	ReplaceRegionSourceCommand* cmd = new ReplaceRegionSourceCommand (playlist, original, replacement, timepos_t (position_val));
+
+	std::string command_name;
+	if (n->get_property (X_("name"), command_name) && !command_name.empty()) {
+		cmd->set_name (command_name);
+	}
+
+	return cmd;
 }

--- a/libs/ardour/session_state.cc
+++ b/libs/ardour/session_state.cc
@@ -4915,6 +4915,10 @@ Session::restore_history (string snapshot_name)
 					if ((c = stateful_diff_command_factory (n))) {
 						ut->add_command (c);
 					}
+				} else if (n->name() == "ReplaceRegionSourceCommand") {
+					if ((c = replace_region_source_command_factory (n))) {
+						ut->add_command (c);
+					}
 				} else {
 					error << string_compose(_("Couldn't figure out how to make a Command out of a %1 XMLNode."), n->name()) << endmsg;
 				}


### PR DESCRIPTION
New dialog created to select audio clip from.
Regions on the playlist are replaced by new regions with same properties but replaced source.
Only enabled when audio region(s) are selected. Region length is reduced if the region is longer than the source clip it is being replaced by else length remains same.
Few changes done in the clip picker to show it correctly in the dialog and get the path of the clip selected. Also, it should not run audition as soon as its is instantiated.
Progress bar added for large number of regions.
This action is totally undoable/redoable.
Made sure no LLM generated code is included.

https://github.com/user-attachments/assets/720e9106-654e-49b9-836b-20bdea5d6aea

For large number of clips:

https://github.com/user-attachments/assets/db1c49f2-732c-4d5c-abbc-22a604e3cc50
