### PR TITLE
cue pianoroll: fix crash when duplicating until out-of-bound

### DIFF
--- a/gtk2_ardour/midi_view.cc
+++ b/gtk2_ardour/midi_view.cc
@@ -4255,7 +4255,9 @@ MidiView::_duplicate_notes (int times)
 		Temporal::Beats lno (_midi_region->source_beats_to_absolute_time (last_note_time + delta).beats());
 		if (lno > _midi_region->end_position().beats()) {
 			apply_note_diff (true, true);
-			_midi_region->playlist()->clear_owned_changes ();
+			if (_midi_region->playlist()) {
+				_midi_region->playlist()->clear_owned_changes ();
+			}
 			_midi_region->trim_end (timepos_t (lno));
 			_editing_context.add_command (new StatefulDiffCommand (_midi_region));
 			_editing_context.commit_reversible_command ();


### PR DESCRIPTION
Managed to crash Ardour. Also managed to fix it.

### Reproduce crash

1. Create empty session
2. Go to "Cues" view
3. Create new MIDI track with any synth (MIDI general synth works)
4. Click on one of the cue slots
5. In the piano roll editor, draw a note
6. Duplicate it until the end of the region, and then some
7. Notice a crash

With my fix, the crash doesn't happen anymore. Instead, the region is extended to accomodate the new note(s).

The `if (_midi_region->playlist())` was copied from the same file, seems this one was forgotten.