### PR TITLE
coreaudio: check _device_outs in the allocation guard

### DIFF
--- a/libs/backends/coreaudio/coreaudio_pcmio.cc
+++ b/libs/backends/coreaudio/coreaudio_pcmio.cc
@@ -540,7 +540,7 @@ CoreAudioPCM::discover()
 	_device_outs = (uint32_t*) calloc(_n_devices, sizeof(uint32_t));
 
 	assert(_device_ins && _device_outs && _device_ids);
-	if (!_device_ins || !_device_ins || !_device_ids) {
+	if (!_device_ins || !_device_outs || !_device_ids) {
 		fprintf(stderr, "OUT OF MEMORY\n");
 		_device_ids = 0;
 		_device_ins = 0;


### PR DESCRIPTION
In `CoreAudioPCM::discover` the out-of-memory guard tests `_device_ins` twice, so a failed `calloc` for `_device_outs` walks past it. The `assert` on the line directly above already spells out the intended three, which is what made this an easy read rather than a guess. With NDEBUG the assert is gone and the null pointer reaches the device loop below, where `_device_outs[idx]` is written for every device found.

While I was there I noticed `libs/ardour/plugin_insert.cc:2401` has the same shape, `nout == 0 || inx.get(*t) == 0 || nout == 0`, but there the third operand is only redundant and nothing is missing, so I left it alone.
