### PR TITLE
VST3: do not treat a single .vst3 file as a module outside Windows

### DIFF
--- a/libs/ardour/vst3_scan.cc
+++ b/libs/ardour/vst3_scan.cc
@@ -369,6 +369,16 @@ ARDOUR::module_path_vst3 (string const& path)
 #endif
 			return "-1";
 		}
+#else
+		/* A single .vst3 file was only ever a valid module on Windows. Here it
+		 * is the Windows dll of a multi-platform bundle (Contents/x86_64-win/),
+		 * found because the folder is scanned recursively; the bundle itself is
+		 * used instead.
+		 */
+#ifndef NDEBUG
+		cerr << "Ignore .vst3 file (not a bundle) '" << path << "'\n";
+#endif
+		return "-1";
 #endif
 		module_path = path;
 	} else {


### PR DESCRIPTION
`module_path_vst3()` skips `<name>.vst3/Contents/x86_64-win/<name>.vst3`, so that a single-file VST3 DLL is not picked up a second time inside its own bundle. That rule is compiled only on Windows (`#ifdef PLATFORM_WINDOWS`).

The same layout exists on Linux. yabridge's merged bundles place a symlink to the Windows DLL at `<name>.vst3/Contents/x86_64-win/<name>.vst3` (or `x86-win` for 32-bit plug-ins) next to the native `Contents/x86_64-linux/<name>.so`. Because `vst3_discover_from_path()` scans recursively, each such DLL is discovered as a separate single-file module: the scanner fails to `dlopen` it ("invalid ELF header"), the path lands in `vst3_x64_blacklist.txt`, and the Plugin Manager shows an error row next to the working bundle entry — one per bridged plug-in. The Plugin Manager's search matches name, type, creator, tags, file or path, not the scan status, so these rows cannot be hidden.

A single `.vst3` file was only ever a valid module on Windows (the legacy single dll, deprecated since VST 3.6.10), so on the other platforms every `.vst3` that is not a bundle directory is now ignored. The Windows code path, including the same-name rule, is unchanged.

Verified on Ubuntu 24.04 with 149 yabridge bundles carrying 150 bundled DLL symlinks (one of them `x86-win`): the start-up scan of the unpatched distribution package (8.4.0) lists all 150 DLL paths, a build of the 8.4 tag with this change lists none, and the 149 bundle entries are the same in both. The branch is based on `master` (ba38f08).
