### PR TITLE
Generic MIDI: suppress immediate feedback echo for absolute CC input

### DIFF
--- a/libs/surfaces/generic_midi/midicontrollable.cc
+++ b/libs/surfaces/generic_midi/midicontrollable.cc
@@ -362,6 +362,11 @@ MIDIControllable::midi_sense_controller (Parser &, EventTwoBytes *msg)
 
 			if (in_sync || _surface->motorised ()) {
 				_controllable->set_value (midi_to_control (new_value), Controllable::UseGroup);
+				
+				// Suppress immediate echo for accepted absolute CC input.
+				// Ardour's CC round-trip maps an input value N to feedback N-1,
+				// shifting controllers that read and apply feedback.
+				last_value = control_to_midi (_controllable->get_value ());
 			}
 			DEBUG_TRACE (DEBUG::GenericMidi, string_compose ("MIDI CC %1 value %2  %3\n", (int) msg->controller_number, (float) midi_to_control(new_value), current_uri() ));
 


### PR DESCRIPTION
## Problem

For Generic MIDI absolute CC controls (e.g. sliders, knobs), an incoming CC value may round-trip through Ardour as `N -> N-1` in feedback.

For example:

```text
Controller sends CC 64
Ardour accepts CC 64
Ardour feedback sends CC 63
Controller updates its internal value to 63
```

For controllers that read and apply feedback, this can shift their internal value or state after each input event, which can make movement asymmetric or cause the controller to drift while being operated.

## Fix

After an absolute CC input has been accepted, update `last_value` using the resulting controllable value.

`write_feedback()` already avoids sending feedback when the generated MIDI value matches `last_value`, so this suppresses only the immediate echo caused by the accepted input.

## Notes

The change is limited to the absolute, non-toggle CC inputs.

Behaviour of toggle controls and relative encoders are unchanged.

Normal feedback caused by later changes from Ardour should continue to be sent.
